### PR TITLE
exec: Expose ExecOptions interface

### DIFF
--- a/packages/exec/src/exec.ts
+++ b/packages/exec/src/exec.ts
@@ -1,5 +1,7 @@
-import * as im from './interfaces'
+import {ExecOptions} from './interfaces'
 import * as tr from './toolrunner'
+
+export {ExecOptions}
 
 /**
  * Exec a command.
@@ -14,7 +16,7 @@ import * as tr from './toolrunner'
 export async function exec(
   commandLine: string,
   args?: string[],
-  options?: im.ExecOptions
+  options?: ExecOptions
 ): Promise<number> {
   const commandArgs = tr.argStringToArray(commandLine)
   if (commandArgs.length === 0) {


### PR DESCRIPTION
`@actions/exec` package exposes `exec` function but does not expose `ExecOptions` for now.

Since `exec` function's option is [big](https://github.com/actions/toolkit/blob/d9347d4ab99fd507c0b9104b2cf79fb44fcc827d/packages/exec/src/interfaces.ts#L5), I want to make the option object in advance with some complicated logic.

For example, let's say to have a function to run a command and whether stdout value is captured or not is controlled by flag:

```typescript
async function runCommand(cmd: string, capture?: boolean) {
    let stdout = '';

    const options = { listeners: {} };
    if (capture) {
        options.listeners.stdout = (data) => {
            stdout += data.toString();
        };
    }
    await exec(cmd, [], options);
    return stdout;
}
```

This code cannot be compiled because we cannot give proper type to `options` variable. If the `ExecOptions` interface is available, we can write a safe code as follows:

```typescript
import { exec, ExecOptions } from '@actions/exec';

async function runCommand(cmd: string, capture?: boolean) {
    let stdout = '';

    const options: ExecOptions = { listeners: {} };
    if (capture) {
        options.listeners.stdout = (data) => {
            stdout += data.toString();
        };
    }
    await exec(cmd, [], options);
    return stdout;
}
```