### PR TITLE
Only run CI on PRs and pushes to master

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,8 @@
 name: toolkit-unit-tests
 on: 
   push:
+    branches:
+      - master
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
Pull requests currently run every workflow twice, on the push to the branch and on the pull request itself. This change limits `push` events to the master branch to avoid this.