### PR TITLE
Prettier 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4064,7 +4064,8 @@
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -17459,9 +17460,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jest": "^25.1.0",
     "jest-circus": "^24.7.1",
     "lerna": "^3.18.4",
-    "prettier": "^1.19.1",
+    "prettier": "2.0.4",
     "ts-jest": "^24.0.2",
     "typescript": "^3.7.4"
   }

--- a/packages/artifact/__tests__/download.test.ts
+++ b/packages/artifact/__tests__/download.test.ts
@@ -205,7 +205,7 @@ describe('Download Tests', () => {
         ]
       }
       const returnData: string = JSON.stringify(response, null, 2)
-      mockReadBody = async function(): Promise<string> {
+      mockReadBody = async function (): Promise<string> {
         return new Promise(resolve => {
           resolve(returnData)
         })
@@ -317,7 +317,7 @@ describe('Download Tests', () => {
         ]
       }
       const returnData: string = JSON.stringify(response, null, 2)
-      mockReadBody = async function(): Promise<string> {
+      mockReadBody = async function (): Promise<string> {
         return new Promise(resolve => {
           resolve(returnData)
         })

--- a/packages/artifact/__tests__/upload.test.ts
+++ b/packages/artifact/__tests__/upload.test.ts
@@ -395,7 +395,7 @@ describe('Upload Tests', () => {
             }`
           }
           const returnData: string = JSON.stringify(response, null, 2)
-          mockReadBody = async function(): Promise<string> {
+          mockReadBody = async function (): Promise<string> {
             return new Promise(resolve => {
               resolve(returnData)
             })
@@ -463,7 +463,7 @@ describe('Upload Tests', () => {
             uploadUrl: `${getRuntimeUrl()}_apis/resources/Containers/13`
           }
           const returnData: string = JSON.stringify(response, null, 2)
-          mockReadBody = async function(): Promise<string> {
+          mockReadBody = async function (): Promise<string> {
             return new Promise(resolve => {
               resolve(returnData)
             })

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -286,7 +286,7 @@ describe('@actions/exec', () => {
     expect(stderrCalled).toBeTruthy()
   })
 
-  it('Handles child process holding streams open', async function() {
+  it('Handles child process holding streams open', async function () {
     const semaphorePath = path.join(
       getTestTemp(),
       'child-process-semaphore.txt'
@@ -332,7 +332,7 @@ describe('@actions/exec', () => {
     fs.unlinkSync(semaphorePath)
   }, 10000) // this was timing out on some slower hosted macOS runs at default 5s
 
-  it('Handles child process holding streams open and non-zero exit code', async function() {
+  it('Handles child process holding streams open and non-zero exit code', async function () {
     const semaphorePath = path.join(
       getTestTemp(),
       'child-process-semaphore.txt'
@@ -386,7 +386,7 @@ describe('@actions/exec', () => {
     fs.unlinkSync(semaphorePath)
   }, 10000) // this was timing out on some slower hosted macOS runs at default 5s
 
-  it('Handles child process holding streams open and stderr', async function() {
+  it('Handles child process holding streams open and stderr', async function () {
     const semaphorePath = path.join(
       getTestTemp(),
       'child-process-semaphore.txt'

--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -264,10 +264,7 @@ export class ToolRunner extends events.EventEmitter {
     }
 
     reverse += '"'
-    return reverse
-      .split('')
-      .reverse()
-      .join('')
+    return reverse.split('').reverse().join('')
   }
 
   private _uvQuoteCmdArg(arg: string): string {
@@ -347,10 +344,7 @@ export class ToolRunner extends events.EventEmitter {
     }
 
     reverse += '"'
-    return reverse
-      .split('')
-      .reverse()
-      .join('')
+    return reverse.split('').reverse().join('')
   }
 
   private _cloneExecOptions(options?: im.ExecOptions): im.ExecOptions {
@@ -668,8 +662,9 @@ class ExecState extends events.EventEmitter {
     }
 
     if (!state.processClosed && state.processExited) {
-      const message = `The STDIO streams did not close within ${state.delay /
-        1000} seconds of the exit event from process '${
+      const message = `The STDIO streams did not close within ${
+        state.delay / 1000
+      } seconds of the exit event from process '${
         state.toolPath
       }'. This may indicate a child process inherited the STDIO streams and has not yet exited.`
       state._debug(message)

--- a/packages/tool-cache/__tests__/tool-cache.test.ts
+++ b/packages/tool-cache/__tests__/tool-cache.test.ts
@@ -16,31 +16,28 @@ import * as tc from '../src/tool-cache'
 
 const IS_WINDOWS = process.platform === 'win32'
 
-describe('@actions/tool-cache', function() {
-  beforeAll(function() {
-    nock('http://example.com')
-      .persist()
-      .get('/bytes/35')
-      .reply(200, {
-        username: 'abc',
-        password: 'def'
-      })
+describe('@actions/tool-cache', function () {
+  beforeAll(function () {
+    nock('http://example.com').persist().get('/bytes/35').reply(200, {
+      username: 'abc',
+      password: 'def'
+    })
     setGlobal('TEST_DOWNLOAD_TOOL_RETRY_MIN_SECONDS', 0)
     setGlobal('TEST_DOWNLOAD_TOOL_RETRY_MAX_SECONDS', 0)
   })
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     await io.rmRF(cachePath)
     await io.rmRF(tempPath)
     await io.mkdirP(cachePath)
     await io.mkdirP(tempPath)
   })
 
-  afterEach(function() {
+  afterEach(function () {
     setResponseMessageFactory(undefined)
   })
 
-  afterAll(async function() {
+  afterAll(async function () {
     await io.rmRF(tempPath)
     await io.rmRF(cachePath)
     setGlobal('TEST_DOWNLOAD_TOOL_RETRY_MIN_SECONDS', undefined)
@@ -180,13 +177,10 @@ describe('@actions/tool-cache', function() {
   })
 
   it('has status code in exception dictionary for HTTP error code responses', async () => {
-    nock('http://example.com')
-      .persist()
-      .get('/bytes/bad')
-      .reply(400, {
-        username: 'bad',
-        password: 'file'
-      })
+    nock('http://example.com').persist().get('/bytes/bad').reply(400, {
+      username: 'bad',
+      password: 'file'
+    })
 
     expect.assertions(2)
 
@@ -199,7 +193,7 @@ describe('@actions/tool-cache', function() {
     }
   })
 
-  it('works with redirect code 302', async function() {
+  it('works with redirect code 302', async function () {
     nock('http://example.com')
       .persist()
       .get('/redirect-to')
@@ -291,7 +285,7 @@ describe('@actions/tool-cache', function() {
       }
     })
 
-    it('extract 7z using custom 7z tool', async function() {
+    it('extract 7z using custom 7z tool', async function () {
       const tempDir = path.join(
         __dirname,
         'test-extract-7z-using-custom-7z-tool'
@@ -480,7 +474,7 @@ describe('@actions/tool-cache', function() {
     }
   })
 
-  it('installs a zip and extracts it to specified directory', async function() {
+  it('installs a zip and extracts it to specified directory', async function () {
     const tempDir = path.join(__dirname, 'test-install-zip')
     try {
       await io.mkdirP(tempDir)
@@ -537,7 +531,7 @@ describe('@actions/tool-cache', function() {
     }
   })
 
-  it('extract zip to a directory that does not exist', async function() {
+  it('extract zip to a directory that does not exist', async function () {
     const tempDir = path.join(__dirname, 'test-install-zip')
     try {
       await io.mkdirP(tempDir)
@@ -591,24 +585,16 @@ describe('@actions/tool-cache', function() {
     }
   })
 
-  it('works with a 502 temporary failure', async function() {
-    nock('http://example.com')
-      .get('/temp502')
-      .twice()
-      .reply(502, undefined)
-    nock('http://example.com')
-      .get('/temp502')
-      .reply(200, undefined)
+  it('works with a 502 temporary failure', async function () {
+    nock('http://example.com').get('/temp502').twice().reply(502, undefined)
+    nock('http://example.com').get('/temp502').reply(200, undefined)
 
     const statusCodeUrl = 'http://example.com/temp502'
     await tc.downloadTool(statusCodeUrl)
   })
 
-  it("doesn't retry 502s more than 3 times", async function() {
-    nock('http://example.com')
-      .get('/perm502')
-      .times(3)
-      .reply(502, undefined)
+  it("doesn't retry 502s more than 3 times", async function () {
+    nock('http://example.com').get('/perm502').times(3).reply(502, undefined)
 
     expect.assertions(1)
 
@@ -620,7 +606,7 @@ describe('@actions/tool-cache', function() {
     }
   })
 
-  it('retries 429s', async function() {
+  it('retries 429s', async function () {
     nock('http://example.com')
       .get('/too-many-requests-429')
       .times(2)
@@ -637,13 +623,9 @@ describe('@actions/tool-cache', function() {
     }
   })
 
-  it("doesn't retry 404", async function() {
-    nock('http://example.com')
-      .get('/not-found-404')
-      .reply(404, undefined)
-    nock('http://example.com')
-      .get('/not-found-404')
-      .reply(500, undefined)
+  it("doesn't retry 404", async function () {
+    nock('http://example.com').get('/not-found-404').reply(404, undefined)
+    nock('http://example.com').get('/not-found-404').reply(500, undefined)
 
     try {
       const statusCodeUrl = 'http://example.com/not-found-404'


### PR DESCRIPTION
This upgrades us to the latest version of [Prettier](https://prettier.io/). See [the blog post introducing version 2.0](https://prettier.io/blog/2020/03/21/2.0.0.html).

I also switched to pinning an exact version of Prettier, [as suggested in the install docs](https://prettier.io/docs/en/install.html).