### PR TITLE
Add 'repository.directory' to package manifests

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/toolkit.git"
+    "url": "git+https://github.com/actions/toolkit.git",
+    "directory": "packages/core"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/toolkit.git"
+    "url": "git+https://github.com/actions/toolkit.git",
+    "directory": "packages/exec"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/toolkit.git"
+    "url": "git+https://github.com/actions/toolkit.git",
+    "directory": "packages/github"
   },
   "scripts": {
     "test": "jest",

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/toolkit.git"
+    "url": "git+https://github.com/actions/toolkit.git",
+    "directory": "packages/io"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/toolkit.git"
+    "url": "git+https://github.com/actions/toolkit.git",
+    "directory": "packages/tool-cache"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",


### PR DESCRIPTION
This is supported by npm ([docs](https://docs.npmjs.com/files/package.json#repository)). It can help tools like Dependabot figure out what's changed between versions.