### PR TITLE
Accept Octokit.Options in the GitHub constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9530,9 +9530,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.4.tgz",
-      "integrity": "sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "lerna": "^3.13.3",
     "prettier": "^1.17.0",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.4.4"
+    "typescript": "^3.6.2"
   }
 }

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -27,6 +27,8 @@ const { data: pullRequest } = await octokit.pulls.get({
 console.log(pullRequest);
 ```
 
+You can pass client options (except `auth`, which is handled by the token argument), as specified by [Octokit](https://octokit.github.io/rest.js/), as a second argument to the `GitHub` constructor.
+
 You can also make GraphQL requests. See https://github.com/octokit/graphql.js for the API.
 
 ```js

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -14,8 +14,8 @@ export class GitHub extends Octokit {
     variables?: Variables
   ) => Promise<GraphQlQueryResponse>
 
-  constructor(token: string) {
-    super({auth: `token ${token}`})
+  constructor(token: string, opts: Omit<Octokit.Options, 'auth'> = {}) {
+    super({...opts, auth: `token ${token}`})
     this.graphql = defaults({
       headers: {authorization: `token ${token}`}
     })


### PR DESCRIPTION
This adds an optional object of Octokit client options to the GitHub constructor. This allows for debugging, API previews, etc.

This PR also bumps TypeScript to 3.6.2 so that I can use the `Omit` type.