### PR TITLE
Make packages/io async

### DIFF
--- a/packages/io/src/io-util.ts
+++ b/packages/io/src/io-util.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
+export const IS_WINDOWS = process.platform === 'win32'
+
 export async function exists(fsPath: string): Promise<boolean> {
   try {
     await fs.promises.stat(fsPath)
@@ -44,7 +46,7 @@ export function isRooted(p: string): boolean {
     throw new Error('isRooted() parameter "p" cannot be empty')
   }
 
-  if (process.platform === 'win32') {
+  if (IS_WINDOWS) {
     return (
       p.startsWith('\\') || /^[A-Z]:/i.test(p) // e.g. \ or \hello or \\hello
     ) // e.g. C: or C:\hello
@@ -68,7 +70,7 @@ export async function tryGetExecutablePath(
     const stats = await fs.promises.stat(filePath)
 
     if (stats.isFile()) {
-      if (process.platform === 'win32') {
+      if (IS_WINDOWS) {
         // on Windows, test for valid extension
         const fileName = path.basename(filePath)
         const dotIndex = fileName.lastIndexOf('.')
@@ -103,7 +105,7 @@ export async function tryGetExecutablePath(
       const stats = await fs.promises.stat(filePath)
 
       if (stats.isFile()) {
-        if (process.platform === 'win32') {
+        if (IS_WINDOWS) {
           // preserve the case of the actual file (since an extension was appended)
           try {
             const directory = path.dirname(filePath)
@@ -143,7 +145,7 @@ export async function tryGetExecutablePath(
 
 function normalizeSeparators(p: string): string {
   p = p || ''
-  if (process.platform === 'win32') {
+  if (IS_WINDOWS) {
     // convert slashes on Windows
     p = p.replace(/\//g, '\\')
 

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -4,7 +4,6 @@ import * as path from 'path'
 import {promisify} from 'util'
 import * as ioUtil from './io-util'
 
-const IS_WINDOWS = process.platform === 'win32'
 const exec = promisify(childProcess.exec)
 
 /**
@@ -102,7 +101,7 @@ export async function mv(
  * @param inputPath path to remove
  */
 export async function rmRF(inputPath: string): Promise<void> {
-  if (IS_WINDOWS) {
+  if (ioUtil.IS_WINDOWS) {
     // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
     // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
     try {
@@ -233,7 +232,7 @@ export async function which(tool: string, check?: boolean): Promise<string> {
     const result: string = await which(tool, false)
 
     if (!result) {
-      if (IS_WINDOWS) {
+      if (ioUtil.IS_WINDOWS) {
         throw new Error(
           `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`
         )
@@ -248,7 +247,7 @@ export async function which(tool: string, check?: boolean): Promise<string> {
   try {
     // build the list of extensions to try
     const extensions: string[] = []
-    if (IS_WINDOWS && process.env.PATHEXT) {
+    if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
       for (const extension of process.env.PATHEXT.split(path.delimiter)) {
         if (extension) {
           extensions.push(extension)
@@ -271,7 +270,7 @@ export async function which(tool: string, check?: boolean): Promise<string> {
     }
 
     // if any path separators, return empty
-    if (tool.includes('/') || (IS_WINDOWS && tool.includes('\\'))) {
+    if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
       return ''
     }
 

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -23,18 +23,11 @@ export interface CopyOptions {
 export async function cp(
   source: string,
   dest: string,
-  options?: CopyOptions
+  options: CopyOptions = {}
 ): Promise<void> {
-  let force = true
-  let recursive = false
-  if (options) {
-    if (options.recursive) {
-      recursive = true
-    }
-    if (options.force === false) {
-      force = false
-    }
-  }
+  const force = Boolean(options.force)
+  const recursive = Boolean(options.recursive)
+
   return new Promise<void>(async (resolve, reject) => {
     try {
       if (fs.lstatSync(source).isDirectory()) {

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -1,7 +1,11 @@
 import * as childProcess from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
-import * as util from './io-util'
+import {promisify} from 'util'
+import * as ioUtil from './io-util'
+
+const IS_WINDOWS = process.platform === 'win32'
+const exec = promisify(childProcess.exec)
 
 /**
  * Interface for cp/mv options
@@ -25,40 +29,30 @@ export async function cp(
   dest: string,
   options: CopyOptions = {}
 ): Promise<void> {
-  const force = Boolean(options.force)
-  const recursive = Boolean(options.recursive)
+  const {force, recursive} = readCopyOptions(options)
 
-  return new Promise<void>(async (resolve, reject) => {
-    try {
-      if (fs.lstatSync(source).isDirectory()) {
-        if (!recursive) {
-          throw new Error(`non-recursive cp failed, ${source} is a directory`)
-        }
-
-        // If directory exists, copy source inside it. Otherwise, create it and copy contents of source inside.
-        if (fs.existsSync(dest)) {
-          if (!fs.lstatSync(dest).isDirectory()) {
-            throw new Error(`${dest} is not a directory`)
-          }
-
-          dest = path.join(dest, path.basename(source))
-        }
-
-        copyDirectoryContents(source, dest, force)
-      } else {
-        if (force) {
-          fs.copyFileSync(source, dest)
-        } else {
-          fs.copyFileSync(source, dest, fs.constants.COPYFILE_EXCL)
-        }
-      }
-    } catch (err) {
-      reject(err)
-      return
+  if (await ioUtil.isDirectory(source)) {
+    if (!recursive) {
+      throw new Error(`non-recursive cp failed, ${source} is a directory`)
     }
 
-    resolve()
-  })
+    // If directory exists, copy source inside it. Otherwise, create it and copy contents of source inside.
+    if (await ioUtil.exists(dest)) {
+      if (!(await ioUtil.isDirectory(dest))) {
+        throw new Error(`${dest} is not a directory`)
+      }
+
+      dest = path.join(dest, path.basename(source))
+    }
+
+    await copyDirectoryContents(source, dest, force)
+  } else {
+    if (force) {
+      await fs.promises.copyFile(source, dest)
+    } else {
+      await fs.promises.copyFile(source, dest, fs.constants.COPYFILE_EXCL)
+    }
+  }
 }
 
 /**
@@ -71,197 +65,154 @@ export async function cp(
 export async function mv(
   source: string,
   dest: string,
-  options?: CopyOptions
+  options: CopyOptions = {}
 ): Promise<void> {
-  let force = true
-  let recursive = false
-  if (options) {
-    if (options.recursive) {
-      recursive = true
+  const {force, recursive} = readCopyOptions(options)
+
+  if (await ioUtil.isDirectory(source)) {
+    if (!recursive) {
+      throw new Error(`non-recursive cp failed, ${source} is a directory`)
     }
-    if (options.force === false) {
-      force = false
-    }
-  }
-  return new Promise<void>(async (resolve, reject) => {
-    try {
-      if (fs.lstatSync(source).isDirectory()) {
-        if (!recursive) {
-          throw new Error(`non-recursive cp failed, ${source} is a directory`)
-        }
 
-        // If directory exists, move source inside it. Otherwise, create it and move contents of source inside.
-        if (fs.existsSync(dest)) {
-          if (!fs.lstatSync(dest).isDirectory()) {
-            throw new Error(`${dest} is not a directory`)
-          }
-
-          dest = path.join(dest, path.basename(source))
-        }
-
-        copyDirectoryContents(source, dest, force, true)
-      } else {
-        if (force) {
-          fs.copyFileSync(source, dest)
-        } else {
-          fs.copyFileSync(source, dest, fs.constants.COPYFILE_EXCL)
-        }
-
-        // Delete file after copying since this is mv.
-        fs.unlinkSync(source)
+    // If directory exists, move source inside it. Otherwise, create it and move contents of source inside.
+    if (await ioUtil.exists(dest)) {
+      if (!(await ioUtil.isDirectory(dest))) {
+        throw new Error(`${dest} is not a directory`)
       }
-    } catch (err) {
-      reject(err)
-      return
+
+      dest = path.join(dest, path.basename(source))
     }
 
-    resolve()
-  })
+    await copyDirectoryContents(source, dest, force, true)
+  } else {
+    if (force) {
+      await fs.promises.copyFile(source, dest)
+    } else {
+      await fs.promises.copyFile(source, dest, fs.constants.COPYFILE_EXCL)
+    }
+
+    // Delete file after copying since this is mv.
+    await fs.promises.unlink(source)
+  }
 }
 
 /**
  * Remove a path recursively with force
  *
- * @param     inputPath     path to remove
+ * @param inputPath path to remove
  */
 export async function rmRF(inputPath: string): Promise<void> {
-  return new Promise<void>(async (resolve, reject) => {
-    if (process.platform === 'win32') {
-      // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
-      // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
-      try {
-        if (fs.statSync(inputPath).isDirectory()) {
-          childProcess.execSync(`rd /s /q "${inputPath}"`)
-        } else {
-          childProcess.execSync(`del /f /a "${inputPath}"`)
-        }
-      } catch (err) {
-        // if you try to delete a file that doesn't exist, desired result is achieved
-        // other errors are valid
-        if (err.code !== 'ENOENT') {
-          reject(err)
-          return
-        }
-      }
-
-      // Shelling out fails to remove a symlink folder with missing source, this unlink catches that
-      try {
-        fs.unlinkSync(inputPath)
-      } catch (err) {
-        // if you try to delete a file that doesn't exist, desired result is achieved
-        // other errors are valid
-        if (err.code !== 'ENOENT') {
-          reject(err)
-          return
-        }
-      }
-    } else {
-      // get the lstats in order to workaround a bug in shelljs@0.3.0 where symlinks
-      // with missing targets are not handled correctly by "rm('-rf', path)"
-      let isDirectory = false
-      try {
-        isDirectory = fs.lstatSync(inputPath).isDirectory()
-      } catch (err) {
-        // if you try to delete a file that doesn't exist, desired result is achieved
-        // other errors are valid
-        if (err.code === 'ENOENT') {
-          resolve()
-        } else {
-          reject(err)
-        }
-        return
-      }
-
-      if (isDirectory) {
-        util._removeDirectory(inputPath)
-        resolve()
-        return
+  if (IS_WINDOWS) {
+    // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
+    // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
+    try {
+      if (await ioUtil.isDirectory(inputPath)) {
+        await exec(`rd /s /q "${inputPath}"`)
       } else {
-        fs.unlinkSync(inputPath)
+        await exec(`del /f /a "${inputPath}"`)
       }
+    } catch (err) {
+      // if you try to delete a file that doesn't exist, desired result is achieved
+      // other errors are valid
+      if (err.code !== 'ENOENT') throw err
     }
 
-    resolve()
-  })
+    // Shelling out fails to remove a symlink folder with missing source, this unlink catches that
+    try {
+      await fs.promises.unlink(inputPath)
+    } catch (err) {
+      // if you try to delete a file that doesn't exist, desired result is achieved
+      // other errors are valid
+      if (err.code !== 'ENOENT') throw err
+    }
+  } else {
+    // get the lstats in order to workaround a bug in shelljs@0.3.0 where symlinks
+    // with missing targets are not handled correctly by "rm('-rf', path)"
+    let isDir = false
+    try {
+      isDir = await ioUtil.isDirectory(inputPath)
+    } catch (err) {
+      // if you try to delete a file that doesn't exist, desired result is achieved
+      // other errors are valid
+      if (err.code !== 'ENOENT') throw err
+      return
+    }
+
+    if (isDir) {
+      await ioUtil.removeDirectory(inputPath)
+    } else {
+      await fs.promises.unlink(inputPath)
+    }
+  }
 }
 
 /**
  * Make a directory.  Creates the full path with folders in between
  * Will throw if it fails
  *
- * @param     p       path to create
- * @returns   Promise<void>
+ * @param   fsPath        path to create
+ * @returns Promise<void>
  */
-export async function mkdirP(p: string): Promise<void> {
-  return new Promise<void>(async (resolve, reject) => {
-    try {
-      if (!p) {
-        throw new Error('Parameter p is required')
-      }
+export async function mkdirP(fsPath: string): Promise<void> {
+  if (!fsPath) {
+    throw new Error('Parameter p is required')
+  }
 
-      // build a stack of directories to create
-      const stack: string[] = []
-      let testDir: string = p
+  // build a stack of directories to create
+  const stack: string[] = []
+  let testDir: string = fsPath
 
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        // validate the loop is not out of control
-        if (stack.length >= (process.env['TEST_MKDIRP_FAILSAFE'] || 1000)) {
-          // let the framework throw
-          fs.mkdirSync(p)
-          resolve()
-          return
-        }
-
-        let stats: fs.Stats
-        try {
-          stats = fs.statSync(testDir)
-        } catch (err) {
-          if (err.code === 'ENOENT') {
-            // validate the directory is not the drive root
-            const parentDir = path.dirname(testDir)
-            if (testDir === parentDir) {
-              throw new Error(
-                `Unable to create directory '${p}'. Root directory does not exist: '${testDir}'`
-              )
-            }
-
-            // push the dir and test the parent
-            stack.push(testDir)
-            testDir = parentDir
-            continue
-          } else if (err.code === 'UNKNOWN') {
-            throw new Error(
-              `Unable to create directory '${p}'. Unable to verify the directory exists: '${testDir}'. If directory is a file share, please verify the share name is correct, the share is online, and the current process has permission to access the share.`
-            )
-          } else {
-            throw err
-          }
-        }
-
-        if (!stats.isDirectory()) {
-          throw new Error(
-            `Unable to create directory '${p}'. Conflicting file exists: '${testDir}'`
-          )
-        }
-
-        // testDir exists
-        break
-      }
-
-      // create each directory
-      let dir = stack.pop()
-      while (dir != null) {
-        fs.mkdirSync(dir)
-        dir = stack.pop()
-      }
-    } catch (err) {
-      reject(err)
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // validate the loop is not out of control
+    if (stack.length >= (process.env['TEST_MKDIRP_FAILSAFE'] || 1000)) {
+      // let the framework throw
+      await fs.promises.mkdir(fsPath)
       return
     }
 
-    resolve()
-  })
+    let stats: fs.Stats
+    try {
+      stats = await fs.promises.stat(testDir)
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        // validate the directory is not the drive root
+        const parentDir = path.dirname(testDir)
+        if (testDir === parentDir) {
+          throw new Error(
+            `Unable to create directory '${fsPath}'. Root directory does not exist: '${testDir}'`
+          )
+        }
+
+        // push the dir and test the parent
+        stack.push(testDir)
+        testDir = parentDir
+        continue
+      } else if (err.code === 'UNKNOWN') {
+        throw new Error(
+          `Unable to create directory '${fsPath}'. Unable to verify the directory exists: '${testDir}'. If directory is a file share, please verify the share name is correct, the share is online, and the current process has permission to access the share.`
+        )
+      } else {
+        throw err
+      }
+    }
+
+    if (!stats.isDirectory()) {
+      throw new Error(
+        `Unable to create directory '${fsPath}'. Conflicting file exists: '${testDir}'`
+      )
+    }
+
+    // testDir exists
+    break
+  }
+
+  // create each directory
+  let dir = stack.pop()
+  while (dir != null) {
+    await fs.promises.mkdir(dir)
+    dir = stack.pop()
+  }
 }
 
 /**
@@ -273,123 +224,113 @@ export async function mkdirP(p: string): Promise<void> {
  * @returns   Promise<string>   path to tool
  */
 export async function which(tool: string, check?: boolean): Promise<string> {
-  return new Promise<string>(async (resolve, reject) => {
-    if (!tool) {
-      reject(new Error("parameter 'tool' is required"))
-      return
-    }
+  if (!tool) {
+    throw new Error("parameter 'tool' is required")
+  }
 
-    // recursive when check=true
-    if (check) {
-      const result: string = await which(tool, false)
-      if (!result) {
-        if (process.platform === 'win32') {
-          reject(
-            new Error(
-              `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`
-            )
-          )
-        } else {
-          reject(
-            new Error(
-              `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`
-            )
-          )
-        }
-        return
-      }
-    }
+  // recursive when check=true
+  if (check) {
+    const result: string = await which(tool, false)
 
-    try {
-      // build the list of extensions to try
-      const extensions: string[] = []
-      if (process.platform === 'win32' && process.env.PATHEXT) {
-        for (const extension of process.env.PATHEXT.split(path.delimiter)) {
-          if (extension) {
-            extensions.push(extension)
-          }
-        }
-      }
-
-      // if it's rooted, return it if exists. otherwise return empty.
-      if (util._isRooted(tool)) {
-        const filePath: string = util._tryGetExecutablePath(tool, extensions)
-        if (filePath) {
-          resolve(filePath)
-          return
-        }
-
-        resolve('')
-        return
-      }
-
-      // if any path separators, return empty
-      if (
-        tool.includes('/') ||
-        (process.platform === 'win32' && tool.includes('\\'))
-      ) {
-        resolve('')
-        return
-      }
-
-      // build the list of directories
-      //
-      // Note, technically "where" checks the current directory on Windows. From a task lib perspective,
-      // it feels like we should not do this. Checking the current directory seems like more of a use
-      // case of a shell, and the which() function exposed by the task lib should strive for consistency
-      // across platforms.
-      const directories: string[] = []
-
-      if (process.env.PATH) {
-        for (const p of process.env.PATH.split(path.delimiter)) {
-          if (p) {
-            directories.push(p)
-          }
-        }
-      }
-
-      // return the first match
-      for (const directory of directories) {
-        const filePath = util._tryGetExecutablePath(
-          directory + path.sep + tool,
-          extensions
+    if (!result) {
+      if (IS_WINDOWS) {
+        throw new Error(
+          `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`
         )
-        if (filePath) {
-          resolve(filePath)
-          return
+      } else {
+        throw new Error(
+          `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`
+        )
+      }
+    }
+  }
+
+  try {
+    // build the list of extensions to try
+    const extensions: string[] = []
+    if (IS_WINDOWS && process.env.PATHEXT) {
+      for (const extension of process.env.PATHEXT.split(path.delimiter)) {
+        if (extension) {
+          extensions.push(extension)
         }
       }
-
-      resolve('')
-    } catch (err) {
-      reject(new Error(`which failed with message ${err.message}`))
     }
-  })
+
+    // if it's rooted, return it if exists. otherwise return empty.
+    if (ioUtil.isRooted(tool)) {
+      const filePath: string = await ioUtil.tryGetExecutablePath(
+        tool,
+        extensions
+      )
+
+      if (filePath) {
+        return filePath
+      }
+
+      return ''
+    }
+
+    // if any path separators, return empty
+    if (tool.includes('/') || (IS_WINDOWS && tool.includes('\\'))) {
+      return ''
+    }
+
+    // build the list of directories
+    //
+    // Note, technically "where" checks the current directory on Windows. From a task lib perspective,
+    // it feels like we should not do this. Checking the current directory seems like more of a use
+    // case of a shell, and the which() function exposed by the task lib should strive for consistency
+    // across platforms.
+    const directories: string[] = []
+
+    if (process.env.PATH) {
+      for (const p of process.env.PATH.split(path.delimiter)) {
+        if (p) {
+          directories.push(p)
+        }
+      }
+    }
+
+    // return the first match
+    for (const directory of directories) {
+      const filePath = await ioUtil.tryGetExecutablePath(
+        directory + path.sep + tool,
+        extensions
+      )
+      if (filePath) {
+        return filePath
+      }
+    }
+
+    return ''
+  } catch (err) {
+    throw new Error(`which failed with message ${err.message}`)
+  }
 }
 
 // Copies contents of source into dest, making any necessary folders along the way.
 // Deletes the original copy if deleteOriginal is true
-function copyDirectoryContents(
+async function copyDirectoryContents(
   source: string,
   dest: string,
   force: boolean,
   deleteOriginal = false
-): void {
-  if (fs.lstatSync(source).isDirectory()) {
-    if (fs.existsSync(dest)) {
-      if (!fs.lstatSync(dest).isDirectory()) {
+): Promise<void> {
+  if (await ioUtil.isDirectory(source)) {
+    if (await ioUtil.exists(dest)) {
+      if (!(await ioUtil.isDirectory(dest))) {
         throw new Error(`${dest} is not a directory`)
       }
     } else {
-      mkdirP(dest)
+      await mkdirP(dest)
     }
 
     // Copy all child files, and directories recursively
-    const sourceChildren: string[] = fs.readdirSync(source)
+    const sourceChildren: string[] = await fs.promises.readdir(source)
 
     for (const newSource of sourceChildren) {
       const newDest = path.join(dest, path.basename(newSource))
-      copyDirectoryContents(
+      await copyDirectoryContents(
         path.resolve(source, newSource),
         newDest,
         force,
@@ -398,16 +339,22 @@ function copyDirectoryContents(
     }
 
     if (deleteOriginal) {
-      fs.rmdirSync(source)
+      await fs.promises.rmdir(source)
     }
   } else {
     if (force) {
-      fs.copyFileSync(source, dest)
+      await fs.promises.copyFile(source, dest)
     } else {
-      fs.copyFileSync(source, dest, fs.constants.COPYFILE_EXCL)
+      await fs.promises.copyFile(source, dest, fs.constants.COPYFILE_EXCL)
     }
     if (deleteOriginal) {
-      fs.unlinkSync(source)
+      await fs.promises.unlink(source)
     }
   }
+}
+
+function readCopyOptions(options: CopyOptions): Required<CopyOptions> {
+  const force = options.force == null ? true : options.force
+  const recursive = Boolean(options.recursive)
+  return {force, recursive}
 }


### PR DESCRIPTION
This pull request rewrites a bunch of logic in packages/io so that it's fully async for IO operations.

In the current iteration of packages/io, functions are returning promises, but are still internally calling the sync versions of `fs` modules.

@damccorm Let me know what you think. Another thing I wanted to point out was something w/async functions—when a function is declared to be `async`, it implicitly returns a promise—there's no need to create and then manually return one, rejecting and resolving, etc. Throwing inside of an async function will cause it to return a rejected promise (which will throw if that call is `await`ed).