### PR TITLE
Retry artifact upload/download if a 500 is hit

### DIFF
--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -189,6 +189,9 @@ describe('Utils', () => {
     )
     expect(utils.isRetryableStatusCode(HttpCodes.GatewayTimeout)).toEqual(true)
     expect(utils.isRetryableStatusCode(HttpCodes.TooManyRequests)).toEqual(true)
+    expect(utils.isRetryableStatusCode(HttpCodes.InternalServerError)).toEqual(
+      true
+    )
     expect(utils.isRetryableStatusCode(HttpCodes.OK)).toEqual(false)
     expect(utils.isRetryableStatusCode(HttpCodes.NotFound)).toEqual(false)
     expect(utils.isRetryableStatusCode(HttpCodes.Forbidden)).toEqual(false)

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -75,7 +75,8 @@ export function isRetryableStatusCode(statusCode?: number): boolean {
     HttpCodes.BadGateway,
     HttpCodes.ServiceUnavailable,
     HttpCodes.GatewayTimeout,
-    HttpCodes.TooManyRequests
+    HttpCodes.TooManyRequests,
+    HttpCodes.InternalServerError
   ]
   return retryableStatusCodes.includes(statusCode)
 }


### PR DESCRIPTION
## Overview

We should be retrying if a 500 is encountered during either artifact upload or download. 

Should fix: https://github.com/actions/download-artifact/issues/33

Looking at telemetry, `v1` triggers these exact same 500s very infrequently (but they do happen) so this isn't something new that all of the sudden started coming up. The `v1` actions treat 500s as retryable. Anything between 400-499 is fail fast while everything else is retried: https://github.com/actions/runner/blob/6c70d53eead402ba5d53676d6ed649a04e219c9b/src/Runner.Plugins/Artifact/FileContainerServer.cs#L483

## Testing

After a lot of runs, I've managed to actually hit a 500 during download, you can see in the log that it is retired and the download is successful: https://github.com/konradpabjan/artifact-test/runs/622943741?check_suite_focus=true#step:5:223