### PR TITLE
Add secret option to getInput

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -109,6 +109,11 @@ describe('@actions/core', () => {
     )
   })
 
+  it('getInput masks secret inputs', () => {
+    expect(core.getInput('My InPuT', { secret: true })).toBe('val')
+    assertWriteCalls([`::add-mask::val${os.EOL}`])
+  })
+
   it('setOutput produces the correct command', () => {
     core.setOutput('some output', 'some value')
     assertWriteCalls([`::set-output name=some output::some value${os.EOL}`])

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -110,7 +110,7 @@ describe('@actions/core', () => {
   })
 
   it('getInput masks secret inputs', () => {
-    expect(core.getInput('My InPuT', { secret: true })).toBe('val')
+    expect(core.getInput('My InPuT', {secret: true})).toBe('val')
     assertWriteCalls([`::add-mask::val${os.EOL}`])
   })
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -9,6 +9,8 @@ import * as path from 'path'
 export interface InputOptions {
   /** Optional. Whether the input is required. If required and not present, will throw. Defaults to false */
   required?: boolean
+  /** Optional. If the input is a secret and should be auto-masked from logs */
+  secret?: boolean
 }
 
 /**
@@ -71,6 +73,9 @@ export function getInput(name: string, options?: InputOptions): string {
     process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || ''
   if (options && options.required && !val) {
     throw new Error(`Input required and not supplied: ${name}`)
+  }
+  if (options && options.secret) {
+    setSecret(val.trim());
   }
 
   return val.trim()

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -75,7 +75,7 @@ export function getInput(name: string, options?: InputOptions): string {
     throw new Error(`Input required and not supplied: ${name}`)
   }
   if (options && options.secret) {
-    setSecret(val.trim());
+    setSecret(val.trim())
   }
 
   return val.trim()


### PR DESCRIPTION
This is a convenience method but I think it has value to mark the inputs which are secrets or passwords at the point where they are captured such that the `setSecret` function call isn't forgotten later.

Here's an example of usage:
```javascript
const username = core.getInput('username', { required: true });
const password = core.getInput('password', { required: true, secret: true });
```

And here's how you currently achieve this:
```javascript
const username = core.getInput('username', { required: true });
const password = core.getInput('password', { required: true });
core.setSecret(password);
```

