### PR TITLE
Copy file into directory

### DIFF
--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -35,7 +35,10 @@ describe('cp', () => {
   })
 
   it('copies file into directory', async () => {
-    const root: string = path.join(path.join(__dirname, '_temp'), 'cp_file_to_directory')
+    const root: string = path.join(
+      path.join(__dirname, '_temp'),
+      'cp_file_to_directory'
+    )
     const sourceFile: string = path.join(root, 'cp_source')
     const targetDirectory: string = path.join(root, 'cp_target')
     const targetFile: string = path.join(targetDirectory, 'cp_source')

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -267,7 +267,7 @@ async function move(
 
     await copyDirectoryContents(source, dest, force, moveOptions.deleteOriginal)
   } else {
-    if (await ioUtil.exists(dest) && await ioUtil.isDirectory(dest)) {
+    if ((await ioUtil.exists(dest)) && (await ioUtil.isDirectory(dest))) {
       dest = path.join(dest, path.basename(source))
     }
     if (force) {


### PR DESCRIPTION
Right now, if we try to copy a file into a directory it fails. We need to add on the file name to the end of the path to be copied in order for it to work correctly.
