### PR TITLE
Fix remove-matcher syntax

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -107,7 +107,7 @@ Problems matchers can be used to scan a build's output to automatically surface 
 
 ```bash
 echo "::add-matcher::eslint-compact-problem-matcher.json"   
-echo "::remove-matcher::eslint-compact"
+echo "::remove-matcher owner=eslint-compact::"
 ```
 
 `add-matcher` takes a path to a Problem Matcher file


### PR DESCRIPTION
Using the syntax `::remove-matcher::the-matcher` wasn't working, but after some trial and error `::remove-matcher owner=the-matcher::` did. There's no mention of this on https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions so I'm not sure if this is a feature that's changing or if it was just documented wrong.