### PR TITLE
Add architecture filter to findFromManifest

### DIFF
--- a/packages/tool-cache/src/manifest.ts
+++ b/packages/tool-cache/src/manifest.ts
@@ -62,9 +62,9 @@ export interface IToolRelease {
 export async function _findMatch(
   versionSpec: string,
   stable: boolean,
-  candidates: IToolRelease[]
+  candidates: IToolRelease[],
+  archFilter: string
 ): Promise<IToolRelease | undefined> {
-  const archFilter = os.arch()
   const platFilter = os.platform()
 
   let result: IToolRelease | undefined

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -526,13 +526,15 @@ export async function getManifestFromRepo(
 export async function findFromManifest(
   versionSpec: string,
   stable: boolean,
-  manifest: IToolRelease[]
+  manifest: IToolRelease[],
+  archFilter: string = os.arch()
 ): Promise<IToolRelease | undefined> {
   // wrap the internal impl
   const match: mm.IToolRelease | undefined = await mm._findMatch(
     versionSpec,
     stable,
-    manifest
+    manifest,
+    archFilter
   )
 
   return match


### PR DESCRIPTION
For some actions, like `setup-python` we want to install tool with different architecture.
For example, Python x86 can be installed to Windows Server 2019 so it makes sense to provide ability to override architecture