### PR TITLE
Add a bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+You're opening a bug report for the GitHub Actions Toolkit - this is the toolkit you can use to build your own reusable Actions in JavaScript or TypeScript.
+
+If you're having trouble using GitHub Actions, you have a bug or need help with your workflow, then please post your question at:
+
+GitHub Community Forum for GitHub Actions
+https://github.community/t5/GitHub-Actions/bd-p/actions
+
+Thanks for trying GitHub Actions!
+
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Code Snippet**
+If applicable, add a code snippet to help explain your problem.
+
+**Additional information**
+Add any other context about the problem here.


### PR DESCRIPTION
Provide an issue template that will help people locate the GitHub Community forum for GitHub Actions.