### PR TITLE
tool-cache: make extract functions quiet by default and more verbose if `core.isDebug` is set

### DIFF
--- a/packages/tool-cache/__tests__/tool-cache.test.ts
+++ b/packages/tool-cache/__tests__/tool-cache.test.ts
@@ -334,7 +334,7 @@ describe('@actions/tool-cache', function() {
             .readFileSync(path.join(tempDir, 'mock7zr-args.txt'))
             .toString()
             .trim()
-        ).toBe(`x -bb1 -bd -sccUTF-8 ${_7zFile}`)
+        ).toBe(`x -bb0 -bd -sccUTF-8 ${_7zFile}`)
         expect(fs.existsSync(path.join(extPath, 'file.txt'))).toBeTruthy()
         expect(
           fs.existsSync(path.join(extPath, 'file-with-ç-character.txt'))

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -144,9 +144,10 @@ export async function extract7z(
   process.chdir(dest)
   if (_7zPath) {
     try {
+      const logLevel = core.isDebug() ? '-bb1' : '-bb0'
       const args: string[] = [
         'x', // eXtract files with full paths
-        '-bb0', // -bb[0-3] : set output log level
+        logLevel, // -bb[0-3] : set output log level
         '-bd', // disable progress indicator
         '-sccUTF-8', // set charset for for console input/output
         file
@@ -227,6 +228,10 @@ export async function extractTar(
   // Initialize args
   const args = [flags]
 
+  if (core.isDebug() && !flags.includes('v')) {
+    args.push('-v')
+  }
+
   let destArg = dest
   let fileArg = file
   if (IS_WINDOWS && isGnuTar) {
@@ -295,7 +300,11 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
 
 async function extractZipNix(file: string, dest: string): Promise<void> {
   const unzipPath = await io.which('unzip', true)
-  await exec(`"${unzipPath}"`, ['-q', file], {cwd: dest})
+  const args = [file]
+  if (!core.isDebug()) {
+    args.unshift('-q')
+  }
+  await exec(`"${unzipPath}"`, args, {cwd: dest})
 }
 
 /**

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -146,7 +146,7 @@ export async function extract7z(
     try {
       const args: string[] = [
         'x', // eXtract files with full paths
-        '-bb1', // -bb[0-3] : set output log level
+        '-bb0', // -bb[0-3] : set output log level
         '-bd', // disable progress indicator
         '-sccUTF-8', // set charset for for console input/output
         file
@@ -295,7 +295,7 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
 
 async function extractZipNix(file: string, dest: string): Promise<void> {
   const unzipPath = await io.which('unzip', true)
-  await exec(`"${unzipPath}"`, [file], {cwd: dest})
+  await exec(`"${unzipPath}"`, ['-q', file], {cwd: dest})
 }
 
 /**


### PR DESCRIPTION
This avoids spamming the log when unzipping large zip files.