### PR TITLE
Add type of context.payload.comment

### DIFF
--- a/packages/github/src/interfaces.ts
+++ b/packages/github/src/interfaces.ts
@@ -36,4 +36,8 @@ export interface WebhookPayload {
     id: number
     [key: string]: any
   }
+  comment?: {
+    id: number
+    [key: string]: any
+  }
 }


### PR DESCRIPTION
## Description

To use `context.payload.comment` in TypeScript, we should do `(context.payload as any).comment`. This PR solves the problem.