### PR TITLE
@actions/artifact 0.3.1 update

### DIFF
--- a/packages/artifact/README.md
+++ b/packages/artifact/README.md
@@ -7,6 +7,7 @@ You can use this package to interact with the actions artifacts.
 - [Download a Single Artifact](#Download-a-Single-Artifact)
 - [Download All Artifacts](#Download-all-Artifacts)
 - [Additional Documentation](#Additional-Documentation)
+- [Contributions](#Contributions)
 
 Relative paths and absolute paths are both allowed. Relative paths are rooted against the current working directory.
 

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -19,3 +19,8 @@
 - Exponential backoff when retryable status codes are encountered
 - Clearer error message if storage quota has been reached
 - Improved logging and output during artifact download
+
+### 0.3.1
+
+- Fix to ensure temporary gzip files get correctly deleted during upload
+- Remove spaces as a forbidden character during upload

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -22,5 +22,5 @@
 
 ### 0.3.1
 
-- Fix to ensure temporary gzip files get correctly deleted during upload
-- Remove spaces as a forbidden character during upload
+- Fix to ensure temporary gzip files get correctly deleted during artifact upload
+- Remove spaces as a forbidden character during upload 

--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -57,7 +57,6 @@ describe('Utils', () => {
       'my|artifact',
       'my*artifact',
       'my?artifact',
-      'my artifact',
       ''
     ]
     for (const invalidName of invalidNames) {
@@ -87,7 +86,6 @@ describe('Utils', () => {
       'some/invalid|artifact/path',
       'some/invalid*artifact/path',
       'some/invalid?artifact/path',
-      'some/invalid artifact/path',
       ''
     ]
     for (const invalidName of invalidNames) {

--- a/packages/artifact/docs/additional-information.md
+++ b/packages/artifact/docs/additional-information.md
@@ -17,7 +17,6 @@ When uploading an artifact, the inputted `name` parameter along with the files s
 - |
 - \*
 - ?
-- empty space
 
 In addition to the aforementioned characters, the inputted `name` also cannot include the following
 - \

--- a/packages/artifact/docs/implementation-details.md
+++ b/packages/artifact/docs/implementation-details.md
@@ -4,7 +4,7 @@ Warning: Implementation details may change at any time without notice. This is m
 
 ## Upload/Compression flow
 
-![image](https://user-images.githubusercontent.com/16109154/77190819-38685d80-6ada-11ea-8281-4703ff8cc025.png)
+![image](https://user-images.githubusercontent.com/16109154/79765587-19522b00-8327-11ea-9679-410bb10e1b13.png)
 
 ## Retry Logic when downloading an individual file
 

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -313,9 +313,7 @@ export class UploadHttpClient {
           // successfully uploaded so the server may report a different size for what was uploaded
           isUploadSuccessful = false
           failedChunkSizes += chunkSize
-          core.warning(
-            `Aborting upload for ${parameters.file} due to failure`
-          )
+          core.warning(`Aborting upload for ${parameters.file} due to failure`)
           abortFileUpload = true
         }
       }
@@ -325,9 +323,9 @@ export class UploadHttpClient {
 
       // only after the file upload is complete and the temporary file is deleted, return the UploadResult
       return {
-          isSuccess: isUploadSuccessful,
-          successfulUploadSize: uploadFileSize - failedChunkSizes,
-          totalSize: totalFileSize
+        isSuccess: isUploadSuccessful,
+        successfulUploadSize: uploadFileSize - failedChunkSizes,
+        totalSize: totalFileSize
       }
     }
   }

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -318,10 +318,11 @@ export class UploadHttpClient {
         }
       }
 
-      // delete the temporary file that was created as part of the upload
-      await tempFile.cleanup()
+      // Delete the temporary file that was created as part of the upload. Even though this operation is async, we don't need to
+      // await this at it unnecessarily could block other uploads from starting faster. If the temp file does not get manually deleted by
+      // calling cleanup, it gets removed when the node process exits. For more info see: https://www.npmjs.com/package/tmp-promise#about
+      tempFile.cleanup()
 
-      // only after the file upload is complete and the temporary file is deleted, return the UploadResult
       return {
         isSuccess: isUploadSuccessful,
         successfulUploadSize: uploadFileSize - failedChunkSizes,

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -248,91 +248,87 @@ export class UploadHttpClient {
       }
     } else {
       // the file that is being uploaded is greater than 64k in size, a temporary file gets created on disk using the
-      // npm tmp-promise package and this file gets used during compression for the GZip file that gets created
-      return tmp
-        .file()
-        .then(async tmpFile => {
-          // create a GZip file of the original file being uploaded, the original file should not be modified in any way
-          uploadFileSize = await createGZipFileOnDisk(
-            parameters.file,
-            tmpFile.path
-          )
-          let uploadFilePath = tmpFile.path
+      // npm tmp-promise package and this file gets used to create a GZipped file
+      const tempFile = await tmp.file()
 
-          // compression did not help with size reduction, use the original file for upload and delete the temp GZip file
-          if (totalFileSize < uploadFileSize) {
-            uploadFileSize = totalFileSize
-            uploadFilePath = parameters.file
-            isGzip = false
-            tmpFile.cleanup()
-          }
+      // create a GZip file of the original file being uploaded, the original file should not be modified in any way
+      uploadFileSize = await createGZipFileOnDisk(
+        parameters.file,
+        tempFile.path
+      )
 
-          let abortFileUpload = false
-          // upload only a single chunk at a time
-          while (offset < uploadFileSize) {
-            const chunkSize = Math.min(
-              uploadFileSize - offset,
-              parameters.maxChunkSize
-            )
+      let uploadFilePath = tempFile.path
 
-            // if an individual file is greater than 100MB (1024*1024*100) in size, display extra information about the upload status
-            if (uploadFileSize > 104857600) {
-              this.statusReporter.updateLargeFileStatus(
-                parameters.file,
-                offset,
-                uploadFileSize
-              )
-            }
+      // compression did not help with size reduction, use the original file for upload and delete the temp GZip file
+      if (totalFileSize < uploadFileSize) {
+        uploadFileSize = totalFileSize
+        uploadFilePath = parameters.file
+        isGzip = false
+      }
 
-            const start = offset
-            const end = offset + chunkSize - 1
-            offset += parameters.maxChunkSize
-
-            if (abortFileUpload) {
-              // if we don't want to continue in the event of an error, any pending upload chunks will be marked as failed
-              failedChunkSizes += chunkSize
-              continue
-            }
-
-            const result = await this.uploadChunk(
-              httpClientIndex,
-              parameters.resourceUrl,
-              fs.createReadStream(uploadFilePath, {
-                start,
-                end,
-                autoClose: false
-              }),
-              start,
-              end,
-              uploadFileSize,
-              isGzip,
-              totalFileSize
-            )
-
-            if (!result) {
-              // Chunk failed to upload, report as failed and do not continue uploading any more chunks for the file. It is possible that part of a chunk was
-              // successfully uploaded so the server may report a different size for what was uploaded
-              isUploadSuccessful = false
-              failedChunkSizes += chunkSize
-              core.warning(
-                `Aborting upload for ${parameters.file} due to failure`
-              )
-              abortFileUpload = true
-            }
-          }
-        })
-        .then(
-          async (): Promise<UploadFileResult> => {
-            // only after the file upload is complete and the temporary file is deleted, return the UploadResult
-            return new Promise(resolve => {
-              resolve({
-                isSuccess: isUploadSuccessful,
-                successfulUploadSize: uploadFileSize - failedChunkSizes,
-                totalSize: totalFileSize
-              })
-            })
-          }
+      let abortFileUpload = false
+      // upload only a single chunk at a time
+      while (offset < uploadFileSize) {
+        const chunkSize = Math.min(
+          uploadFileSize - offset,
+          parameters.maxChunkSize
         )
+
+        // if an individual file is greater than 100MB (1024*1024*100) in size, display extra information about the upload status
+        if (uploadFileSize > 104857600) {
+          this.statusReporter.updateLargeFileStatus(
+            parameters.file,
+            offset,
+            uploadFileSize
+          )
+        }
+
+        const start = offset
+        const end = offset + chunkSize - 1
+        offset += parameters.maxChunkSize
+
+        if (abortFileUpload) {
+          // if we don't want to continue in the event of an error, any pending upload chunks will be marked as failed
+          failedChunkSizes += chunkSize
+          continue
+        }
+
+        const result = await this.uploadChunk(
+          httpClientIndex,
+          parameters.resourceUrl,
+          fs.createReadStream(uploadFilePath, {
+            start,
+            end,
+            autoClose: false
+          }),
+          start,
+          end,
+          uploadFileSize,
+          isGzip,
+          totalFileSize
+        )
+
+        if (!result) {
+          // Chunk failed to upload, report as failed and do not continue uploading any more chunks for the file. It is possible that part of a chunk was
+          // successfully uploaded so the server may report a different size for what was uploaded
+          isUploadSuccessful = false
+          failedChunkSizes += chunkSize
+          core.warning(
+            `Aborting upload for ${parameters.file} due to failure`
+          )
+          abortFileUpload = true
+        }
+      }
+
+      // delete the temporary file that was created as part of the upload
+      await tempFile.cleanup()
+
+      // only after the file upload is complete and the temporary file is deleted, return the UploadResult
+      return {
+          isSuccess: isUploadSuccessful,
+          successfulUploadSize: uploadFileSize - failedChunkSizes,
+          totalSize: totalFileSize
+      }
     }
   }
 

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -318,10 +318,9 @@ export class UploadHttpClient {
         }
       }
 
-      // Delete the temporary file that was created as part of the upload. Even though this operation is async, we don't need to
-      // await this at it unnecessarily could block other uploads from starting faster. If the temp file does not get manually deleted by
+      // Delete the temporary file that was created as part of the upload. If the temp file does not get manually deleted by
       // calling cleanup, it gets removed when the node process exits. For more info see: https://www.npmjs.com/package/tmp-promise#about
-      tempFile.cleanup()
+      await tempFile.cleanup()
 
       return {
         isSuccess: isUploadSuccessful,

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -245,15 +245,7 @@ Header Information: ${JSON.stringify(response.message.headers, undefined, 2)}
  *
  * FilePaths can include characters such as \ and / which are not permitted in the artifact name alone
  */
-const invalidArtifactFilePathCharacters = [
-  '"',
-  ':',
-  '<',
-  '>',
-  '|',
-  '*',
-  '?'
-]
+const invalidArtifactFilePathCharacters = ['"', ':', '<', '>', '|', '*', '?']
 const invalidArtifactNameCharacters = [
   ...invalidArtifactFilePathCharacters,
   '\\',

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -252,8 +252,7 @@ const invalidArtifactFilePathCharacters = [
   '>',
   '|',
   '*',
-  '?',
-  ' '
+  '?'
 ]
 const invalidArtifactNameCharacters = [
   ...invalidArtifactFilePathCharacters,


### PR DESCRIPTION
# Overview

Small updates
- Bump package version to `0.3.1` (`RELEASES.MD`, `package.json` and `package-lock.json`)
   - This is super small so it doesn't feel right to go straight to `0.4.0`
- Updates to temporary files during artifact upload
   - Explicitly call `cleanup` when we are done using temporary files
   - Cleanup code a little so that some ugly `.then()` statements aren't needed
   - Update comments and some documentation
- Remove spaces as forbidden characters when uploading artifacts
   - For some reason I added this earlier, in `v1` this is not a restriction. See the existing code [here](https://github.com/actions/runner/blob/9f78ad3b3428322131eff596e1e5b027f8db6c14/src/Runner.Plugins/Artifact/PublishArtifact.cs#L43)
   - When we push `v2-preview` into `master` for `upload-artifact` this extra restriction could break some people so we don't want to do that
   - Update tests and docs to reflect this change

# Upload compression/flow

Reminder of what happens during upload (slightly updated to mention when temp files get deleted):

![image](https://user-images.githubusercontent.com/16109154/79765587-19522b00-8327-11ea-9679-410bb10e1b13.png)

# Testing

End to end test: https://github.com/konradpabjan/artifact-test/runs/602161502?check_suite_focus=true
