### PR TITLE
only audit on ubuntu-latest

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,6 +50,8 @@ jobs:
 
     - name: audit tools
       run: npm audit --audit-level=moderate
+      if: matrix.runs-on == 'ubuntu-latest'
 
     - name: audit packages
       run: npm run audit-all
+      if: matrix.runs-on == 'ubuntu-latest'


### PR DESCRIPTION
we don't need to run module audits on all OSes and ubuntu is the fastest run