### PR TITLE
add core method to saveState and getState.

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -126,5 +126,5 @@ const core = require('@actions/core');
 
 var pid = core.getState("pidToKill");
 
-kill(pid);
+process.kill(pid);
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -95,3 +95,36 @@ const result = await core.group('Do something async', async () => {
   return response
 })
 ```
+
+#### Action state
+
+You can use this library to save state and get state for sharing information between a given wrapper action: 
+
+**action.yml**
+```yaml
+name: 'Wrapper action sample'
+inputs:
+  name:
+    default: 'GitHub'
+runs:
+  using: 'node12'
+  main: 'main.js'
+  post: 'cleanup.js'
+```
+
+In action's `main.js`:
+
+```js
+const core = require('@actions/core');
+
+core.saveState("pidToKill", 12345);
+```
+
+In action's `cleanup.js`:
+```js
+const core = require('@actions/core');
+
+var pid = core.getState("pidToKill");
+
+kill(pid);
+```

--- a/packages/core/__tests__/lib.test.ts
+++ b/packages/core/__tests__/lib.test.ts
@@ -20,7 +20,7 @@ const testEnvVars = {
   INPUT_MULTIPLE_SPACES_VARIABLE: 'I have multiple spaces',
 
   // Save inputs
-  STATE_state_1: 'state_val'
+  STATE_TEST_1: 'state_val'
 }
 
 describe('@actions/core', () => {
@@ -96,17 +96,17 @@ describe('@actions/core', () => {
   })
 
   it('getInput gets required input', () => {
-    expect(core.getInput('my input', { required: true })).toBe('val')
+    expect(core.getInput('my input', { required: true})).toBe('val')
   })
 
   it('getInput throws on missing required input', () => {
-    expect(() => core.getInput('missing', { required: true })).toThrow(
+    expect(() => core.getInput('missing', { required: true})).toThrow(
       'Input required and not supplied: missing'
     )
   })
 
   it('getInput does not throw on missing non-required input', () => {
-    expect(core.getInput('missing', { required: false })).toBe('')
+    expect(core.getInput('missing', { required: false})).toBe('')
   })
 
   it('getInput is case insensitive', () => {
@@ -204,7 +204,7 @@ describe('@actions/core', () => {
   })
 
   it('getState gets wrapper action state', () => {
-    expect(core.getState('state_1')).toBe('state_val')
+    expect(core.getState('TEST_1')).toBe('state_val')
   })
 })
 

--- a/packages/core/__tests__/lib.test.ts
+++ b/packages/core/__tests__/lib.test.ts
@@ -96,17 +96,17 @@ describe('@actions/core', () => {
   })
 
   it('getInput gets required input', () => {
-    expect(core.getInput('my input', { required: true})).toBe('val')
+    expect(core.getInput('my input', {required: true})).toBe('val')
   })
 
   it('getInput throws on missing required input', () => {
-    expect(() => core.getInput('missing', { required: true})).toThrow(
+    expect(() => core.getInput('missing', {required: true})).toThrow(
       'Input required and not supplied: missing'
     )
   })
 
   it('getInput does not throw on missing non-required input', () => {
-    expect(core.getInput('missing', { required: false})).toBe('')
+    expect(core.getInput('missing', {required: false})).toBe('')
   })
 
   it('getInput is case insensitive', () => {

--- a/packages/core/__tests__/lib.test.ts
+++ b/packages/core/__tests__/lib.test.ts
@@ -17,7 +17,10 @@ const testEnvVars = {
   INPUT_MY_INPUT: 'val',
   INPUT_MISSING: '',
   'INPUT_SPECIAL_CHARS_\'\t"\\': '\'\t"\\ response ',
-  INPUT_MULTIPLE_SPACES_VARIABLE: 'I have multiple spaces'
+  INPUT_MULTIPLE_SPACES_VARIABLE: 'I have multiple spaces',
+
+  // Save inputs
+  STATE_state_1: 'state_val'
 }
 
 describe('@actions/core', () => {
@@ -93,17 +96,17 @@ describe('@actions/core', () => {
   })
 
   it('getInput gets required input', () => {
-    expect(core.getInput('my input', {required: true})).toBe('val')
+    expect(core.getInput('my input', { required: true })).toBe('val')
   })
 
   it('getInput throws on missing required input', () => {
-    expect(() => core.getInput('missing', {required: true})).toThrow(
+    expect(() => core.getInput('missing', { required: true })).toThrow(
       'Input required and not supplied: missing'
     )
   })
 
   it('getInput does not throw on missing non-required input', () => {
-    expect(core.getInput('missing', {required: false})).toBe('')
+    expect(core.getInput('missing', { required: false })).toBe('')
   })
 
   it('getInput is case insensitive', () => {
@@ -193,6 +196,15 @@ describe('@actions/core', () => {
   it('debug escapes the message', () => {
     core.debug('\r\ndebug\n')
     assertWriteCalls([`::debug::%0D%0Adebug%0A${os.EOL}`])
+  })
+
+  it('saveState produces the correct command', () => {
+    core.saveState('state_1', 'some value')
+    assertWriteCalls([`::save-state name=state_1,::some value${os.EOL}`])
+  })
+
+  it('getState gets wrapper action state', () => {
+    expect(core.getState('state_1')).toBe('state_val')
   })
 })
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,4 +1,4 @@
-import {issue, issueCommand} from './command'
+import { issue, issueCommand } from './command'
 
 import * as os from 'os'
 import * as path from 'path'
@@ -37,7 +37,7 @@ export enum ExitCode {
  */
 export function exportVariable(name: string, val: string): void {
   process.env[name] = val
-  issueCommand('set-env', {name}, val)
+  issueCommand('set-env', { name }, val)
 }
 
 /**
@@ -86,7 +86,7 @@ export function getInput(name: string, options?: InputOptions): string {
  * @param     value    value to store
  */
 export function setOutput(name: string, value: string): void {
-  issueCommand('set-output', {name}, value)
+  issueCommand('set-output', { name }, value)
 }
 
 //-----------------------------------------------------------------------
@@ -177,4 +177,28 @@ export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
   }
 
   return result
+}
+
+//-----------------------------------------------------------------------
+// Wrapper action state
+//-----------------------------------------------------------------------
+
+/**
+ * Saves state for current action, the state can only be retrieved by this action's post job execution.
+ *
+ * @param     name     name of the state to store
+ * @param     value    value to store
+ */
+export function saveState(name: string, value: string): void {
+  issueCommand('save-state', { name }, value)
+}
+
+/**
+ * Gets the value of an state set by this action's main execution.
+ *
+ * @param     name     name of the state to get
+ * @returns   string
+ */
+export function getState(name: string): string {
+  return process.env[`STATE_${name}`] || ''
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,4 +1,4 @@
-import { issue, issueCommand} from './command'
+import {issue, issueCommand} from './command'
 
 import * as os from 'os'
 import * as path from 'path'
@@ -86,7 +86,7 @@ export function getInput(name: string, options?: InputOptions): string {
  * @param     value    value to store
  */
 export function setOutput(name: string, value: string): void {
-  issueCommand('set-output', { name }, value)
+  issueCommand('set-output', {name}, value)
 }
 
 //-----------------------------------------------------------------------
@@ -190,7 +190,7 @@ export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
  * @param     value    value to store
  */
 export function saveState(name: string, value: string): void {
-  issueCommand('save-state', { name }, value)
+  issueCommand('save-state', {name}, value)
 }
 
 /**

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,4 +1,4 @@
-import { issue, issueCommand } from './command'
+import { issue, issueCommand} from './command'
 
 import * as os from 'os'
 import * as path from 'path'
@@ -37,7 +37,7 @@ export enum ExitCode {
  */
 export function exportVariable(name: string, val: string): void {
   process.env[name] = val
-  issueCommand('set-env', { name }, val)
+  issueCommand('set-env', {name}, val)
 }
 
 /**


### PR DESCRIPTION
In wrapper action, action author uses these 2 methods for sharing information between his action's main-execution and post-execution, this information is only available to this pair of action's executions, other action within the same job won't get it.

Ex: 
In the main execution:
```javascript
  core.saveState("pidToKill", 12345);
```
In the post-execution:
```javascript
  var pid = core.getState("pidToKill");
  process.kill(pid);
```