### PR TITLE
Fix bad apostrophes

### DIFF
--- a/docs/action-types.md
+++ b/docs/action-types.md
@@ -3,7 +3,7 @@
 There are two types of actions.  JavaScript and Docker actions.
 
 - **JavaScript Actions**: JavaScript actions run on the host machine.  The unit of work is decoupled from the environment.
-- **Docker Actions**: A container action is a container which carries both the unit of work along with the environment and it's dependencies packaged up as a container.
+- **Docker Actions**: A container action is a container which carries both the unit of work along with the environment and its dependencies packaged up as a container.
 
 Both have access to the workspace and the github event payload and context.
 
@@ -11,7 +11,7 @@ Both have access to the workspace and the github event payload and context.
 
 Docker actions carry both the unit of work and the environment.
 
-This creates a more consistent and reliable unit of work where the consumer of the action does not need to worry about the toolsets and it's dependencies.
+This creates a more consistent and reliable unit of work where the consumer of the action does not need to worry about the toolsets and its dependencies.
 
 Docker actions are currently limited to Linux only.
 
@@ -19,7 +19,7 @@ Docker actions are currently limited to Linux only.
 
 JavaScript actions decouple the unit of work from the environment and run directly on the host machine or VM.
 
-Consider a simple example of testing a node lib on node 8, 10 and running a custom action.  Each job will setup a node version on the host and custom-action will run it's unit of work on each environment (node8+ubunut16, node8+windows-2019, etc.)
+Consider a simple example of testing a node lib on node 8, 10 and running a custom action.  Each job will setup a node version on the host and custom-action will run its unit of work on each environment (node8+ubunut16, node8+windows-2019, etc.)
 
 ```yaml
 on: push
@@ -42,4 +42,4 @@ jobs:
     - uses: actions/custom-action@master
 ```
 
-JavaScript actions work on any environment that host action runtime is supported on which is currently node 12.  However, a host action that runs a toolset expects the environment that it's running on to have that toolset in it's PATH or using a setup-* action to acquire it on demand.
+JavaScript actions work on any environment that host action runtime is supported on which is currently node 12.  However, a host action that runs a toolset expects the environment that it's running on to have that toolset in its PATH or using a setup-* action to acquire it on demand.


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!