### PR TITLE
fix syntax error in output example

### DIFF
--- a/packages/exec/README.md
+++ b/packages/exec/README.md
@@ -29,8 +29,8 @@ Capture output or specify [other options](https://github.com/actions/toolkit/blo
 ```js
 const exec = require('@actions/exec');
 
-const myOutput = '';
-const myError = '';
+let myOutput = '';
+let myError = '';
 
 const options = {};
 options.listeners = {


### PR DESCRIPTION
a const can't change so this gives syntax errors when trying to reassign them with ` +=` when receiving output