### PR TITLE
fix unzip error

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -130,7 +130,7 @@ export async function extract7z(
   ok(IS_WINDOWS, 'extract7z() not supported on current OS')
   ok(file, 'parameter "file" is required')
 
-  dest = dest || (await _createExtractFolder(dest))
+  dest = await _createExtractFolder(dest)
 
   const originalCwd = process.cwd()
   process.chdir(dest)
@@ -199,7 +199,7 @@ export async function extractTar(
     throw new Error("parameter 'file' is required")
   }
 
-  dest = dest || (await _createExtractFolder(dest))
+  dest = await _createExtractFolder(dest)
   const tarPath: string = await io.which('tar', true)
   await exec(`"${tarPath}"`, [flags, '-C', dest, '-f', file])
 
@@ -218,7 +218,7 @@ export async function extractZip(file: string, dest?: string): Promise<string> {
     throw new Error("parameter 'file' is required")
   }
 
-  dest = dest || (await _createExtractFolder(dest))
+  dest = await _createExtractFolder(dest)
 
   if (IS_WINDOWS) {
     await extractZipWin(file, dest)


### PR DESCRIPTION
Fixes these errors when extracting a zip/tar/7z file to a destination folder that does not exist.

tar on macos and linux
```
/bin/tar: /home/runner/work/toolkit/toolkit/packages/tool-cache/__tests__/TEMP/test-
install-tar.gz/not-exist: Cannot open: No such file or directory
```

7z on windows
```
ENOENT: no such file or directory, chdir 'D:\a\toolkit\toolkit\packages\exec\__tests__'
-> 'D:\a\toolkit\toolkit\packages\tool-cache\__tests__\test-install-7z\not-exist'
```

zip on macos

```
There was an error when attempting to execute the process '/usr/bin/unzip'. This may
indicate the process failed to start. Error: spawn /usr/bin/unzip ENOENT
```

fixes #213 
fixes #82 