### PR TITLE
Highlight codeblocks in markdown files

### DIFF
--- a/docs/github-package.md
+++ b/docs/github-package.md
@@ -8,7 +8,7 @@ Its main purpose will be to provide a hydrated GitHub context/Octokit client wit
 
 ##### interfaces.ts
 
-```
+```ts
 /*
  * Interfaces
  */
@@ -56,7 +56,7 @@ export interface WebhookPayloadWithRepository {
 
 Contains a GitHub context
 
-```
+```ts
 export class Context {
    /**
    * Webhook payload object that triggered the workflow
@@ -89,7 +89,7 @@ export class Context {
 
 Contains a hydrated Octokit client
 
-```
+```ts
 export class GithubClient extends Octokit {
  // For making GraphQL requests
  public graphql: (query: string, variables?: Variables) => Promise<GraphQlQueryResponse>

--- a/docs/package-specs.md
+++ b/docs/package-specs.md
@@ -6,7 +6,7 @@ In order to support the node-config action, I propose adding the following into 
 
 Holds all the functions necessary for interacting with the runner/environment.
 
-```
+```ts
 // Logging functions
 export function debug(message: string): void
 export function warning(message: string): void
@@ -66,7 +66,7 @@ export function setFailed(message: string): void
 
 Holds all the functions necessary for file system manipulation (cli scenarios, not fs replacements):
 
-```
+```ts
 /**
  * Interface for cp/mv options
  */
@@ -132,7 +132,7 @@ export function which(tool: string, options?: WhichOptions): Promise<string>
 
 Holds all the functions necessary for running the tools node-config depends on (aka 7-zip and tar)
 
-```
+```ts
 /**
  * Interface for exec options
  */
@@ -155,7 +155,7 @@ export function exec(commandLine: string, args?: string[], options?: IExecOption
 
 Holds all the functions necessary for downloading and caching node.
 
-```
+```ts
 /**
  * Download a tool from an url and stream it into a file
  *

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,7 +35,7 @@ core.exportSecret('secretVar', variableWithSecretValue);
 
 You can explicitly add items to the path for all remaining steps in a workflow:
 
-```
+```js
 const core = require('@actions/core');
 
 core.addPath('pathToTool');

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@
 
 You can use this library to get inputs or set outputs:
 
-```
+```js
 const core = require('@actions/core');
 
 const myInput = core.getInput('inputName', { required: true });
@@ -22,7 +22,7 @@ core.setOutput('outputKey', 'outputVal');
 
 You can also export variables and secrets for future steps. Variables get set in the environment automatically, while secrets must be scoped into the environment from a workflow using `${{ secrets.FOO }}`. Secrets will also be masked from the logs:
 
-```
+```js
 const core = require('@actions/core');
 
 // Do stuff
@@ -45,7 +45,7 @@ core.addPath('pathToTool');
 
 You should use this library to set the failing exit code for your action:
 
-```
+```js
 const core = require('@actions/core');
 
 try {
@@ -62,7 +62,7 @@ catch (err) {
 
 Finally, this library provides some utilities for logging. Note that debug logging is hidden from the logs by default. This behavior can be toggled by enabling the [Step Debug Logs](../../docs/action-debugging.md#step-debug-logs).
 
-```
+```js
 const core = require('@actions/core');
 
 const myInput = core.getInput('input');

--- a/packages/exec/README.md
+++ b/packages/exec/README.md
@@ -6,7 +6,7 @@
 
 You can use this package to execute your tools on the command line in a cross platform way:
 
-```
+```js
 const exec = require('@actions/exec');
 
 await exec.exec('node index.js');
@@ -16,7 +16,7 @@ await exec.exec('node index.js');
 
 You can also pass in arg arrays:
 
-```
+```js
 const exec = require('@actions/exec');
 
 await exec.exec('node', ['index.js', 'foo=bar']);
@@ -26,7 +26,7 @@ await exec.exec('node', ['index.js', 'foo=bar']);
 
 Capture output or specify [other options](https://github.com/actions/toolkit/blob/d9347d4ab99fd507c0b9104b2cf79fb44fcc827d/packages/exec/src/interfaces.ts#L5):
 
-```
+```js
 const exec = require('@actions/exec');
 
 const myOutput = '';
@@ -50,7 +50,7 @@ await exec.exec('node', ['index.js', 'foo=bar'], options);
 
 You can use it in conjunction with the `which` function from `@actions/io` to execute tools that are not in the PATH:
 
-```
+```js
 const exec = require('@actions/exec');
 const io = require('@actions/io');
 

--- a/packages/io/README.md
+++ b/packages/io/README.md
@@ -8,7 +8,7 @@
 
 Recursively make a directory. Follows rules specified in [man mkdir](https://linux.die.net/man/1/mkdir) with the `-p` option specified:
 
-```
+```js
 const io = require('@actions/io');
 
 await io.mkdirP('path/to/make');
@@ -18,7 +18,7 @@ await io.mkdirP('path/to/make');
 
 Copy or move files or folders. Follows rules specified in [man cp](https://linux.die.net/man/1/cp) and [man mv](https://linux.die.net/man/1/mv):
 
-```
+```js
 const io = require('@actions/io');
 
 // Recursive must be true for directories
@@ -32,7 +32,7 @@ await io.mv('path/to/file', 'path/to/dest');
 
 Remove a file or folder recursively. Follows rules specified in [man rm](https://linux.die.net/man/1/rm) with the `-r` and `-f` rules specified.
 
-```
+```js
 const io = require('@actions/io');
 
 await io.rmRF('path/to/directory');
@@ -43,7 +43,7 @@ await io.rmRF('path/to/file');
 
 Get the path to a tool and resolves via paths. Follows the rules specified in [man which](https://linux.die.net/man/1/which).
 
-```
+```js
 const exec = require('@actions/exec');
 const io = require('@actions/io');
 

--- a/packages/tool-cache/README.md
+++ b/packages/tool-cache/README.md
@@ -8,7 +8,7 @@
 
 You can use this to download tools (or other files) from a download URL:
 
-```
+```js
 const tc = require('@actions/tool-cache');
 
 const node12Path = await tc.downloadTool('http://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-x64.tar.gz');
@@ -18,7 +18,7 @@ const node12Path = await tc.downloadTool('http://nodejs.org/dist/v12.7.0/node-v1
 
 These can then be extracted in platform specific ways:
 
-```
+```js
 const tc = require('@actions/tool-cache');
 
 if (process.platform === 'win32') {
@@ -41,7 +41,7 @@ Finally, you can cache these directories in our tool-cache. This is useful if yo
 
 You'll often want to add it to the path as part of this step:
 
-```
+```js
 const tc = require('@actions/tool-cache');
 const core = require('@actions/core');
 
@@ -54,7 +54,7 @@ core.addPath(cachedPath);
 
 You can also cache files for reuse.
 
-```
+```js
 const tc = require('@actions/tool-cache');
 
 tc.cacheFile('path/to/exe', 'destFileName.exe', 'myExeName', '1.1.0');
@@ -64,7 +64,7 @@ tc.cacheFile('path/to/exe', 'destFileName.exe', 'myExeName', '1.1.0');
 
 Finally, you can find directories and files you've previously cached:
 
-```
+```js
 const tc = require('@actions/tool-cache');
 const core = require('@actions/core');
 
@@ -74,7 +74,7 @@ core.addPath(nodeDirectory);
 
 You can even find all cached versions of a tool:
 
-```
+```js
 const tc = require('@actions/tool-cache');
 
 const allNodeVersions = tc.findAllVersions('node');


### PR DESCRIPTION
There are a bunch of code blocks in the various packages' READMEs and docs without the fancy syntax highlighting that GitHub provides. This is a small change, but I think it has a nice impact 😄 

I'm not sure who to request reviews from - please let me know if there's right person!