### PR TITLE
Fix path

### DIFF
--- a/docs/javascript-action.md
+++ b/docs/javascript-action.md
@@ -78,7 +78,7 @@ async function run() {
 run();
 ```
 
-Modify tests in `__tests__\main.test.ts`.  The template uses [jest](https://github.com/facebook/jest).
+Modify tests in `__tests__/main.test.ts`.  The template uses [jest](https://github.com/facebook/jest).
 
 ## Build and Test
 


### PR DESCRIPTION
Docs say it's `using:` but it's actually `uses:`.

See this for reference: https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepsuses