### PR TITLE
Simplify mkdirP implementation

### DIFF
--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -3,7 +3,6 @@ import {promises as fs} from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import * as io from '../src/io'
-import * as ioUtil from '../src/io-util'
 
 describe('cp', () => {
   it('copies file with no flags', async () => {
@@ -812,31 +811,6 @@ describe('mkdirP', () => {
     expect(
       (await fs.lstat(path.join(realDirPath, 'sub_dir'))).isDirectory()
     ).toBe(true)
-  })
-
-  it('breaks if mkdirP loop out of control', async () => {
-    const testPath = path.join(
-      getTestTemp(),
-      'mkdirP_failsafe',
-      '1',
-      '2',
-      '3',
-      '4',
-      '5',
-      '6',
-      '7',
-      '8',
-      '9',
-      '10'
-    )
-
-    expect.assertions(1)
-
-    try {
-      await ioUtil.mkdirP(testPath, 10)
-    } catch (err) {
-      expect(err.code).toBe('ENOENT')
-    }
   })
 })
 

--- a/packages/io/src/io-util.ts
+++ b/packages/io/src/io-util.ts
@@ -1,4 +1,3 @@
-import {ok} from 'assert'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -57,52 +56,6 @@ export function isRooted(p: string): boolean {
   }
 
   return p.startsWith('/')
-}
-
-/**
- * Recursively create a directory at `fsPath`.
- *
- * This implementation is optimistic, meaning it attempts to create the full
- * path first, and backs up the path stack from there.
- *
- * @param fsPath The path to create
- * @param maxDepth The maximum recursion depth
- * @param depth The current recursion depth
- */
-export async function mkdirP(
-  fsPath: string,
-  maxDepth: number = 1000,
-  depth: number = 1
-): Promise<void> {
-  ok(fsPath, 'a path argument must be provided')
-
-  fsPath = path.resolve(fsPath)
-
-  if (depth >= maxDepth) return mkdir(fsPath)
-
-  try {
-    await mkdir(fsPath)
-    return
-  } catch (err) {
-    switch (err.code) {
-      case 'ENOENT': {
-        await mkdirP(path.dirname(fsPath), maxDepth, depth + 1)
-        await mkdir(fsPath)
-        return
-      }
-      default: {
-        let stats: fs.Stats
-
-        try {
-          stats = await stat(fsPath)
-        } catch (err2) {
-          throw err
-        }
-
-        if (!stats.isDirectory()) throw err
-      }
-    }
-  }
 }
 
 /**

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -1,3 +1,4 @@
+import {ok} from 'assert'
 import * as childProcess from 'child_process'
 import * as path from 'path'
 import {promisify} from 'util'
@@ -161,7 +162,8 @@ export async function rmRF(inputPath: string): Promise<void> {
  * @returns Promise<void>
  */
 export async function mkdirP(fsPath: string): Promise<void> {
-  await ioUtil.mkdirP(fsPath)
+  ok(fsPath, 'a path argument must be provided')
+  await ioUtil.mkdir(fsPath, {recursive: true})
 }
 
 /**


### PR DESCRIPTION
less code = fewer bugs ☺️ 

The `recursive` option have been available since Node.js 10.12.0 ([ref](https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback)), and since GitHub Actions runs on Node.js 12.x this should always be available.