### PR TITLE
add: "types" to each package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/actions/toolkit/tree/master/packages/core",
   "license": "MIT",
   "main": "lib/core.js",
+  "types": "lib/core.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/actions/toolkit/tree/master/packages/exec",
   "license": "MIT",
   "main": "lib/exec.js",
+  "types": "lib/exec.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/actions/toolkit/tree/master/packages/github",
   "license": "MIT",
   "main": "lib/github.js",
+  "types": "lib/github.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/actions/toolkit/tree/master/packages/io",
   "license": "MIT",
   "main": "lib/io.js",
+  "types": "lib/io.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/actions/toolkit/tree/master/packages/exec",
   "license": "MIT",
   "main": "lib/tool-cache.js",
+  "types": "lib/tool-cache.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"


### PR DESCRIPTION
I'm using IntelliJ IDEA and IDE couldn't find type definition of packages. I think it is because each `package.json` doesn't contain `types` field, isn't it? Editing files under `node_modules` resolved the issue.