### PR TITLE
Fix test timeouts

### DIFF
--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -661,7 +661,7 @@ describe('@actions/exec', () => {
         `[command]"${exePath}" myarg1 myarg2`
       )
       expect(output.trim()).toBe("args[0]: 'myarg1'\r\nargs[1]: 'myarg2'")
-    }, 10000) // slower windows runs timeout, so upping timeout to 10s (from default of 5s)
+    }, 20000) // slower windows runs timeout, so upping timeout to 20s (from default of 5s)
 
     it('execs .cmd with a space and with verbatim args (Windows)', async () => {
       // this test validates the quoting that tool runner adds around the script path.

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -287,8 +287,6 @@ describe('@actions/exec', () => {
   })
 
   it('Handles child process holding streams open', async function() {
-    // this was timing out on some slower hosted macOS runs at default 5s
-    jest.setTimeout(10000)
     const semaphorePath = path.join(
       getTestTemp(),
       'child-process-semaphore.txt'
@@ -332,11 +330,9 @@ describe('@actions/exec', () => {
     ).toBe(1)
 
     fs.unlinkSync(semaphorePath)
-  })
+  }, 10000) // this was timing out on some slower hosted macOS runs at default 5s
 
   it('Handles child process holding streams open and non-zero exit code', async function() {
-    // this was timing out on some slower hosted macOS runs at default 5s
-    jest.setTimeout(10000)
     const semaphorePath = path.join(
       getTestTemp(),
       'child-process-semaphore.txt'
@@ -388,7 +384,7 @@ describe('@actions/exec', () => {
     ).toBe(1)
 
     fs.unlinkSync(semaphorePath)
-  })
+  }, 10000) // this was timing out on some slower hosted macOS runs at default 5s
 
   it('Handles child process holding streams open and stderr', async function() {
     const semaphorePath = path.join(
@@ -665,7 +661,7 @@ describe('@actions/exec', () => {
         `[command]"${exePath}" myarg1 myarg2`
       )
       expect(output.trim()).toBe("args[0]: 'myarg1'\r\nargs[1]: 'myarg2'")
-    })
+    }, 10000) // slower windows runs timeout, so upping timeout to 10s (from default of 5s)
 
     it('execs .cmd with a space and with verbatim args (Windows)', async () => {
       // this test validates the quoting that tool runner adds around the script path.


### PR DESCRIPTION
Looks like we need longer timeouts, particularly on windows