### PR TITLE
Be more lenient in accepting command inputs

### DIFF
--- a/packages/core/__tests__/command.test.ts
+++ b/packages/core/__tests__/command.test.ts
@@ -113,7 +113,7 @@ describe('@actions/core/src/command', () => {
     ])
   })
 
-  it('should not crash on bad user input', () => {
+  it('should handle issueing commands for non-string objects', () => {
     command.issueCommand(
       'some-command',
       {
@@ -124,7 +124,7 @@ describe('@actions/core/src/command', () => {
       ({test: 'object'} as unknown) as string
     )
     assertWriteCalls([
-      `::some-command prop1=[object Object],prop2=123,prop3=true::[object Object]${os.EOL}`
+      `::some-command prop1={\"test\"%3A\"object\"},prop2=123,prop3=true::{\"test\":\"object\"}${os.EOL}`
     ])
   })
 })

--- a/packages/core/__tests__/command.test.ts
+++ b/packages/core/__tests__/command.test.ts
@@ -124,7 +124,7 @@ describe('@actions/core/src/command', () => {
       ({test: 'object'} as unknown) as string
     )
     assertWriteCalls([
-      `::some-command prop1={\"test\"%3A\"object\"},prop2=123,prop3=true::{\"test\":\"object\"}${os.EOL}`
+      `::some-command prop1={"test"%3A"object"},prop2=123,prop3=true::{"test":"object"}${os.EOL}`
     ])
   })
 })

--- a/packages/core/__tests__/command.test.ts
+++ b/packages/core/__tests__/command.test.ts
@@ -112,6 +112,21 @@ describe('@actions/core/src/command', () => {
       `::some-command prop1=value 1,prop2=value 2,prop3=value 3::${os.EOL}`
     ])
   })
+
+  it('should not crash on bad user input', () => {
+    command.issueCommand(
+      'some-command',
+      {
+        prop1: ({test: 'object'} as unknown) as string,
+        prop2: (123 as unknown) as string,
+        prop3: (true as unknown) as string
+      },
+      ({test: 'object'} as unknown) as string
+    )
+    assertWriteCalls([
+      `::some-command prop1=[object Object],prop2=123,prop3=true::[object Object]${os.EOL}`
+    ])
+  })
 })
 
 // Assert that process.stdout.write calls called only with the given arguments.

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -169,6 +169,12 @@ describe('@actions/core', () => {
     assertWriteCalls([`::warning::%0D%0Awarning%0A${os.EOL}`])
   })
 
