### PR TITLE
Update readme to show how to use the secret GITHUB_TOKEN

### DIFF
--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -11,6 +11,8 @@ const github = require('@actions/github');
 const core = require('@actions/core');
 
 // This should be a token with access to your repository scoped in as a secret.
+// The YML workflow will need to set myToken with the GitHub Secret Token
+// myToken: ${{ secrets.GITHUB_TOKEN }
 const myToken = core.getInput('myToken');
 
 const octokit = new github.GitHub(myToken);


### PR DESCRIPTION
This updates the example with some inline comments to show that you need to use the  `GITHUB_TOKEN` secret as the token which will need to be passed in for you to use & authenticate the GitHub API