### PR TITLE
Update homepage to be tool-cache instead of exec

### DIFF
--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -7,7 +7,7 @@
     "actions",
     "exec"
   ],
-  "homepage": "https://github.com/actions/toolkit/tree/master/packages/exec",
+  "homepage": "https://github.com/actions/toolkit/tree/master/packages/tool-cache",
   "license": "MIT",
   "main": "lib/tool-cache.js",
   "types": "lib/tool-cache.d.ts",


### PR DESCRIPTION
I noticed https://www.npmjs.com/package/@actions/tool-cache was linking to the wrong homepage, this pull request updates the homepage to be the `tool-cache` folder instead of the `exec` folder.