### PR TITLE
Overwrite files when calling unzip from the tool-cache package

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -295,7 +295,7 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
 
 async function extractZipNix(file: string, dest: string): Promise<void> {
   const unzipPath = await io.which('unzip')
-  await exec(`"${unzipPath}"`, [file], {cwd: dest})
+  await exec(`"${unzipPath}"`, ['-o', file], {cwd: dest})
 }
 
 /**


### PR DESCRIPTION
While Windows implementation is executed in the non-interactive mode, `unzip` can prompt user in a many different situations, one of them if any of the extracted files already exists in the destination path,
see [@actions-rs/tool-cache#5](https://github.com/actions-rs/tool-cache/issues/5) as a bug example.

This patch adds `-o` flag to the `unzip` invocation, allowing non-interactive file overwrites as it stated in the `unzip` help:

```
unzip modifiers:
  -o   Overwrite existing files without prompting.  Useful with -f.  Use with
         care.
```