### PR TITLE
Check if tool path exists before executing

### DIFF
--- a/packages/tool-cache/__tests__/tool-cache.test.ts
+++ b/packages/tool-cache/__tests__/tool-cache.test.ts
@@ -461,7 +461,7 @@ describe('@actions/tool-cache', function() {
         ]
         await exec.exec(`"${powershellPath}"`, args)
       } else {
-        const zipPath: string = await io.which('zip')
+        const zipPath: string = await io.which('zip', true)
         await exec.exec(`"${zipPath}`, [zipFile, '-r', '.'], {cwd: stagingDir})
       }
 
@@ -512,7 +512,7 @@ describe('@actions/tool-cache', function() {
         ]
         await exec.exec(`"${powershellPath}"`, args)
       } else {
-        const zipPath: string = await io.which('zip')
+        const zipPath: string = await io.which('zip', true)
         await exec.exec(zipPath, [zipFile, '-r', '.'], {cwd: stagingDir})
       }
 
@@ -569,7 +569,7 @@ describe('@actions/tool-cache', function() {
         ]
         await exec.exec(`"${powershellPath}"`, args)
       } else {
-        const zipPath: string = await io.which('zip')
+        const zipPath: string = await io.which('zip', true)
         await exec.exec(zipPath, [zipFile, '-r', '.'], {cwd: stagingDir})
       }
 

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -279,7 +279,7 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
   const command = `$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.FileSystem } catch { } ; [System.IO.Compression.ZipFile]::ExtractToDirectory('${escapedFile}', '${escapedDest}')`
 
   // run powershell
-  const powershellPath = await io.which('powershell')
+  const powershellPath = await io.which('powershell', true)
   const args = [
     '-NoLogo',
     '-Sta',
@@ -294,7 +294,7 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
 }
 
 async function extractZipNix(file: string, dest: string): Promise<void> {
-  const unzipPath = await io.which('unzip')
+  const unzipPath = await io.which('unzip', true)
   await exec(`"${unzipPath}"`, [file], {cwd: dest})
 }
 


### PR DESCRIPTION
For: tool-cache

This clears up the error messages when the runner does not have a `unzip` or `powershell` binary installed. This can be an issue on self-hosted runners, and makes it easier to track the root cause of the error.