### PR TITLE
[docs]: fix wording in typescript-action

### DIFF
--- a/docs/typescript-action.md
+++ b/docs/typescript-action.md
@@ -1,4 +1,4 @@
-# Creating a JavaScript Action
+# Creating a TypeScript Action
 
 The [typescript-action](https://github.com/actions/typescript-action) repo contains everything you need to get started.
 


### PR DESCRIPTION
I believe this should say "TypeScript Action" not "JavaScript Action" :)