### PR TITLE
Avoid re-using non-keep-alive "main" HTTP client

### DIFF
--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -112,7 +112,8 @@ export class UploadHttpClient {
       })
     }
 
-    const parallelUploads = [...new Array(FILE_CONCURRENCY).keys()]
+    // http client indices start at 1 to avoid re-using the main client
+    const parallelUploads = new Array(FILE_CONCURRENCY).fill(0).map((x, i) => i + 1)
     const failedItemsToReport: string[] = []
     let currentFile = 0
     let completedFiles = 0

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -38,7 +38,7 @@ export class UploadHttpClient {
   private statusReporter: UploadStatusReporter
 
   constructor() {
-    this.uploadHttpManager = new HttpManager(getUploadFileConcurrency())
+    this.uploadHttpManager = new HttpManager(getUploadFileConcurrency() + 1)
     this.statusReporter = new UploadStatusReporter()
   }
 


### PR DESCRIPTION
I noticed a comment on actions/upload-artifact#62 citing 15% slower uploads and thought I'd poke around. It looks like the chunked uploads are using HTTP clients starting from index 0, but the client at index 0 is also used for things other than uploading.

I'll be honest, it seems like allocating a separate HTTP client outside the pool for the non-upload work would make more sense here, or just using the default Agent.