### PR TITLE
tool-cache: Work around a weird GNU Tar behavior on Windows

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -200,6 +200,10 @@ export async function extractTar(
   }
 
   dest = dest || (await _createExtractFolder(dest))
+  if (IS_WINDOWS) {
+    // For some reason, GNU Tar on Windows expects paths to be slash-separated even though this is not the standard Windows path delimiter
+    dest = dest.replace(/\\/g, '/')
+  }
   const tarPath: string = await io.which('tar', true)
   await exec(`"${tarPath}"`, [flags, '-C', dest, '-f', file])
 


### PR DESCRIPTION
For some reason GNU Tar insists on parsing the destination path using an Unix path delimiter (`/`), even on windows where the path delimiter is `\`.

This patch simply rewrites `\` to `/` in the destination path.