+  it('warning handles an error object', () => {
+    const message = 'this is my error message'
+    core.warning(new Error(message))
+    assertWriteCalls([`::warning::Error: ${message}${os.EOL}`])
+  })
+
   it('startGroup starts a new group', () => {
     core.startGroup('my-group')
     assertWriteCalls([`::group::my-group${os.EOL}`])

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -54,6 +54,16 @@ describe('@actions/core', () => {
     assertWriteCalls([`::set-env name=my var2::var val%0D%0A${os.EOL}`])
   })
 
+  it('exportVariable handles boolean inputs', () => {
+    core.exportVariable('my var', true)
+    assertWriteCalls([`::set-env name=my var::true${os.EOL}`])
+  })
+
+  it('exportVariable handles number inputs', () => {
+    core.exportVariable('my var', 5)
+    assertWriteCalls([`::set-env name=my var::5${os.EOL}`])
+  })
+
   it('setSecret produces the correct command', () => {
     core.setSecret('secret val')
     assertWriteCalls([`::add-mask::secret val${os.EOL}`])
@@ -104,16 +114,33 @@ describe('@actions/core', () => {
     assertWriteCalls([`::set-output name=some output::some value${os.EOL}`])
   })
 
-  it('setFailure sets the correct exit code and failure message', () => {
+  it('setOutput handles bools', () => {
+    core.setOutput('some output', false)
+    assertWriteCalls([`::set-output name=some output::false${os.EOL}`])
+  })
+
+  it('setOutput handles numbers', () => {
+    core.setOutput('some output', 1.01)
+    assertWriteCalls([`::set-output name=some output::1.01${os.EOL}`])
+  })
+
+  it('setFailed sets the correct exit code and failure message', () => {
     core.setFailed('Failure message')
     expect(process.exitCode).toBe(core.ExitCode.Failure)
     assertWriteCalls([`::error::Failure message${os.EOL}`])
   })
 
-  it('setFailure escapes the failure message', () => {
+  it('setFailed escapes the failure message', () => {
     core.setFailed('Failure \r\n\nmessage\r')
     expect(process.exitCode).toBe(core.ExitCode.Failure)
     assertWriteCalls([`::error::Failure %0D%0A%0Amessage%0D${os.EOL}`])
+  })
+
+  it('setFailed handles Error', () => {
+    const message = 'this is my error message'
+    core.setFailed(new Error(message))
+    expect(process.exitCode).toBe(core.ExitCode.Failure)
+    assertWriteCalls([`::error::Error: ${message}${os.EOL}`])
   })
 
   it('error sets the correct error message', () => {
@@ -124,6 +151,12 @@ describe('@actions/core', () => {
   it('error escapes the error message', () => {
     core.error('Error message\r\n\n')
     assertWriteCalls([`::error::Error message%0D%0A%0A${os.EOL}`])
+  })
+
+  it('error handles an error object', () => {
+    const message = 'this is my error message'
+    core.error(new Error(message))
+    assertWriteCalls([`::error::Error: ${message}${os.EOL}`])
   })
 
   it('warning sets the correct message', () => {
@@ -172,6 +205,16 @@ describe('@actions/core', () => {
   it('saveState produces the correct command', () => {
     core.saveState('state_1', 'some value')
     assertWriteCalls([`::save-state name=state_1::some value${os.EOL}`])
+  })
+
+  it('saveState handles numbers', () => {
+    core.saveState('state_1', 1)
+    assertWriteCalls([`::save-state name=state_1::1${os.EOL}`])
+  })
+
+  it('saveState handles bools', () => {
+    core.saveState('state_1', true)
+    assertWriteCalls([`::save-state name=state_1::true${os.EOL}`])
   })
 
   it('getState gets wrapper action state', () => {

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -64,15 +64,13 @@ class Command {
             } else {
               cmdStr += ','
             }
-            // safely escape the property - avoid blowing up when attempting to
-            // call .replace() if property is not a string for some reason
+
             cmdStr += `${key}=${escapeProperty(val)}`
           }
         }
       }
     }
-    // safely append the message - avoid blowing up when attempting to
-    // call .replace() if message is not a string for some reason
+
     cmdStr += `${CMD_STRING}${escapeData(this.message)}`
     return cmdStr
   }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -61,13 +61,15 @@ class Command {
             } else {
               cmdStr += ','
             }
-
+            // safely escape the property - avoid blowing up when attempting to
+            // call .replace() if property is not a string for some reason
             cmdStr += `${key}=${escapeProperty(`${val || ''}`)}`
           }
         }
       }
     }
-
+    // safely append the message - avoid blowing up when attempting to
+    // call .replace() if message is not a string for some reason
     cmdStr += `${CMD_STRING}${escapeData(`${this.message || ''}`)}`
     return cmdStr
   }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -62,13 +62,13 @@ class Command {
               cmdStr += ','
             }
 
-            cmdStr += `${key}=${escapeProperty(val)}`
+            cmdStr += `${key}=${escapeProperty(`${val || ''}`)}`
           }
         }
       }
     }
 
-    cmdStr += `${CMD_STRING}${escapeData(this.message)}`
+    cmdStr += `${CMD_STRING}${escapeData(`${this.message || ''}`)}`
     return cmdStr
   }
 }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -2,8 +2,11 @@ import * as os from 'os'
 
 // For internal use, subject to change.
 
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 interface CommandProperties {
-  [key: string]: string
+  [key: string]: any
 }
 
 /**
@@ -19,7 +22,7 @@ interface CommandProperties {
 export function issueCommand(
   command: string,
   properties: CommandProperties,
-  message: string
+  message: any
 ): void {
   const cmd = new Command(command, properties, message)
   process.stdout.write(cmd.toString() + os.EOL)
@@ -63,27 +66,40 @@ class Command {
             }
             // safely escape the property - avoid blowing up when attempting to
             // call .replace() if property is not a string for some reason
-            cmdStr += `${key}=${escapeProperty(`${val || ''}`)}`
+            cmdStr += `${key}=${escapeProperty(val)}`
           }
         }
       }
     }
     // safely append the message - avoid blowing up when attempting to
     // call .replace() if message is not a string for some reason
-    cmdStr += `${CMD_STRING}${escapeData(`${this.message || ''}`)}`
+    cmdStr += `${CMD_STRING}${escapeData(this.message)}`
     return cmdStr
   }
 }
 
-function escapeData(s: string): string {
-  return (s || '')
+/**
+ * Sanatizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+export function toCommandValue(input: any): string {
+  if (input === null || input === undefined) {
+    return ''
+  } else if (typeof input === 'string' || input instanceof String) {
+    return input as string
+  }
+  return JSON.stringify(input)
+}
+
+function escapeData(s: any): string {
+  return toCommandValue(s)
     .replace(/%/g, '%25')
     .replace(/\r/g, '%0D')
     .replace(/\n/g, '%0A')
 }
 
-function escapeProperty(s: string): string {
-  return (s || '')
+function escapeProperty(s: any): string {
+  return toCommandValue(s)
     .replace(/%/g, '%25')
     .replace(/\r/g, '%0D')
     .replace(/\n/g, '%0A')

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -216,16 +216,17 @@ export function getState(name: string): string {
 }
 
 /**
- * Sanatizes an input into a string so it can be passed into issueCommand
- * @param input Input parameter to sanitize into a string
+ * Sanatizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function sanitizeInput(input: any): string {
   if (input == null) {
     return ''
   } else if (typeof input === 'string' || input instanceof String) {
     return input as string
   } else if (input instanceof Error) {
-    return (input as Error).toString()
+    return input.toString()
   } else {
     return JSON.stringify(input)
   }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -195,10 +195,8 @@ export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
  * @param     name     name of the state to store
  * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
-export function saveState(
-  name: string,
-  value: any
-): void {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function saveState(name: string, value: any): void {
   issueCommand('save-state', {name}, value)
 }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -33,7 +33,7 @@ export enum ExitCode {
 /**
  * Sets env variable for this action and future actions in the job
  * @param name the name of the variable to set
- * @param val the value of the variable. Will be converted to a string via JSON.stringify
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function exportVariable(name: string, val: any): void {
@@ -80,7 +80,7 @@ export function getInput(name: string, options?: InputOptions): string {
  * Sets the value of an output.
  *
  * @param     name     name of the output to set
- * @param     value    value to store. Will be converted to a string via JSON.stringify
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function setOutput(name: string, value: any): void {
@@ -123,7 +123,7 @@ export function debug(message: string): void {
 
 /**
  * Adds an error issue
- * @param message error issue message
+ * @param message error issue message. Errors will be converted to string via toString()
  */
 export function error(message: string | Error): void {
   issue('error', message instanceof Error ? message.toString() : message)
@@ -131,10 +131,10 @@ export function error(message: string | Error): void {
 
 /**
  * Adds an warning issue
- * @param message warning issue message
+ * @param message warning issue message. Errors will be converted to string via toString()
  */
-export function warning(message: string): void {
-  issue('warning', message)
+export function warning(message: string | Error): void {
+  issue('warning', message instanceof Error ? message.toString() : message)
 }
 
 /**
@@ -193,11 +193,11 @@ export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
  * Saves state for current action, the state can only be retrieved by this action's post job execution.
  *
  * @param     name     name of the state to store
- * @param     value    value to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
 export function saveState(
   name: string,
-  value: string | number | boolean
+  value: any
 ): void {
   issueCommand('save-state', {name}, value)
 }


### PR DESCRIPTION
Users have been encountering friction when trying to use command inputs.

[This commit](https://github.com/actions/toolkit/commit/8b0300129f08728419263b016de8630f1d426d5f#diff-30c957fdb0e7818041c155a0e3ac6e0b) broke some our handling when users don't pass in strings. We re-added that handling and implemented a test for it. 



We also have had a number of users ask for additional input types. 
https://github.com/actions/toolkit/issues/386 -> Set Failed and Error should accept errors
https://github.com/actions/toolkit/issues/370 -> Set Output should format data into strings

This commit resolves those use cases.

Resolves #398, #386, #370