### PR TITLE
bump tool-cache's http-client to 1.0.8

### DIFF
--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -2,7 +2,9 @@
 
 ### 1.3.4
 
-- [Update the http-client to 1.0.8 which had a security fix](https://github.com/actions/toolkit/pull/xxx)
+- [Update the http-client to 1.0.8 which had a security fix](https://github.com/actions/toolkit/pull/429)
+
+Here is [the security issue](https://github.com/actions/http-client/pull/27) that was fixed in the http-client 1.0.8 release
 
 ### 1.3.3
 

--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/tool-cache Releases
 
+### 1.3.4
+
+- [Update the http-client to 1.0.8 which had a security fix](https://github.com/actions/toolkit/pull/xxx)
+
 ### 1.3.3
 
 - [Update downloadTool to only retry 500s and 408 and 429](https://github.com/actions/toolkit/pull/373)

--- a/packages/tool-cache/package-lock.json
+++ b/packages/tool-cache/package-lock.json
@@ -1,16 +1,34 @@
 {
 	"name": "@actions/tool-cache",
-	"version": "1.3.2",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@actions/http-client": {
+		"@actions/core": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
+			"integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
+		},
+		"@actions/exec": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.3.tgz",
-			"integrity": "sha512-wFwh1U4adB/Zsk4cc9kVqaBOHoknhp/pJQk+aWTocbAZWpIl4Zx/At83WFRLXvxB+5HVTWOACM6qjULMZfQSfw==",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.3.tgz",
+			"integrity": "sha512-TogJGnueOmM7ntCi0ASTUj4LapRRtDfj57Ja4IhPmg2fls28uVOPbAn8N+JifaOumN2UG3oEO/Ixek2A4NcYSA==",
+			"requires": {
+				"@actions/io": "^1.0.1"
+			}
+		},
+		"@actions/http-client": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+			"integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
 			"requires": {
 				"tunnel": "0.0.6"
 			}
+		},
+		"@actions/io": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
+			"integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
 		},
 		"@types/nock": {
 			"version": "10.0.3",

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/tool-cache",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Actions tool-cache lib",
   "keywords": [
     "github",
@@ -38,7 +38,7 @@
   "dependencies": {
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.0",
-    "@actions/http-client": "^1.0.3",
+    "@actions/http-client": "^1.0.8",
     "@actions/io": "^1.0.1",
     "semver": "^6.1.0",
     "uuid": "^3.3.2"


### PR DESCRIPTION
Consume an updated 1.0.8 http-client which had a security issue

Here is [the security issue](https://github.com/actions/http-client/pull/27) that was fixed in the http-client 1.0.8 release