### PR TITLE
Fix a link

### DIFF
--- a/docs/typescript-action.md
+++ b/docs/typescript-action.md
@@ -161,4 +161,4 @@ steps:
 
 # Next Steps
 
-Now that you've created a basic action, see how to [leverage the github context](./github-package) in your actions
+Now that you've created a basic action, see how to [leverage the github context](./github-package.md) in your actions


### PR DESCRIPTION
At the end of the typescript-action.md it links to `github-package`, but the extension was missing a linking failed.