### PR TITLE
Core debug

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,3 +78,20 @@ catch (err) {
   core.error(`Error ${err}, action may still succeed though`);
 }
 ```
+
+This library can also wrap chunks of output in foldable groups.
+
+```js
+const core = require('@actions/core')
+
+// Manually wrap output
+core.groupStart('Do some function')
+doSomeFunction()
+core.groupEnd()
+
+// Wrap an asynchronous function call
+const result = await core.group('Do something async', async () => {
+  const response = await doSomeHTTPRequest()
+  return response
+})
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -85,9 +85,9 @@ This library can also wrap chunks of output in foldable groups.
 const core = require('@actions/core')
 
 // Manually wrap output
-core.groupStart('Do some function')
+core.startGroup('Do some function')
 doSomeFunction()
-core.groupEnd()
+core.endGroup()
 
 // Wrap an asynchronous function call
 const result = await core.group('Do something async', async () => {

--- a/packages/core/__tests__/lib.test.ts
+++ b/packages/core/__tests__/lib.test.ts
@@ -166,9 +166,11 @@ describe('@actions/core', () => {
   })
 
   it('group wraps an async call in a group', async () => {
-    await core.group('mygroup', async () => {
+    const result = await core.group('mygroup', async () => {
       process.stdout.write('in my group\n')
+      return true
     })
+    expect(result).toBe(true)
     assertWriteCalls([
       `##[group]mygroup${os.EOL}`,
       'in my group\n',

--- a/packages/core/__tests__/lib.test.ts
+++ b/packages/core/__tests__/lib.test.ts
@@ -155,6 +155,27 @@ describe('@actions/core', () => {
     assertWriteCalls([`##[warning]%0D%0Awarning%0A${os.EOL}`])
   })
 
+  it('startGroup starts a new group', () => {
+    core.startGroup('my-group')
+    assertWriteCalls([`##[group]my-group${os.EOL}`])
+  })
+
+  it('endGroup ends new group', () => {
+    core.endGroup()
+    assertWriteCalls([`##[endgroup]${os.EOL}`])
+  })
+
+  it('group wraps an async call in a group', async () => {
+    await core.group('mygroup', async () => {
+      process.stdout.write('in my group\n')
+    })
+    assertWriteCalls([
+      `##[group]mygroup${os.EOL}`,
+      'in my group\n',
+      `##[endgroup]${os.EOL}`
+    ])
+  })
+
   it('debug sets the correct message', () => {
     core.debug('Debug')
     assertWriteCalls([`##[debug]Debug${os.EOL}`])

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -25,7 +25,7 @@ export function issueCommand(
   process.stdout.write(cmd.toString() + os.EOL)
 }
 
-export function issue(name: string, message: string): void {
+export function issue(name: string, message: string = ''): void {
   issueCommand(name, {}, message)
 }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -159,7 +159,14 @@ export function endGroup(): void {
  */
 export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
   startGroup(name)
-  const result = await fn()
-  endGroup()
+
+  let result: T
+
+  try {
+    result = await fn()
+  } finally {
+    endGroup()
+  }
+
   return result
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -130,3 +130,36 @@ export function error(message: string): void {
 export function warning(message: string): void {
   issue('warning', message)
 }
+
+/**
+ * Begin an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ *
+ * @param name The name of the output group
+ */
+export function startGroup(name: string): void {
+  issue('group', name)
+}
+
+/**
+ * End an output group.
+ */
+export function endGroup(): void {
+  issue('endgroup')
+}
+
+/**
+ * Wrap an asynchronous function call in a group.
+ *
+ * Returns the same type as the function itself.
+ *
+ * @param name The name of the group
+ * @param fn The function to wrap in the group
+ */
+export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  startGroup(name)
+  const result = await fn()
+  endGroup()
+  return result
+}


### PR DESCRIPTION
This pull request adds helpers for `group` and `endgroup`.

- Adds `core.startGroup('name')` and `core.endGroup()` for simple commands
- Adds `core.group('name', asyncFn)` for wrapping asynchronous commands 