### PR TITLE
Ignore DS_Store files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 packages/*/node_modules/
 packages/*/lib/
 packages/*/__tests__/_temp/
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 packages/*/node_modules/
 packages/*/lib/
 packages/*/__tests__/_temp/
-**/.DS_Store
+.DS_Store


### PR DESCRIPTION
We really shouldn't be tracking these. They are a generated file on OSX that serve no purpose.