### PR TITLE
@actions/artifact keep-alive configuration

### DIFF
--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -120,7 +120,7 @@ describe('Utils', () => {
     const size = 24
     const uncompressedLength = 100
     const range = 'bytes 0-199/200'
-    const options = utils.getUploadRequestOptions(
+    const options = utils.getUploadHeaders(
       contentType,
       true,
       true,
@@ -142,7 +142,7 @@ describe('Utils', () => {
   })
 
   it('Test constructing upload headers with only required parameter', () => {
-    const options = utils.getUploadRequestOptions('application/octet-stream')
+    const options = utils.getUploadHeaders('application/octet-stream')
     expect(Object.keys(options).length).toEqual(2)
     expect(options['Accept']).toEqual(
       `application/json;api-version=${utils.getApiVersion()}`
@@ -152,7 +152,7 @@ describe('Utils', () => {
 
   it('Test constructing download headers with all optional parameters', () => {
     const contentType = 'application/json'
-    const options = utils.getDownloadRequestOptions(contentType, true, true)
+    const options = utils.getDownloadHeaders(contentType, true, true)
     expect(Object.keys(options).length).toEqual(5)
     expect(options['Content-Type']).toEqual(contentType)
     expect(options['Connection']).toEqual('Keep-Alive')
@@ -164,7 +164,7 @@ describe('Utils', () => {
   })
 
   it('Test constructing download headers with only required parameter', () => {
-    const options = utils.getDownloadRequestOptions('application/octet-stream')
+    const options = utils.getDownloadHeaders('application/octet-stream')
     expect(Object.keys(options).length).toEqual(2)
     expect(options['Content-Type']).toEqual('application/octet-stream')
     // check for default accept type

--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -189,6 +189,9 @@ describe('Utils', () => {
     )
     expect(utils.isRetryableStatusCode(HttpCodes.GatewayTimeout)).toEqual(true)
     expect(utils.isRetryableStatusCode(HttpCodes.TooManyRequests)).toEqual(true)
+    expect(utils.isRetryableStatusCode(HttpCodes.InternalServerError)).toEqual(
+      true
+    )
     expect(utils.isRetryableStatusCode(HttpCodes.OK)).toEqual(false)
     expect(utils.isRetryableStatusCode(HttpCodes.NotFound)).toEqual(false)
     expect(utils.isRetryableStatusCode(HttpCodes.Forbidden)).toEqual(false)

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -184,6 +184,8 @@ export class DefaultArtifactClient implements ArtifactClient {
       await downloadHttpClient.downloadSingleArtifact(
         downloadSpecification.filesToDownload
       )
+
+      downloadHttpClient.disposeAllConnections()
     }
 
     return {
@@ -248,6 +250,8 @@ export class DefaultArtifactClient implements ArtifactClient {
         downloadPath: downloadSpecification.rootDownloadLocation
       })
     }
+    downloadHttpClient.disposeAllConnections()
+
     return response
   }
 }

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -32,6 +32,11 @@ export class DownloadHttpClient {
     this.statusReporter = new StatusReporter(1000)
   }
 
+  disposeAllConnections(): void {
+    // safety dispose all connections when we are done making all http calls
+    this.downloadHttpManager.disposeAllClients()
+  }
+
   /**
    * Gets a list of all artifacts that are in a specific container
    */
@@ -47,7 +52,7 @@ export class DownloadHttpClient {
       return JSON.parse(body)
     }
     displayHttpDiagnostics(response)
-    this.downloadHttpManager.disposeAllClients()
+    this.disposeAllConnections()
     throw new Error(
       `Unable to list artifacts for the run. Resource Url ${artifactUrl}`
     )
@@ -75,7 +80,7 @@ export class DownloadHttpClient {
       return JSON.parse(body)
     }
     displayHttpDiagnostics(response)
-    this.downloadHttpManager.disposeAllClients()
+    this.disposeAllConnections()
     throw new Error(`Unable to get ContainersItems from ${resourceUrl}`)
   }
 
@@ -130,8 +135,6 @@ export class DownloadHttpClient {
       })
       .finally(() => {
         this.statusReporter.stop()
-        // safety dispose all connections
-        this.downloadHttpManager.disposeAllClients()
       })
   }
 

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -180,7 +180,6 @@ export class DownloadHttpClient {
           )
         )
       } else {
-        this.downloadHttpManager.disposeAndReplaceClient(httpClientIndex)
         if (retryAfterValue) {
           // Back off by waiting the specified time denoted by the retry-after header
           core.info(

--- a/packages/artifact/src/internal/http-manager.ts
+++ b/packages/artifact/src/internal/http-manager.ts
@@ -1,5 +1,6 @@
 import {HttpClient} from '@actions/http-client/index'
 import {createHttpClient} from './utils'
+import {info} from '@actions/core'
 
 /**
  * Used for managing http clients during either upload or download
@@ -19,8 +20,10 @@ export class HttpManager {
   }
 
   // client disposal is necessary if a keep-alive connection is used to properly close the connection
+  // this should be called if a connection gets reset, timeouts or gets dropped for some unexpected reason and we would like to retry
   // for more information see: https://github.com/actions/http-client/blob/04e5ad73cd3fd1f5610a32116b0759eddf6570d2/index.ts#L292
   disposeAndReplaceClient(index: number): void {
+    info(`disposing and replacing http client ${index}`)
     this.clients[index].dispose()
     this.clients[index] = createHttpClient()
   }

--- a/packages/artifact/src/internal/http-manager.ts
+++ b/packages/artifact/src/internal/http-manager.ts
@@ -1,6 +1,5 @@
 import {HttpClient} from '@actions/http-client/index'
 import {createHttpClient} from './utils'
-import {info} from '@actions/core'
 
 /**
  * Used for managing http clients during either upload or download
@@ -20,14 +19,6 @@ export class HttpManager {
   }
 
   // client disposal is necessary if a keep-alive connection is used to properly close the connection
-  // this should be called if a connection gets reset, timeouts or gets dropped for some unexpected reason and we would like to retry
-  // for more information see: https://github.com/actions/http-client/blob/04e5ad73cd3fd1f5610a32116b0759eddf6570d2/index.ts#L292
-  disposeAndReplaceClient(index: number): void {
-    info(`disposing and replacing http client ${index}`)
-    this.clients[index].dispose()
-    this.clients[index] = createHttpClient()
-  }
-
   disposeAllClients(): void {
     for (const [index] of this.clients.entries()) {
       this.clients[index].dispose()

--- a/packages/artifact/src/internal/http-manager.ts
+++ b/packages/artifact/src/internal/http-manager.ts
@@ -25,9 +25,9 @@ export class HttpManager {
     this.clients[index] = createHttpClient()
   }
 
-  disposeAndReplaceAllClients(): void {
+  disposeAllClients(): void {
     for (const [index] of this.clients.entries()) {
-      this.disposeAndReplaceClient(index)
+      this.clients[index].dispose()
     }
   }
 }

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -305,7 +305,7 @@ export class UploadHttpClient {
           fs.createReadStream(uploadFilePath, {
             start,
             end,
-            autoClose: false
+            autoClose: true
           }),
           start,
           end,
@@ -396,7 +396,6 @@ export class UploadHttpClient {
     }
 
     const backOff = async (retryAfterValue?: number): Promise<void> => {
-      this.uploadHttpManager.disposeAndReplaceClient(httpClientIndex)
       if (retryAfterValue) {
         core.info(
           `Backoff due to too many requests, retry #${retryCount}. Waiting for ${retryAfterValue} milliseconds before continuing the upload`

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -79,7 +79,8 @@ export function isRetryableStatusCode(statusCode?: number): boolean {
     HttpCodes.BadGateway,
     HttpCodes.ServiceUnavailable,
     HttpCodes.GatewayTimeout,
-    HttpCodes.TooManyRequests
+    HttpCodes.TooManyRequests,
+    HttpCodes.InternalServerError
   ]
   return retryableStatusCodes.includes(statusCode)
 }


### PR DESCRIPTION
## Keep Alive

I was doing some stress testing, and I came upon a really weird error that caused two files not to upload and some resets not to work correctly. You can see the run here: https://github.com/konradpabjan/artifact-test/runs/615227935?check_suite_focus=true#step:3:7251
https://github.com/konradpabjan/artifact-test/runs/615227935?check_suite_focus=true#step:3:7474
TLDR, two files don't upload, and resetting the connections doesn't work correctly.

This hasn't been reported as part of the `v2-preview` (which was suspicious) and I haven't seen the `ECONNRESET` error ever since switching over to multiple http-clients so I did a little digging into why this could have happened. I had a suspicion that `keep-alive` was the problem since there was a stacktrace that said the connection was already reset?

Turns out, there is a `keep-alive` configuration setting as part of the `@actions/http-client` that needs to be set (this is independent of any headers). https://github.com/actions/http-client/blob/f6aae3dda4f4c9dc0b49737b36007330f78fd53a/index.ts#L143

I'm making all the http-clients use keep alive. I'm also cleanup up some of the code to clarify between `headers` and `requestOptions`.

## Add 500 as a retryable status code

I'm also adding `500` as a retryable status code. I've managed to hit a few of these and we would normally fail the file upload: https://github.com/konradpabjan/artifact-test/runs/622212761?check_suite_focus=true#step:9:6690. Digging in, these 500s are always some SQL error that happens pretty randomly.

Looking at Kusto, `v1` triggers these exact same 500s from time to time so this isn't something new that all of the sudden started coming up ( a follow up issue might be good). The `v1` actions does treat 500s as retryable. Anything between 400-499 is fail fast while everything else is retried: https://github.com/actions/runner/blob/6c70d53eead402ba5d53676d6ed649a04e219c9b/src/Runner.Plugins/Artifact/FileContainerServer.cs#L483

## Testing

You can see retries working for downloads when a 500 is hit: https://github.com/konradpabjan/artifact-test/runs/622943741?check_suite_focus=true#step:5:223

I tried hitting a 500 for uploads, but after 3+ hours, i got nothing, here are some successful runs:
https://github.com/konradpabjan/artifact-test/actions/runs/89232043
https://github.com/konradpabjan/artifact-test/actions/runs/89221845
https://github.com/konradpabjan/artifact-test/actions/runs/89203550




