### PR TITLE
add/fix API for creating secrets

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,16 +18,17 @@ const myInput = core.getInput('inputName', { required: true });
 core.setOutput('outputKey', 'outputVal');
 ```
 
-#### Exporting variables
+#### Exporting variables and secrets
 
-You can also export variables for future steps. Variables get set in the environment.
+You can also export variables and secrets for future steps. Both get set in the environment; the only difference is that a secret is masked in the logs.
 
 ```js
 const core = require('@actions/core');
 
-// Do stuff
-
+// add envVar to the environment, with 'Val' visible in logs
 core.exportVariable('envVar', 'Val');
+// add secretVar to the environment, with only '***' visible in logs
+core.exportSecret('secretVar', 'secret');
 ```
 
 #### PATH Manipulation

--- a/packages/core/__tests__/lib.test.ts
+++ b/packages/core/__tests__/lib.test.ts
@@ -51,34 +51,34 @@ describe('@actions/core', () => {
     assertWriteCalls([`::set-env name=my var2,::var val%0D%0A${os.EOL}`])
   })
 
-  // it('exportSecret produces the correct commands and sets the env', () => {
-  //   core.exportSecret('my secret', 'secret val')
-  //   expect(process.env['my secret']).toBe('secret val')
-  //   assertWriteCalls([
-  //     `::set-env name=my secret,::secret val${os.EOL}`,
-  //     `::set-secret]secret val${os.EOL}`
-  //   ])
-  // })
+  it('exportSecret produces the correct commands and sets the env', () => {
+    core.exportSecret('my secret', 'secret val')
+    expect(process.env['my secret']).toBe('secret val')
+    assertWriteCalls([
+      `::set-env name=my secret,::secret val${os.EOL}`,
+      `::add-mask::secret val${os.EOL}`
+    ])
+  })
 
-  // it('exportSecret escapes secret names', () => {
-  //   core.exportSecret('special char secret \r\n];', 'special secret val')
-  //   expect(process.env['special char secret \r\n];']).toBe('special secret val')
-  //   assertWriteCalls([
-  //     `::set-env name=special char secret %0D%0A%5D%3B,::special secret val${
-  //       os.EOL
-  //     }`,
-  //     `::set-secret]special secret val${os.EOL}`
-  //   ])
-  // })
+  it('exportSecret escapes secret names', () => {
+    core.exportSecret('special char secret \r\n];', 'special secret val')
+    expect(process.env['special char secret \r\n];']).toBe('special secret val')
+    assertWriteCalls([
+      `::set-env name=special char secret %0D%0A%5D%3B,::special secret val${
+        os.EOL
+      }`,
+      `::add-mask::special secret val${os.EOL}`
+    ])
+  })
 
-  // it('exportSecret escapes secret values', () => {
-  //   core.exportSecret('my secret2', 'secret val\r\n')
-  //   expect(process.env['my secret2']).toBe('secret val\r\n')
-  //   assertWriteCalls([
-  //     `::set-env name=my secret2,::secret val%0D%0A${os.EOL}`,
-  //     `::set-secret]secret val%0D%0A${os.EOL}`
-  //   ])
-  // })
+  it('exportSecret escapes secret values', () => {
+    core.exportSecret('my secret2', 'secret val\r\n')
+    expect(process.env['my secret2']).toBe('secret val\r\n')
+    assertWriteCalls([
+      `::set-env name=my secret2,::secret val%0D%0A${os.EOL}`,
+      `::add-mask::secret val%0D%0A${os.EOL}`
+    ])
+  })
 
   it('prependPath produces the correct commands and sets the env', () => {
     core.addPath('myPath')

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -47,10 +47,7 @@ export function exportVariable(name: string, val: string): void {
  */
 export function exportSecret(name: string, val: string): void {
   exportVariable(name, val)
-
-  // the runner will error with not implemented
-  // leaving the function but raising the error earlier
-  issueCommand('set-secret', {}, val)
+  issueCommand('add-mask', {}, val)
 }
 
 /**


### PR DESCRIPTION
I noticed in the actual code that there's a function for adding secrets, but it seems it uses a deprecated command and just errors out. I believe this is the proper fix to make it work again.

Please let me know if there's anything I missed (`CHANGELOG` etc). Also, the build command fails for `tool-cache`. I don't know if that's normal or not.