### PR TITLE
set base URL for GHES

### DIFF
--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/github Releases
 
+### 2.2.0
+
+- [Support GHES: Use GITHUB_API_URL and GITHUB_GRAPHQL_URL to determine baseUrl](https://github.com/actions/toolkit/pull/449)
+
 ### 2.1.1
 
 - [Use import {Octokit}](https://github.com/actions/toolkit/pull/332)

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Actions github lib",
   "keywords": [
     "github",


### PR DESCRIPTION
Related to ADR for setting GHE URLs (in c2c-actions)

The toolkit should use the GITHUB_API_URL and GITHUB_GRAPHQL_URL to connect to GHES or Dotcom.