### PR TITLE
handle response body error

### DIFF
--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@actions/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-xD+CQd9p4lU7ZfRqmUcbJpqR+Ss51rJRVeXMyOLrZQImN9/8Sy/BEUBnHO/UKD3z03R686PVTLfEPmkropGuLw=="
-    },
     "@actions/http-client": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.6.tgz",

--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/tool-cache Releases
 
+### 1.3.2
+
+- [Update downloadTool with better error handling and retries](https://github.com/actions/toolkit/pull/369)
+
 ### 1.3.1
 
 - [Increase http-client min version](https://github.com/actions/toolkit/pull/314)

--- a/packages/tool-cache/__tests__/retry-helper.test.ts
+++ b/packages/tool-cache/__tests__/retry-helper.test.ts
@@ -1,0 +1,87 @@
+import * as core from '@actions/core'
+import {RetryHelper} from '../src/retry-helper'
+
+let info: string[]
+let retryHelper: RetryHelper
+
+describe('retry-helper tests', () => {
+  beforeAll(() => {
+    // Mock @actions/core info()
+    jest.spyOn(core, 'info').mockImplementation((message: string) => {
+      info.push(message)
+    })
+
+    retryHelper = new RetryHelper(3, 0, 0)
+  })
+
+  beforeEach(() => {
+    // Reset info
+    info = []
+  })
+
+  afterAll(() => {
+    // Restore
+    jest.restoreAllMocks()
+  })
+
+  it('first attempt succeeds', async () => {
+    const actual = await retryHelper.execute(async () => {
+      return 'some result'
+    })
+    expect(actual).toBe('some result')
+    expect(info).toHaveLength(0)
+  })
+
+  it('second attempt succeeds', async () => {
+    let attempts = 0
+    const actual = await retryHelper.execute(async () => {
+      if (++attempts === 1) {
+        throw new Error('some error')
+      }
+
+      return Promise.resolve('some result')
+    })
+    expect(attempts).toBe(2)
+    expect(actual).toBe('some result')
+    expect(info).toHaveLength(2)
+    expect(info[0]).toBe('some error')
+    expect(info[1]).toMatch(/Waiting .+ seconds before trying again/)
+  })
+
+  it('third attempt succeeds', async () => {
+    let attempts = 0
+    const actual = await retryHelper.execute(async () => {
+      if (++attempts < 3) {
+        throw new Error(`some error ${attempts}`)
+      }
+
+      return Promise.resolve('some result')
+    })
+    expect(attempts).toBe(3)
+    expect(actual).toBe('some result')
+    expect(info).toHaveLength(4)
+    expect(info[0]).toBe('some error 1')
+    expect(info[1]).toMatch(/Waiting .+ seconds before trying again/)
+    expect(info[2]).toBe('some error 2')
+    expect(info[3]).toMatch(/Waiting .+ seconds before trying again/)
+  })
+
+  it('all attempts fail succeeds', async () => {
+    let attempts = 0
+    let error: Error = (null as unknown) as Error
+    try {
+      await retryHelper.execute(() => {
+        throw new Error(`some error ${++attempts}`)
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error.message).toBe('some error 3')
+    expect(attempts).toBe(3)
+    expect(info).toHaveLength(4)
+    expect(info[0]).toBe('some error 1')
+    expect(info[1]).toMatch(/Waiting .+ seconds before trying again/)
+    expect(info[2]).toBe('some error 2')
+    expect(info[3]).toMatch(/Waiting .+ seconds before trying again/)
+  })
+})

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/tool-cache",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Actions tool-cache lib",
   "keywords": [
     "github",

--- a/packages/tool-cache/src/retry-helper.ts
+++ b/packages/tool-cache/src/retry-helper.ts
@@ -1,0 +1,55 @@
+import * as core from '@actions/core'
+
+/**
+ * Internal class for retries
+ */
+export class RetryHelper {
+  private maxAttempts: number
+  private minSeconds: number
+  private maxSeconds: number
+
+  constructor(maxAttempts: number, minSeconds: number, maxSeconds: number) {
+    if (maxAttempts < 1) {
+      throw new Error('max attempts should be greater than or equal to 1')
+    }
+
+    this.maxAttempts = maxAttempts
+    this.minSeconds = Math.floor(minSeconds)
+    this.maxSeconds = Math.floor(maxSeconds)
+    if (this.minSeconds > this.maxSeconds) {
+      throw new Error('min seconds should be less than or equal to max seconds')
+    }
+  }
+
+  async execute<T>(action: () => Promise<T>): Promise<T> {
+    let attempt = 1
+    while (attempt < this.maxAttempts) {
+      // Try
+      try {
+        return await action()
+      } catch (err) {
+        core.info(err.message)
+      }
+
+      // Sleep
+      const seconds = this.getSleepAmount()
+      core.info(`Waiting ${seconds} seconds before trying again`)
+      await this.sleep(seconds)
+      attempt++
+    }
+
+    // Last attempt
+    return await action()
+  }
+
+  private getSleepAmount(): number {
+    return (
+      Math.floor(Math.random() * (this.maxSeconds - this.minSeconds + 1)) +
+      this.minSeconds
+    )
+  }
+
+  private async sleep(seconds: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, seconds * 1000))
+  }
+}


### PR DESCRIPTION
Update tool-cache downloadTool() to handle errors from response body stream

related to https://github.com/actions/setup-node/issues/116