### PR TITLE
Add docs and wrapper for "echo" command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -148,7 +148,7 @@ echo "::echo::off"
 This is wrapped by the core method:
 
 ```javascript
-function setCommandEcho(enable: boolean): void {}
+function setCommandEcho(enabled: boolean): void {}
 ```
 
 The `add-mask`, `debug`, `warning` and `error` commands do not support echoing.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,13 +122,36 @@ echo "::save-state name=FOO::foovalue"
 
 ### Log Level
 
-Finally, there are several commands to emit different levels of log output:
+There are several commands to emit different levels of log output:
 
 | log level | example usage |
 |---|---|
 | [debug](action-debugging.md)  | `echo "::debug::My debug message"` |
 | warning | `echo "::warning::My warning message"` |
 | error | `echo "::error::My error message"` |
+
+### Command Echoing
+By default, the echoing of commands to stdout only occurs if [Step Debugging is enabled](./actions-debugging.md#How-to-Access-Step-Debug-Logs)
+
+You can enable or disable this for the current step by using the `echo` command.
+
+```bash
+echo "::echo::on"
+```
+
+You can also disable echoing.
+
+```bash
+echo "::echo::off"
+```
+
+This is wrapped by the core method:
+
+```javascript
+function setCommandEcho(enable: boolean): void {}
+```
+
+The `add-mask`, `debug`, `warning` and `error` commands do not support echoing.
 
 ### Command Prompt 
 CMD processes the `"` character differently from other shells when echoing. In CMD, the above snippets should have the `"` characters removed in order to correctly process. For example, the set output command would be:

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -239,6 +239,16 @@ describe('@actions/core', () => {
       process.env['RUNNER_DEBUG'] = current
     }
   })
+
+  it('setCommandEcho can enable echoing', () => {
+    core.setCommandEcho(true)
+    assertWriteCalls([`::echo::on${os.EOL}`])
+  })
+
+  it('setCommandEcho can disable echoing', () => {
+    core.setCommandEcho(false)
+    assertWriteCalls([`::echo::off${os.EOL}`])
+  })
 })
 
 // Assert that process.stdout.write calls called only with the given arguments.

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -92,8 +92,8 @@ export function setOutput(name: string, value: any): void {
  * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
  *
  */
-export function setCommandEcho(enable: boolean): void {
-  issue('echo', enable ? 'on' : 'off')
+export function setCommandEcho(enabled: boolean): void {
+  issue('echo', enabled ? 'on' : 'off')
 }
 
 //-----------------------------------------------------------------------

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -87,6 +87,15 @@ export function setOutput(name: string, value: any): void {
   issueCommand('set-output', {name}, value)
 }
 
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+export function setCommandEcho(enable: boolean): void {
+  issue('echo', enable ? 'on' : 'off')
+}
+
 //-----------------------------------------------------------------------
 // Results
 //-----------------------------------------------------------------------


### PR DESCRIPTION
We added a command to the runner to enable and disable echoing of commands into stdout. This PR adds documentation and a toolkit wrapper for that feature.

Resolves #192 