### PR TITLE
Export findVersions()

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -353,7 +353,7 @@ export function find(
 
   // attempt to resolve an explicit version
   if (!_isExplicitVersion(versionSpec)) {
-    const localVersions: string[] = findVersions(toolName, arch)
+    const localVersions: string[] = findAllVersions(toolName, arch)
     const match = _evaluateVersions(localVersions, versionSpec)
     versionSpec = match
   }
@@ -375,12 +375,12 @@ export function find(
 }
 
 /**
- * Finds the paths to tool versions that are installed in the local tool cache
+ * Finds the paths to all versions of a tool that are installed in the local tool cache
  *
  * @param toolName  name of the tool
  * @param arch      optional arch.  defaults to arch of computer
  */
-export function findVersions(toolName: string, arch?: string): string[] {
+export function findAllVersions(toolName: string, arch?: string): string[] {
   const versions: string[] = []
 
   arch = arch || os.arch()


### PR DESCRIPTION
This renames the function `_findLocalToolVersions()` to `findVersions()` and exports it.   Set-up tasks of the past found it useful for showing which tool versions _were_ available when the desired tool version/arch wasn't available.  For example:

"Version spec 12.4 did not match any version in the tool cache. The following versions were found:  ..."