### PR TITLE
Correct wrong docs

### DIFF
--- a/docs/javascript-action.md
+++ b/docs/javascript-action.md
@@ -18,7 +18,7 @@ e.g. To use https://github.com/actions/setup-node, user's will author:
 
 ```yaml
 steps:
-    using: actions/setup-node@master
+    uses: actions/setup-node@master
 ```
 
 # Dev Workflow


### PR DESCRIPTION
Docs say it's `using:` but it's actually `uses:`.

See this for reference: https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepsuses