### PR TITLE
Fix cp and mv

### DIFF
--- a/packages/io/src/io-util.ts
+++ b/packages/io/src/io-util.ts
@@ -3,12 +3,16 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 export const {
+  chmod,
   copyFile,
   lstat,
   mkdir,
   readdir,
+  readlink,
+  rename,
   rmdir,
   stat,
+  symlink,
   unlink
 } = fs.promises
 


### PR DESCRIPTION
This change does a couple things:
1) It fixes #25 by copying symlinks for cp. 
2) It simplifies/improves move to just rename the appropriate thing rather than copy/delete.
3) It removes the recursive option for move. `-r` isn't a bash option for mv (I believe) and all moves are automatically recursive, so this seemed natural.
4) cp no longer throws on failing to copy files due to not specifying force. This is consistent with the Unix `cp` behavior when `-f` isn't specified.

Note that I also tested that this fixes the bug we were seeing with setup-node on Unix.