### PR TITLE
Update to latest TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11563,9 +11563,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -13134,9 +13134,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "jest": "^24.9.0",
     "jest-circus": "^24.7.1",
     "lerna": "^3.18.4",
-    "prettier": "^1.17.0",
+    "prettier": "^1.19.1",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.6.2"
+    "typescript": "^3.7.4"
   }
 }

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -748,9 +748,7 @@ describe('@actions/exec', () => {
       const exitCode = await exec.exec(`"${cmdPath}"`, args, options)
       expect(exitCode).toBe(0)
       expect(outStream.getContents().split(os.EOL)[0]).toBe(
-        `[command]${
-          process.env.ComSpec
-        } /D /S /C ""${cmdPath}" "my arg 1" "my arg 2""`
+        `[command]${process.env.ComSpec} /D /S /C ""${cmdPath}" "my arg 1" "my arg 2""`
       )
       expect(output.trim()).toBe(
         'args[0]: "<quote>my arg 1<quote>"\r\n' +
@@ -780,9 +778,7 @@ describe('@actions/exec', () => {
         const exitCode = await exec.exec(`${cmd}`, args, options)
         expect(exitCode).toBe(0)
         expect(outStream.getContents().split(os.EOL)[0]).toBe(
-          `[command]${
-            process.env.ComSpec
-          } /D /S /C "${cmdPath} "my arg 1" "my arg 2""`
+          `[command]${process.env.ComSpec} /D /S /C "${cmdPath} "my arg 1" "my arg 2""`
         )
         expect(output.trim()).toBe(
           'args[0]: "<quote>my arg 1<quote>"\r\n' +

--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -639,23 +639,15 @@ class ExecState extends events.EventEmitter {
     if (this.processExited) {
       if (this.processError) {
         error = new Error(
-          `There was an error when attempting to execute the process '${
-            this.toolPath
-          }'. This may indicate the process failed to start. Error: ${
-            this.processError
-          }`
+          `There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`
         )
       } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
         error = new Error(
-          `The process '${this.toolPath}' failed with exit code ${
-            this.processExitCode
-          }`
+          `The process '${this.toolPath}' failed with exit code ${this.processExitCode}`
         )
       } else if (this.processStderr && this.options.failOnStdErr) {
         error = new Error(
-          `The process '${
-            this.toolPath
-          }' failed because one or more lines were written to the STDERR stream`
+          `The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`
         )
       }
     }

--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -1171,9 +1171,9 @@ describe('which', () => {
       const originalPath = process.env['PATH']
       try {
         // modify PATH
-        process.env['PATH'] = `${process.env['PATH']}${
-          path.delimiter
-        }${testPath}`
+        process.env[
+          'PATH'
+        ] = `${process.env['PATH']}${path.delimiter}${testPath}`
 
         // find each file
         for (const fileName of Object.keys(files)) {
@@ -1244,9 +1244,9 @@ describe('which', () => {
       await fs.writeFile(notExpectedFilePath, '')
       const originalPath = process.env['PATH']
       try {
-        process.env['PATH'] = `${process.env['PATH']}${
-          path.delimiter
-        }${testPath}`
+        process.env[
+          'PATH'
+        ] = `${process.env['PATH']}${path.delimiter}${testPath}`
         expect(await io.which(fileName)).toBe(expectedFilePath)
       } finally {
         process.env['PATH'] = originalPath

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -76,9 +76,7 @@ export async function downloadTool(
       if (response.message.statusCode !== 200) {
         const err = new HTTPError(response.message.statusCode)
         core.debug(
-          `Failed to download from "${url}". Code(${
-            response.message.statusCode
-          }) Message(${response.message.statusMessage})`
+          `Failed to download from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`
         )
         throw err
       }
@@ -93,9 +91,7 @@ export async function downloadTool(
           })
         } catch (err) {
           core.debug(
-            `Failed to download from "${url}". Code(${
-              response.message.statusCode
-            }) Message(${response.message.statusMessage})`
+            `Failed to download from "${url}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`
           )
           reject(err)
         }


### PR DESCRIPTION
Updating to TypeScript version 3.7 to allow using [Optional Chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) and [Nullish Coalescing](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing), among other benefits.

`prettier` was updated to allow it to recognize the `??` operator.
With the `prettier` update, it appears print width is determined differently for strings with `${}` variables.

All code changes are purely cosmetic.