### PR TITLE
tool-cache: clarify that extractTar extracts gzipped tars

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -183,11 +183,11 @@ export async function extract7z(
 }
 
 /**
- * Extract a tar
+ * Extract a compressed tar archive
  *
  * @param file     path to the tar
  * @param dest     destination directory. Optional.
- * @param flags    flags for the tar. Optional.
+ * @param flags    flags for the tar command to use for extraction. Defaults to 'xz' (extracting gzipped tars). Optional.
  * @returns        path to the destination directory
  */
 export async function extractTar(


### PR DESCRIPTION
The default downloadTool implementation strips the filename so when passing it to the extractTar function, it doesn't have a way of knowing the format without manually specifying it. However what the extractTar function arguments meant and how to specify them wasn't clear before reading the source code, so the documentation here got updated to reflect that.

I put the default value of the flags argument into the documentation because it seems to be missing when shown in auto completion when depending on tool-cache.