### PR TITLE
@actions/github v3 using Octokit/core

### DIFF
--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -19,7 +19,7 @@ async function run() {
 
     const octokit = github.getOctokit(token)
 
-    // You can also pass in additional options as a second parameter to getOptions
+    // You can also pass in additional options as a second parameter to getOctokit
     // const octokit = github.getOctokit(myToken, {userAgent: "MyActionVersion1"});
 
     const { data: pullRequest } = await octokit.pulls.get({
@@ -80,7 +80,7 @@ if (github.context.eventName === 'push') {
 For example, using the `@octokit/plugin-enterprise-server` you can now access enterprise admin apis on GHES instances.
 
 ```ts
-import { GitHub, getOptions } from '@actions/github/utils'
+import { GitHub, getOctokitOptions } from '@actions/github/lib/utils'
 import { enterpriseServer220Admin } from '@octokit/plugin-enterprise-server'
 
 const octokit = GitHub.plugin(enterpriseServer220Admin)
@@ -88,7 +88,7 @@ const octokit = GitHub.plugin(enterpriseServer220Admin)
 // const octokit = GitHub.plugin(enterpriseServer220Admin).defaults({userAgent: "MyNewUserAgent"})
 
 const myToken = core.getInput('myToken');
-const myOctokit = new octokit(getOptions(token))
+const myOctokit = new octokit(getOctokitOptions(token))
 // Create a new user
 myOctokit.enterpriseAdmin.createUser({
   username: "testuser",

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -91,7 +91,7 @@ const myToken = core.getInput('myToken');
 const myOctokit = new octokit(getOctokitOptions(token))
 // Create a new user
 myOctokit.enterpriseAdmin.createUser({
-  username: "testuser",
+  login: "testuser",
   email: "testuser@test.com",
 });
 ```

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -18,8 +18,13 @@ async function run() {
     const myToken = core.getInput('myToken');
 
     const octokit = new github.GitHub(github.getOptions(myToken));
-    // or you may set the authentication on the options yourself
-    // const octokit = new github.GitHub({auth: `token ${myToken}`});
+
+    // You can set the authentication on the options yourself instead
+    // const octokit = new github.GitHub({auth: `token ${myToken}`, userAgent: "MyActionVersion1"});
+
+    // You can also pass in additional options as a second parameter to getOptions
+    // const octokit = new github.GitHub(github.getOptions(myToken), {userAgent: "MyActionVersion1"});
+
     const { data: pullRequest } = await octokit.pulls.get({
         owner: 'octokit',
         repo: 'rest.js',
@@ -34,8 +39,6 @@ async function run() {
 
 run();
 ```
-
-You can pass client options, as specified by [Octokit](https://github.com/octokit/core.js#options), as a second argument getOptions function.
 
 You can also make GraphQL requests. See https://github.com/octokit/graphql.js for the API.
 

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Returns an authenticated Octokit client that follows the machine [proxy settings](https://help.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners). See https://octokit.github.io/rest.js for the API.
+Returns an authenticated Octokit client that follows the machine [proxy settings](https://help.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners) and correctly sets GHES base urls. See https://octokit.github.io/rest.js for the API.
 
 ```js
 const github = require('@actions/github');
@@ -17,8 +17,9 @@ async function run() {
     // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret
     const myToken = core.getInput('myToken');
 
-    const octokit = new github.GitHub(myToken);
-
+    const octokit = new github.GitHub(github.getOptions(myToken));
+    // or you may set the authentication on the options yourself
+    // const octokit = new github.GitHub({auth: `token ${myToken}`});
     const { data: pullRequest } = await octokit.pulls.get({
         owner: 'octokit',
         repo: 'rest.js',
@@ -34,7 +35,7 @@ async function run() {
 run();
 ```
 
-You can pass client options, as specified by [Octokit](https://octokit.github.io/rest.js/), as a second argument to the `GitHub` constructor.
+You can pass client options, as specified by [Octokit](https://github.com/octokit/core.js#options), as a second argument getOptions function.
 
 You can also make GraphQL requests. See https://github.com/octokit/graphql.js for the API.
 

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -17,13 +17,13 @@ async function run() {
     // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret
     const myToken = core.getInput('myToken');
 
-    const octokit = new github.GitHub(github.getOptions(myToken));
+    const octokit = github.getOctokit(token)
+
+    // You can also pass in additional options as a second parameter to getOptions
+    // const octokit = github.getOctokit(myToken, {userAgent: "MyActionVersion1"});
 
     // You can set the authentication on the options yourself instead
     // const octokit = new github.GitHub({auth: `token ${myToken}`, userAgent: "MyActionVersion1"});
-
-    // You can also pass in additional options as a second parameter to getOptions
-    // const octokit = new github.GitHub(github.getOptions(myToken), {userAgent: "MyActionVersion1"});
 
     const { data: pullRequest } = await octokit.pulls.get({
         owner: 'octokit',
@@ -75,4 +75,26 @@ if (github.context.eventName === 'push') {
   const pushPayload = github.context.payload as Webhooks.WebhookPayloadPush
   core.info(`The head commit is: ${pushPayload.head}`)
 }
+```
+
+## Extending the Octokit instance
+`@octokit/core` now supports the [plugin architecture](https://github.com/octokit/core.js#plugins). You can extend the GitHub instance using plugins. 
+
+For example, using the `@octokit/plugin-enterprise-server` you can now access enterprise admin apis on GHES instances.
+
+```ts
+const { GitHub, getOptions } = require("@actions/github");
+const { enterpriseServer220Admin } = require("@octokit/plugin-enterprise-server");
+
+const octokit = GitHub.plugin(enterpriseServer220Admin).defaults({userAgent: "MyNewUserAgent"})
+// or override some of the default values as well 
+// const octokit = GitHub.plugin(enterpriseServer220Admin).defaults({userAgent: "MyNewUserAgent"})
+
+const myToken = core.getInput('myToken');
+const myOctokit = new octokit(getOptions(token))
+// Create a new user
+myOctokit.enterpriseAdmin.createUser({
+  username: "testuser",
+  email: "testuser@test.com",
+});
 ```

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -22,9 +22,6 @@ async function run() {
     // You can also pass in additional options as a second parameter to getOptions
     // const octokit = github.getOctokit(myToken, {userAgent: "MyActionVersion1"});
 
-    // You can set the authentication on the options yourself instead
-    // const octokit = new github.GitHub({auth: `token ${myToken}`, userAgent: "MyActionVersion1"});
-
     const { data: pullRequest } = await octokit.pulls.get({
         owner: 'octokit',
         repo: 'rest.js',
@@ -83,10 +80,10 @@ if (github.context.eventName === 'push') {
 For example, using the `@octokit/plugin-enterprise-server` you can now access enterprise admin apis on GHES instances.
 
 ```ts
-const { GitHub, getOptions } = require("@actions/github");
-const { enterpriseServer220Admin } = require("@octokit/plugin-enterprise-server");
+import { GitHub, getOptions } from '@actions/github/utils'
+import { enterpriseServer220Admin } from '@octokit/plugin-enterprise-server'
 
-const octokit = GitHub.plugin(enterpriseServer220Admin).defaults({userAgent: "MyNewUserAgent"})
+const octokit = GitHub.plugin(enterpriseServer220Admin)
 // or override some of the default values as well 
 // const octokit = GitHub.plugin(enterpriseServer220Admin).defaults({userAgent: "MyNewUserAgent"})
 

--- a/packages/github/__tests__/github.proxy.test.ts
+++ b/packages/github/__tests__/github.proxy.test.ts
@@ -7,7 +7,7 @@ const proxyUrl = 'http://127.0.0.1:8081'
 const originalProxyUrl = process.env['https_proxy']
 process.env['https_proxy'] = proxyUrl
 // eslint-disable-next-line import/first
-import {GitHub, getOptions} from '../src/github'
+import {getOctokit} from '../src/github'
 
 describe('@actions/github', () => {
   let proxyConnects: string[]
@@ -48,7 +48,7 @@ describe('@actions/github', () => {
       return
     }
 
-    const octokit = new GitHub(getOptions(token))
+    const octokit = getOctokit(token)
     const branch = await octokit.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
@@ -64,7 +64,7 @@ describe('@actions/github', () => {
       return
     }
     process.env['https_proxy'] = proxyUrl
-    const octokit = new GitHub(getOptions(token))
+    const octokit = getOctokit(token)
 
     const repository = await octokit.graphql(
       '{repository(owner:"actions", name:"toolkit"){name}}'
@@ -80,13 +80,11 @@ describe('@actions/github', () => {
     }
 
     // Valid token
-    const octokit = new GitHub(
-      getOptions(token, {
-        request: {
-          agent: new https.Agent()
-        }
-      })
-    )
+    const octokit = getOctokit(token, {
+      request: {
+        agent: new https.Agent()
+      }
+    })
     const branch = await octokit.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',

--- a/packages/github/__tests__/github.proxy.test.ts
+++ b/packages/github/__tests__/github.proxy.test.ts
@@ -7,7 +7,7 @@ const proxyUrl = 'http://127.0.0.1:8081'
 const originalProxyUrl = process.env['https_proxy']
 process.env['https_proxy'] = proxyUrl
 // eslint-disable-next-line import/first
-import {GitHub} from '../src/github'
+import {GitHub, getOptions} from '../src/github'
 
 describe('@actions/github', () => {
   let proxyConnects: string[]
@@ -48,7 +48,7 @@ describe('@actions/github', () => {
       return
     }
 
-    const octokit = new GitHub(token)
+    const octokit = new GitHub(getOptions(token))
     const branch = await octokit.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
@@ -64,7 +64,7 @@ describe('@actions/github', () => {
       return
     }
     process.env['https_proxy'] = proxyUrl
-    const octokit = new GitHub(token)
+    const octokit = new GitHub(getOptions(token))
 
     const repository = await octokit.graphql(
       '{repository(owner:"actions", name:"toolkit"){name}}'
@@ -80,11 +80,13 @@ describe('@actions/github', () => {
     }
 
     // Valid token
-    const octokit = new GitHub(token, {
-      request: {
-        agent: new https.Agent()
-      }
-    })
+    const octokit = new GitHub(
+      getOptions(token, {
+        request: {
+          agent: new https.Agent()
+        }
+      })
+    )
     const branch = await octokit.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',

--- a/packages/github/__tests__/github.test.ts
+++ b/packages/github/__tests__/github.test.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import proxy from 'proxy'
-import {GitHub, getOptions} from '../src/github'
+import {GitHub, getOctokitOptions, getOctokit} from '../src/github'
 
 describe('@actions/github', () => {
   const proxyUrl = 'http://127.0.0.1:8080'
@@ -43,7 +43,22 @@ describe('@actions/github', () => {
     if (!token) {
       return
     }
-    const octokit = new GitHub(getOptions(token))
+    const octokit = new GitHub(getOctokitOptions(token))
+    const branch = await octokit.repos.getBranch({
+      owner: 'actions',
+      repo: 'toolkit',
+      branch: 'master'
+    })
+    expect(branch.data.name).toBe('master')
+    expect(proxyConnects).toHaveLength(0)
+  })
+
+  it('basic getOctokit client', async () => {
+    const token = getToken()
+    if (!token) {
+      return
+    }
+    const octokit = getOctokit(token)
     const branch = await octokit.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
@@ -90,7 +105,7 @@ describe('@actions/github', () => {
       return
     }
 
-    const octokit = new GitHub(getOptions(token))
+    const octokit = getOctokit(token)
     const repository = await octokit.graphql(
       '{repository(owner:"actions", name:"toolkit"){name}}'
     )
@@ -105,7 +120,7 @@ describe('@actions/github', () => {
     }
 
     // Valid token
-    let octokit = new GitHub(getOptions(token))
+    let octokit = getOctokit(token)
     const repository = await octokit.graphql(
       '{repository(owner:"actions", name:"toolkit"){name}}'
     )

--- a/packages/github/__tests__/github.test.ts
+++ b/packages/github/__tests__/github.test.ts
@@ -1,6 +1,7 @@
 import * as http from 'http'
 import proxy from 'proxy'
-import {GitHub, getOctokitOptions, getOctokit} from '../src/github'
+import {getOctokit} from '../src/github'
+import {GitHub, getOctokitOptions} from '../src/utils'
 
 describe('@actions/github', () => {
   const proxyUrl = 'http://127.0.0.1:8080'

--- a/packages/github/__tests__/github.test.ts
+++ b/packages/github/__tests__/github.test.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import proxy from 'proxy'
-import {GitHub} from '../src/github'
+import {GitHub, getOptions} from '../src/github'
 
 describe('@actions/github', () => {
   const proxyUrl = 'http://127.0.0.1:8080'
@@ -43,7 +43,7 @@ describe('@actions/github', () => {
     if (!token) {
       return
     }
-    const octokit = new GitHub(token)
+    const octokit = new GitHub(getOptions(token))
     const branch = await octokit.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
@@ -90,7 +90,7 @@ describe('@actions/github', () => {
       return
     }
 
-    const octokit = new GitHub(token)
+    const octokit = new GitHub(getOptions(token))
     const repository = await octokit.graphql(
       '{repository(owner:"actions", name:"toolkit"){name}}'
     )
@@ -105,7 +105,7 @@ describe('@actions/github', () => {
     }
 
     // Valid token
-    let octokit = new GitHub(token)
+    let octokit = new GitHub(getOptions(token))
     const repository = await octokit.graphql(
       '{repository(owner:"actions", name:"toolkit"){name}}'
     )

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -465,9 +465,9 @@
       }
     },
     "@octokit/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-uvzmkemQrBgD8xuGbjhxzJN1darJk9L2cS+M99cHrDG2jlSVpxNJVhoV86cXdYBqdHCc9Z995uLCczaaHIYA6Q==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.2.tgz",
+      "integrity": "sha512-+hEKCEGvbS902uuSk/TyVnI7eWDEKVm1BIPnbKy8gsxjTYaybEU8EG73B3Ju5cMj2/OIZ0uHoQWD1nGWhWsj2g==",
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
@@ -475,111 +475,26 @@
         "@octokit/types": "^2.0.0",
         "before-after-hook": "^2.1.0",
         "universal-user-agent": "^5.0.0"
-      },
-      "dependencies": {
-        "@octokit/endpoint": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
-          "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
-          "requires": {
-            "@octokit/types": "^2.11.1",
-            "is-plain-object": "^3.0.0",
-            "universal-user-agent": "^5.0.0"
-          },
-          "dependencies": {
-            "@octokit/types": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.14.0.tgz",
-              "integrity": "sha512-1w2wxpN45rEXPDFeB7rGain7wcJ/aTRg8bdILITVnS0O7a4zEGELa3JmIe+jeLdekQjvZRbVfNPqS+mi5fKCKQ==",
-              "requires": {
-                "@types/node": ">= 8"
-              }
-            }
-          }
-        },
-        "@octokit/request": {
-          "version": "5.4.2",
-          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
-          "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
-          "requires": {
-            "@octokit/endpoint": "^6.0.1",
-            "@octokit/request-error": "^2.0.0",
-            "@octokit/types": "^2.11.1",
-            "deprecation": "^2.0.0",
-            "is-plain-object": "^3.0.0",
-            "node-fetch": "^2.3.0",
-            "once": "^1.4.0",
-            "universal-user-agent": "^5.0.0"
-          },
-          "dependencies": {
-            "@octokit/types": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.14.0.tgz",
-              "integrity": "sha512-1w2wxpN45rEXPDFeB7rGain7wcJ/aTRg8bdILITVnS0O7a4zEGELa3JmIe+jeLdekQjvZRbVfNPqS+mi5fKCKQ==",
-              "requires": {
-                "@types/node": ">= 8"
-              }
-            }
-          }
-        },
-        "@octokit/request-error": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
-          "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
-          "requires": {
-            "@octokit/types": "^2.0.0",
-            "deprecation": "^2.0.0",
-            "once": "^1.4.0"
-          }
-        }
       }
     },
     "@octokit/endpoint": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
-      "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
+      "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
       "requires": {
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^2.11.1",
         "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
+        "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/graphql": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
-      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.4.0.tgz",
+      "integrity": "sha512-Du3hAaSROQ8EatmYoSAJjzAz3t79t9Opj/WY1zUgxVUGfIKn0AEjg+hlOLscF6fv6i/4y/CeUvsWgIfwMkTccw==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^2.0.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
-      }
-    },
-    "@octokit/plugin-enterprise-server": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-server/-/plugin-enterprise-server-7.4.1.tgz",
-      "integrity": "sha512-lbuur11bnczaaO/HoEvLFErwkawWPO+prWBK1MMISc39ZsRcmwYfxfXyybQdeBC4cG1AaoFN0rTaw8kXPgtQ8g==",
-      "requires": {
-        "@octokit/types": "^2.0.2"
+        "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/plugin-paginate-rest": {
@@ -620,34 +535,24 @@
       }
     },
     "@octokit/request": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
-      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
+      "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
       "requires": {
-        "@octokit/endpoint": "^5.5.0",
-        "@octokit/request-error": "^1.0.1",
-        "@octokit/types": "^2.0.0",
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^2.11.1",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
+        "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/request-error": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
-      "integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
       "requires": {
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
@@ -655,9 +560,9 @@
       }
     },
     "@octokit/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+      "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
       "requires": {
         "@types/node": ">= 8"
       }
@@ -4853,9 +4758,9 @@
       "dev": true
     },
     "windows-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
+      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
       "requires": {
         "execa": "^1.0.0"
       }

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -574,6 +574,14 @@
         }
       }
     },
+    "@octokit/plugin-enterprise-server": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-server/-/plugin-enterprise-server-7.4.1.tgz",
+      "integrity": "sha512-lbuur11bnczaaO/HoEvLFErwkawWPO+prWBK1MMISc39ZsRcmwYfxfXyybQdeBC4cG1AaoFN0rTaw8kXPgtQ8g==",
+      "requires": {
+        "@octokit/types": "^2.0.2"
+      }
+    },
     "@octokit/plugin-paginate-rest": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.0.tgz",
@@ -3449,11 +3457,6 @@
           "dev": true
         }
       }
-    },
-    "octokit-plugin-action-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/octokit-plugin-action-context/-/octokit-plugin-action-context-1.0.0.tgz",
-      "integrity": "sha512-un0gUOVP2urVLmDBUnVDvB7d3z3QQnlZ+FlGzZ54of3lyTlpjeJ3vyklUKk6PtSOCUmGD2j3CJElQtdQjp9log=="
     },
     "once": {
       "version": "1.4.0",

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -464,6 +464,76 @@
         "@octokit/types": "^2.0.0"
       }
     },
+    "@octokit/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uvzmkemQrBgD8xuGbjhxzJN1darJk9L2cS+M99cHrDG2jlSVpxNJVhoV86cXdYBqdHCc9Z995uLCczaaHIYA6Q==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^2.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "@octokit/endpoint": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
+          "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
+          "requires": {
+            "@octokit/types": "^2.11.1",
+            "is-plain-object": "^3.0.0",
+            "universal-user-agent": "^5.0.0"
+          },
+          "dependencies": {
+            "@octokit/types": {
+              "version": "2.14.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.14.0.tgz",
+              "integrity": "sha512-1w2wxpN45rEXPDFeB7rGain7wcJ/aTRg8bdILITVnS0O7a4zEGELa3JmIe+jeLdekQjvZRbVfNPqS+mi5fKCKQ==",
+              "requires": {
+                "@types/node": ">= 8"
+              }
+            }
+          }
+        },
+        "@octokit/request": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
+          "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
+          "requires": {
+            "@octokit/endpoint": "^6.0.1",
+            "@octokit/request-error": "^2.0.0",
+            "@octokit/types": "^2.11.1",
+            "deprecation": "^2.0.0",
+            "is-plain-object": "^3.0.0",
+            "node-fetch": "^2.3.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^5.0.0"
+          },
+          "dependencies": {
+            "@octokit/types": {
+              "version": "2.14.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.14.0.tgz",
+              "integrity": "sha512-1w2wxpN45rEXPDFeB7rGain7wcJ/aTRg8bdILITVnS0O7a4zEGELa3JmIe+jeLdekQjvZRbVfNPqS+mi5fKCKQ==",
+              "requires": {
+                "@types/node": ">= 8"
+              }
+            }
+          }
+        },
+        "@octokit/request-error": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+          "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+          "requires": {
+            "@octokit/types": "^2.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        }
+      }
+    },
     "@octokit/endpoint": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
@@ -505,25 +575,40 @@
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
-      "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.0.tgz",
+      "integrity": "sha512-KoNxC3PLNar8UJwR+1VMQOw2IoOrrFdo5YOiDKnBhpVbKpw+zkBKNMNKwM44UWL25Vkn0Sl3nYIEGKY+gW5ebw==",
       "requires": {
-        "@octokit/types": "^2.0.1"
+        "@octokit/types": "^2.12.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.12.2.tgz",
+          "integrity": "sha512-1GHLI/Jll3j6F0GbYyZPFTcHZMGjAiRfkTEoRUyaVVk2IWbDdwEiClAJvXzfXCDayuGSNCqAUH8lpjZtqW9GDw==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
-    "@octokit/plugin-request-log": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
-      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
-    },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
-      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.10.0.tgz",
+      "integrity": "sha512-Z2DBsdnkWKuVBVFiLoEUKP/82ylH4Ij5F1Mss106hnQYXTxDfCWAyHW+hJ6ophuHVJ9Flaaue3fYn4CggzkHTg==",
       "requires": {
-        "@octokit/types": "^2.0.1",
+        "@octokit/types": "^2.14.0",
         "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.14.0.tgz",
+          "integrity": "sha512-1w2wxpN45rEXPDFeB7rGain7wcJ/aTRg8bdILITVnS0O7a4zEGELa3JmIe+jeLdekQjvZRbVfNPqS+mi5fKCKQ==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/request": {
@@ -559,29 +644,6 @@
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      }
-    },
-    "@octokit/rest": {
-      "version": "16.43.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
-      "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
-      "requires": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/plugin-paginate-rest": "^1.1.1",
-        "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
-        "@octokit/request": "^5.2.0",
-        "@octokit/request-error": "^1.0.2",
-        "atob-lite": "^2.0.0",
-        "before-after-hook": "^2.0.0",
-        "btoa-lite": "^1.0.0",
-        "deprecation": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "lodash.uniq": "^4.5.0",
-        "octokit-pagination-methods": "^1.1.0",
-        "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
       }
     },
     "@octokit/types": {
@@ -921,11 +983,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "atob-lite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1123,11 +1180,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "btoa-lite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -3031,26 +3083,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lolex": {
       "version": "5.1.2",
@@ -3413,10 +3450,10 @@
         }
       }
     },
-    "octokit-pagination-methods": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
+    "octokit-plugin-action-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/octokit-plugin-action-context/-/octokit-plugin-action-context-1.0.0.tgz",
+      "integrity": "sha512-un0gUOVP2urVLmDBUnVDvB7d3z3QQnlZ+FlGzZ54of3lyTlpjeJ3vyklUKk6PtSOCUmGD2j3CJElQtdQjp9log=="
     },
     "once": {
       "version": "1.4.0",
@@ -4615,9 +4652,9 @@
       }
     },
     "universal-user-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
       "requires": {
         "os-name": "^3.1.0"
       }

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -38,8 +38,10 @@
   },
   "dependencies": {
     "@actions/http-client": "^1.0.3",
+    "@octokit/core": "^2.5.0",
     "@octokit/graphql": "^4.3.1",
-    "@octokit/rest": "^16.43.1"
+    "@octokit/plugin-paginate-rest": "^2.2.0",
+    "@octokit/plugin-rest-endpoint-methods": "^3.10.0"
   },
   "devDependencies": {
     "jest": "^25.1.0",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -38,8 +38,7 @@
   },
   "dependencies": {
     "@actions/http-client": "^1.0.3",
-    "@octokit/core": "^2.5.0",
-    "@octokit/graphql": "^4.3.1",
+    "@octokit/core": "^2.5.1",
     "@octokit/plugin-paginate-rest": "^2.2.0",
     "@octokit/plugin-rest-endpoint-methods": "^3.10.0"
   },

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -40,6 +40,7 @@
     "@actions/http-client": "^1.0.3",
     "@octokit/core": "^2.5.0",
     "@octokit/graphql": "^4.3.1",
+    "@octokit/plugin-enterprise-server": "^7.4.1",
     "@octokit/plugin-paginate-rest": "^2.2.0",
     "@octokit/plugin-rest-endpoint-methods": "^3.10.0"
   },

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Actions github lib",
   "keywords": [
     "github",
@@ -40,7 +40,6 @@
     "@actions/http-client": "^1.0.3",
     "@octokit/core": "^2.5.0",
     "@octokit/graphql": "^4.3.1",
-    "@octokit/plugin-enterprise-server": "^7.4.1",
     "@octokit/plugin-paginate-rest": "^2.2.0",
     "@octokit/plugin-rest-endpoint-methods": "^3.10.0"
   },

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -1,48 +1,17 @@
 import * as Context from './context'
-import * as Utils from './internal/utils'
+import {GitHub, getOctokitOptions} from './utils'
 
 // octokit + plugins
-import {Octokit} from '@octokit/core'
 import {OctokitOptions} from '@octokit/core/dist-types/types'
-import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
-import {paginateRest} from '@octokit/plugin-paginate-rest'
 
 export const context = new Context.Context()
 
-const baseUrl = Utils.getApiBaseUrl()
-const defaults = {
-  baseUrl,
-  request: {
-    agent: Utils.getProxyAgent(baseUrl)
-  }
-}
-
-export const GitHub = Octokit.plugin(
-  restEndpointMethods,
-  paginateRest
-).defaults(defaults)
-
 /**
- * Convience function to correctly format Octokit Options to pass into the constructor.
+ * Returns a hydrated octokit ready to use for GitHub Actions
  *
  * @param     token    the repo PAT or GITHUB_TOKEN
  * @param     options  other options to set
  */
-export function getOctokitOptions(
-  token: string,
-  options?: OctokitOptions
-): OctokitOptions {
-  const opts = Object.assign({}, options || {}) // Shallow clone - don't mutate the object provided by the caller
-
-  // Auth
-  const auth = Utils.getAuthString(token, opts)
-  if (auth) {
-    opts.auth = auth
-  }
-
-  return opts
-}
-
 export function getOctokit(
   token: string,
   options?: OctokitOptions

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -28,7 +28,7 @@ export const GitHub = Octokit.plugin(
  * @param     token    the repo PAT or GITHUB_TOKEN
  * @param     options  other options to set
  */
-export function getOptions(
+export function getOctokitOptions(
   token: string,
   options?: OctokitOptions
 ): OctokitOptions {
@@ -41,4 +41,11 @@ export function getOptions(
   }
 
   return opts
+}
+
+export function getOctokit(
+  token: string,
+  options?: OctokitOptions
+): InstanceType<typeof GitHub> {
+  return new GitHub(getOctokitOptions(token, options))
 }

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -23,7 +23,7 @@ export const GitHub = Octokit.plugin(
 ).defaults(defaults)
 
 /**
- * Convience function to correctly format options from a token
+ * Convience function to correctly format Octokit Options to pass into the constructor.
  *
  * @param     token    the repo PAT or GITHUB_TOKEN
  * @param     options  other options to set

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -1,17 +1,18 @@
 import * as Context from './context'
-import {OctokitOptions} from '@octokit/core/dist-types/types'
 import * as Utils from './internal/utils'
 
 // octokit + plugins
 import {Octokit as Core} from '@octokit/core'
+import {OctokitOptions, Constructor} from '@octokit/core/dist-types/types'
 import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
 import {paginateRest} from '@octokit/plugin-paginate-rest'
-import {enterpriseServer220Admin} from '@octokit/plugin-enterprise-server'
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 export const context = new Context.Context()
-const OctokitEnterprise = Core.plugin(paginateRest, enterpriseServer220Admin)
-const Octokit = Core.plugin(paginateRest, restEndpointMethods)
-export class GitHub extends Octokit {
+
+class GitHubCore extends Core {
   /* eslint-disable no-dupe-class-members */
   // Disable no-dupe-class-members due to false positive for method overload
   // https://github.com/typescript-eslint/typescript-eslint/issues/291
@@ -30,22 +31,33 @@ export class GitHub extends Octokit {
     super(Utils.getOctokitOptions(Utils.disambiguate(token, opts)))
     this.graphql = Utils.getGraphQL(Utils.disambiguate(token, opts))
   }
-}
 
-export class GitHubEnterprise extends OctokitEnterprise {
-  /**
-   * Sets up the REST client and GraphQL client with auth and proxy support.
-   * The parameter `token` or `opts.auth` must be supplied. The GraphQL client
-   * authorization is not setup when `opts.auth` is a function or object.
-   *
-   * @param token  Auth token
-   * @param opts   Octokit options
-   * @param version the version of the GitHubEnterprise
-   */
-  constructor(token: string, opts?: Omit<OctokitOptions, 'auth'>)
-  constructor(opts: OctokitOptions)
-  constructor(token: string | OctokitOptions, opts?: OctokitOptions) {
-    super(Utils.getOctokitOptions(Utils.disambiguate(token, opts)))
-    this.graphql = Utils.getGraphQL(Utils.disambiguate(token, opts))
+  // Base class assumes the octokit options are the first arg, that is not the case for us, so we need to reimplement
+  static defaults<T extends Constructor<any>>(
+    this: T,
+    defaults: OctokitOptions
+  ): T {
+    const GitHubWithDefaults = class extends this {
+      constructor(...args: any[]) {
+        const token = args[0]
+        const opts = args[1]
+        const options = Utils.getOctokitOptions(Utils.disambiguate(token, opts))
+        super(Object.assign({}, defaults, options))
+      }
+    }
+    return GitHubWithDefaults
   }
 }
+
+const baseUrl = Utils.getApiBaseUrl()
+const defaults = {
+  baseUrl,
+  request: {
+    agent: Utils.getProxyAgent(baseUrl)
+  }
+}
+
+export const GitHub = GitHubCore.plugin(
+  paginateRest,
+  restEndpointMethods
+).defaults(defaults)

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -32,5 +32,13 @@ export function getOptions(
   token: string,
   options?: OctokitOptions
 ): OctokitOptions {
-  return Utils.getOctokitOptions(Utils.disambiguate(token, options))
+  const opts = Object.assign({}, options || {}) // Shallow clone - don't mutate the object provided by the caller
+
+  // Auth
+  const auth = Utils.getAuthString(token, opts)
+  if (auth) {
+    opts.auth = auth
+  }
+
+  return opts
 }

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -1,30 +1,16 @@
-// we need this to setup our constructors, it is not exported by default
-import {OctokitOptions} from '@octokit/core/dist-types/types'
 import * as Context from './context'
-import * as http from 'http'
-import * as httpClient from '@actions/http-client'
-import {graphql} from '@octokit/graphql'
-
-// we need this type to set up a property on the GitHub object
-// that has token authorization
-// (it is not exported from octokit by default)
-import {
-  graphql as GraphQL,
-  RequestParameters as GraphQLRequestParameters
-} from '@octokit/graphql/dist-types/types'
+import {OctokitOptions} from '@octokit/core/dist-types/types'
+import * as Utils from './internal/utils'
 
 // octokit + plugins
-import { Octokit as Core } from "@octokit/core";
-import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods"
-import { paginateRest } from "@octokit/plugin-paginate-rest"
+import {Octokit as Core} from '@octokit/core'
+import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
+import {paginateRest} from '@octokit/plugin-paginate-rest'
+import {enterpriseServer220Admin} from '@octokit/plugin-enterprise-server'
 
 export const context = new Context.Context()
-
-const Octokit = Core.plugin(restEndpointMethods, paginateRest).defaults(
-  {
-    agent: getDefaultProxyAgent()
-  })
-
+const OctokitEnterprise = Core.plugin(paginateRest, enterpriseServer220Admin)
+const Octokit = Core.plugin(paginateRest, restEndpointMethods)
 export class GitHub extends Octokit {
   /* eslint-disable no-dupe-class-members */
   // Disable no-dupe-class-members due to false positive for method overload
@@ -41,130 +27,25 @@ export class GitHub extends Octokit {
   constructor(token: string, opts?: Omit<OctokitOptions, 'auth'>)
   constructor(opts: OctokitOptions)
   constructor(token: string | OctokitOptions, opts?: OctokitOptions) {
-    super(GitHub.getOctokitOptions(GitHub.disambiguate(token, opts)))
-    this.graphql = GitHub.getGraphQL(GitHub.disambiguate(token, opts))
-  }
-
-  /**
-   * Disambiguates the constructor overload parameters
-   */
-  private static disambiguate(
-    token: string | OctokitOptions,
-    opts?: OctokitOptions
-  ): [string, OctokitOptions] {
-    return [
-      typeof token === 'string' ? token : '',
-      typeof token === 'object' ? token : opts || {}
-    ]
-  }
-
-  private static getOctokitOptions(
-    args: [string, OctokitOptions]
-  ): OctokitOptions {
-    const token = args[0]
-    const options = {...args[1]} // Shallow clone - don't mutate the object provided by the caller
-
-    // Base URL - GHES or Dotcom
-    options.baseUrl = options.baseUrl || this.getApiBaseUrl()
-
-    // Auth
-    const auth = GitHub.getAuthString(token, options)
-    if (auth) {
-      options.auth = auth
-    }
-
-    // Proxy
-    const agent = GitHub.getProxyAgent(options.baseUrl, options)
-    if (agent) {
-      // Shallow clone - don't mutate the object provided by the caller
-      options.request = options.request ? {...options.request} : {}
-
-      // Set the agent
-      options.request.agent = agent
-    }
-
-    return options
-  }
-
-  private static getGraphQL(args: [string, OctokitOptions]): GraphQL {
-    const defaults: GraphQLRequestParameters = {}
-    defaults.baseUrl = this.getGraphQLBaseUrl()
-    const token = args[0]
-    const options = args[1]
-
-    // Authorization
-    const auth = this.getAuthString(token, options)
-    if (auth) {
-      defaults.headers = {
-        authorization: auth
-      }
-    }
-
-    // Proxy
-    const agent = GitHub.getProxyAgent(defaults.baseUrl, options)
-    if (agent) {
-      defaults.request = {agent}
-    }
-
-    return graphql.defaults(defaults)
-  }
-
-  private static getAuthString(
-    token: string,
-    options: OctokitOptions
-  ): string | undefined {
-    // Validate args
-    if (!token && !options.auth) {
-      throw new Error('Parameter token or opts.auth is required')
-    } else if (token && options.auth) {
-      throw new Error(
-        'Parameters token and opts.auth may not both be specified'
-      )
-    }
-
-    return typeof options.auth === 'string' ? options.auth : `token ${token}`
-  }
-
-  private static getProxyAgent(
-    destinationUrl: string,
-    options: OctokitOptions
-  ): http.Agent | undefined {
-    if (!options.request || !options.request.agent) {
-      if (httpClient.getProxyUrl(destinationUrl)) {
-        const hc = new httpClient.HttpClient()
-        return hc.getAgent(destinationUrl)
-      }
-    }
-
-    return undefined
-  }
-
-  private static getApiBaseUrl(): string {
-    return process.env['GITHUB_API_URL'] || 'https://api.github.com'
-  }
-
-  private static getGraphQLBaseUrl(): string {
-    let url =
-      process.env['GITHUB_GRAPHQL_URL'] || 'https://api.github.com/graphql'
-
-    // Shouldn't be a trailing slash, but remove if so
-    if (url.endsWith('/')) {
-      url = url.substr(0, url.length - 1)
-    }
-
-    // Remove trailing "/graphql"
-    if (url.toUpperCase().endsWith('/GRAPHQL')) {
-      url = url.substr(0, url.length - '/graphql'.length)
-    }
-    return url
+    super(Utils.getOctokitOptions(Utils.disambiguate(token, opts)))
+    this.graphql = Utils.getGraphQL(Utils.disambiguate(token, opts))
   }
 }
 
-function getDefaultProxyAgent() : http.Agent | undefined
-{
-  const serverUrl = 'https://api.github.com'
-  if (httpClient.getProxyUrl(serverUrl)) {
-    const hc = new httpClient.HttpClient()
-    return hc.getAgent(serverUrl)
+export class GitHubEnterprise extends OctokitEnterprise {
+  /**
+   * Sets up the REST client and GraphQL client with auth and proxy support.
+   * The parameter `token` or `opts.auth` must be supplied. The GraphQL client
+   * authorization is not setup when `opts.auth` is a function or object.
+   *
+   * @param token  Auth token
+   * @param opts   Octokit options
+   * @param version the version of the GitHubEnterprise
+   */
+  constructor(token: string, opts?: Omit<OctokitOptions, 'auth'>)
+  constructor(opts: OctokitOptions)
+  constructor(token: string | OctokitOptions, opts?: OctokitOptions) {
+    super(Utils.getOctokitOptions(Utils.disambiguate(token, opts)))
+    this.graphql = Utils.getGraphQL(Utils.disambiguate(token, opts))
   }
 }

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -2,52 +2,12 @@ import * as Context from './context'
 import * as Utils from './internal/utils'
 
 // octokit + plugins
-import {Octokit as Core} from '@octokit/core'
-import {OctokitOptions, Constructor} from '@octokit/core/dist-types/types'
+import {Octokit} from '@octokit/core'
+import {OctokitOptions} from '@octokit/core/dist-types/types'
 import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
 import {paginateRest} from '@octokit/plugin-paginate-rest'
 
-// We use any as a valid input type
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 export const context = new Context.Context()
-
-class GitHubCore extends Core {
-  /* eslint-disable no-dupe-class-members */
-  // Disable no-dupe-class-members due to false positive for method overload
-  // https://github.com/typescript-eslint/typescript-eslint/issues/291
-
-  /**
-   * Sets up the REST client and GraphQL client with auth and proxy support.
-   * The parameter `token` or `opts.auth` must be supplied. The GraphQL client
-   * authorization is not setup when `opts.auth` is a function or object.
-   *
-   * @param token  Auth token
-   * @param opts   Octokit options
-   */
-  constructor(token: string, opts?: Omit<OctokitOptions, 'auth'>)
-  constructor(opts: OctokitOptions)
-  constructor(token: string | OctokitOptions, opts?: OctokitOptions) {
-    super(Utils.getOctokitOptions(Utils.disambiguate(token, opts)))
-    this.graphql = Utils.getGraphQL(Utils.disambiguate(token, opts))
-  }
-
-  // Base class assumes the octokit options are the first arg, that is not the case for us, so we need to reimplement
-  static defaults<T extends Constructor<any>>(
-    this: T,
-    defaults: OctokitOptions
-  ): T {
-    const GitHubWithDefaults = class extends this {
-      constructor(...args: any[]) {
-        const token = args[0]
-        const opts = args[1]
-        const options = Utils.getOctokitOptions(Utils.disambiguate(token, opts))
-        super(Object.assign({}, defaults, options))
-      }
-    }
-    return GitHubWithDefaults
-  }
-}
 
 const baseUrl = Utils.getApiBaseUrl()
 const defaults = {
@@ -57,7 +17,20 @@ const defaults = {
   }
 }
 
-export const GitHub = GitHubCore.plugin(
-  paginateRest,
-  restEndpointMethods
+export const GitHub = Octokit.plugin(
+  restEndpointMethods,
+  paginateRest
 ).defaults(defaults)
+
+/**
+ * Convience function to correctly format options from a token
+ *
+ * @param     token    the repo PAT or GITHUB_TOKEN
+ * @param     options  other options to set
+ */
+export function getOptions(
+  token: string,
+  options?: OctokitOptions
+): OctokitOptions {
+  return Utils.getOctokitOptions(Utils.disambiguate(token, options))
+}

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -30,23 +30,10 @@ export function getOctokitOptions(
   const token = args[0]
   const options = {...args[1]} // Shallow clone - don't mutate the object provided by the caller
 
-  // Base URL - GHES or Dotcom
-  options.baseUrl = options.baseUrl || getApiBaseUrl()
-
   // Auth
   const auth = getAuthString(token, options)
   if (auth) {
     options.auth = auth
-  }
-
-  // Proxy
-  const agent = getProxyAgent(options.baseUrl, options)
-  if (agent) {
-    // Shallow clone - don't mutate the object provided by the caller
-    options.request = options.request ? {...options.request} : {}
-
-    // Set the agent
-    options.request.agent = agent
   }
 
   return options
@@ -79,7 +66,6 @@ export function getAuthString(
   token: string,
   options: OctokitOptions
 ): string | undefined {
-  // Validate args
   if (!token && !options.auth) {
     throw new Error('Parameter token or opts.auth is required')
   } else if (token && options.auth) {
@@ -91,15 +77,16 @@ export function getAuthString(
 
 export function getProxyAgent(
   destinationUrl: string,
-  options: OctokitOptions
+  options?: OctokitOptions
 ): http.Agent | undefined {
-  if (!options.request || !options.request.agent) {
+  if (!options || !options.request || !options.request.agent) {
     if (httpClient.getProxyUrl(destinationUrl)) {
       const hc = new httpClient.HttpClient()
       return hc.getAgent(destinationUrl)
     }
+  } else if (options && options.request && options.request.agent) {
+    return options.request.agent
   }
-
   return undefined
 }
 

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -43,19 +43,9 @@ export function getAuthString(
   return typeof options.auth === 'string' ? options.auth : `token ${token}`
 }
 
-export function getProxyAgent(
-  destinationUrl: string,
-  options?: OctokitOptions
-): http.Agent | undefined {
-  if (!options || !options.request || !options.request.agent) {
-    if (httpClient.getProxyUrl(destinationUrl)) {
-      const hc = new httpClient.HttpClient()
-      return hc.getAgent(destinationUrl)
-    }
-  } else if (options && options.request && options.request.agent) {
-    return options.request.agent
-  }
-  return undefined
+export function getProxyAgent(destinationUrl: string): http.Agent | undefined {
+  const hc = new httpClient.HttpClient()
+  return hc.getAgent(destinationUrl)
 }
 
 export function getApiBaseUrl(): string {

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -1,14 +1,5 @@
 import * as http from 'http'
 import * as httpClient from '@actions/http-client'
-import {graphql} from '@octokit/graphql'
-
-// we need this type to set up a property on the GitHub object
-// that has token authorization
-// (it is not exported from octokit by default)
-import {
-  graphql as GraphQL,
-  RequestParameters as GraphQLRequestParameters
-} from '@octokit/graphql/dist-types/types'
 import {OctokitOptions} from '@octokit/core/dist-types/types'
 
 /**
@@ -37,29 +28,6 @@ export function getOctokitOptions(
   }
 
   return options
-}
-
-export function getGraphQL(args: [string, OctokitOptions]): GraphQL {
-  const defaults: GraphQLRequestParameters = {}
-  defaults.baseUrl = getGraphQLBaseUrl()
-  const token = args[0]
-  const options = args[1]
-
-  // Authorization
-  const auth = getAuthString(token, options)
-  if (auth) {
-    defaults.headers = {
-      authorization: auth
-    }
-  }
-
-  // Proxy
-  const agent = getProxyAgent(defaults.baseUrl, options)
-  if (agent) {
-    defaults.request = {agent}
-  }
-
-  return graphql.defaults(defaults)
 }
 
 export function getAuthString(
@@ -92,20 +60,4 @@ export function getProxyAgent(
 
 export function getApiBaseUrl(): string {
   return process.env['GITHUB_API_URL'] || 'https://api.github.com'
-}
-
-export function getGraphQLBaseUrl(): string {
-  let url =
-    process.env['GITHUB_GRAPHQL_URL'] || 'https://api.github.com/graphql'
-
-  // Shouldn't be a trailing slash, but remove if so
-  if (url.endsWith('/')) {
-    url = url.substr(0, url.length - 1)
-  }
-
-  // Remove trailing "/graphql"
-  if (url.toUpperCase().endsWith('/GRAPHQL')) {
-    url = url.substr(0, url.length - '/graphql'.length)
-  }
-  return url
 }

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -15,7 +15,7 @@ export function getAuthString(
   return typeof options.auth === 'string' ? options.auth : `token ${token}`
 }
 
-export function getProxyAgent(destinationUrl: string): http.Agent | undefined {
+export function getProxyAgent(destinationUrl: string): http.Agent {
   const hc = new httpClient.HttpClient()
   return hc.getAgent(destinationUrl)
 }

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -1,0 +1,124 @@
+import * as http from 'http'
+import * as httpClient from '@actions/http-client'
+import {graphql} from '@octokit/graphql'
+
+// we need this type to set up a property on the GitHub object
+// that has token authorization
+// (it is not exported from octokit by default)
+import {
+  graphql as GraphQL,
+  RequestParameters as GraphQLRequestParameters
+} from '@octokit/graphql/dist-types/types'
+import {OctokitOptions} from '@octokit/core/dist-types/types'
+
+/**
+ * Disambiguates the constructor overload parameters
+ */
+export function disambiguate(
+  token: string | OctokitOptions,
+  opts?: OctokitOptions
+): [string, OctokitOptions] {
+  return [
+    typeof token === 'string' ? token : '',
+    typeof token === 'object' ? token : opts || {}
+  ]
+}
+
+export function getOctokitOptions(
+  args: [string, OctokitOptions]
+): OctokitOptions {
+  const token = args[0]
+  const options = {...args[1]} // Shallow clone - don't mutate the object provided by the caller
+
+  // Base URL - GHES or Dotcom
+  options.baseUrl = options.baseUrl || getApiBaseUrl()
+
+  // Auth
+  const auth = getAuthString(token, options)
+  if (auth) {
+    options.auth = auth
+  }
+
+  // Proxy
+  const agent = getProxyAgent(options.baseUrl, options)
+  if (agent) {
+    // Shallow clone - don't mutate the object provided by the caller
+    options.request = options.request ? {...options.request} : {}
+
+    // Set the agent
+    options.request.agent = agent
+  }
+
+  return options
+}
+
+export function getGraphQL(args: [string, OctokitOptions]): GraphQL {
+  const defaults: GraphQLRequestParameters = {}
+  defaults.baseUrl = getGraphQLBaseUrl()
+  const token = args[0]
+  const options = args[1]
+
+  // Authorization
+  const auth = getAuthString(token, options)
+  if (auth) {
+    defaults.headers = {
+      authorization: auth
+    }
+  }
+
+  // Proxy
+  const agent = getProxyAgent(defaults.baseUrl, options)
+  if (agent) {
+    defaults.request = {agent}
+  }
+
+  return graphql.defaults(defaults)
+}
+
+export function getAuthString(
+  token: string,
+  options: OctokitOptions
+): string | undefined {
+  // Validate args
+  if (!token && !options.auth) {
+    throw new Error('Parameter token or opts.auth is required')
+  } else if (token && options.auth) {
+    throw new Error('Parameters token and opts.auth may not both be specified')
+  }
+
+  return typeof options.auth === 'string' ? options.auth : `token ${token}`
+}
+
+export function getProxyAgent(
+  destinationUrl: string,
+  options: OctokitOptions
+): http.Agent | undefined {
+  if (!options.request || !options.request.agent) {
+    if (httpClient.getProxyUrl(destinationUrl)) {
+      const hc = new httpClient.HttpClient()
+      return hc.getAgent(destinationUrl)
+    }
+  }
+
+  return undefined
+}
+
+export function getApiBaseUrl(): string {
+  return process.env['GITHUB_API_URL'] || 'https://api.github.com'
+}
+
+export function getGraphQLBaseUrl(): string {
+  let url =
+    process.env['GITHUB_GRAPHQL_URL'] || 'https://api.github.com/graphql'
+
+  // Shouldn't be a trailing slash, but remove if so
+  if (url.endsWith('/')) {
+    url = url.substr(0, url.length - 1)
+  }
+
+  // Remove trailing "/graphql"
+  if (url.toUpperCase().endsWith('/GRAPHQL')) {
+    url = url.substr(0, url.length - '/graphql'.length)
+  }
+  return url
+}

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -2,34 +2,6 @@ import * as http from 'http'
 import * as httpClient from '@actions/http-client'
 import {OctokitOptions} from '@octokit/core/dist-types/types'
 
-/**
- * Disambiguates the constructor overload parameters
- */
-export function disambiguate(
-  token: string | OctokitOptions,
-  opts?: OctokitOptions
-): [string, OctokitOptions] {
-  return [
-    typeof token === 'string' ? token : '',
-    typeof token === 'object' ? token : opts || {}
-  ]
-}
-
-export function getOctokitOptions(
-  args: [string, OctokitOptions]
-): OctokitOptions {
-  const token = args[0]
-  const options = {...args[1]} // Shallow clone - don't mutate the object provided by the caller
-
-  // Auth
-  const auth = getAuthString(token, options)
-  if (auth) {
-    options.auth = auth
-  }
-
-  return options
-}
-
 export function getAuthString(
   token: string,
   options: OctokitOptions

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -1,0 +1,44 @@
+import * as Context from './context'
+import * as Utils from './internal/utils'
+
+// octokit + plugins
+import {Octokit} from '@octokit/core'
+import {OctokitOptions} from '@octokit/core/dist-types/types'
+import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
+import {paginateRest} from '@octokit/plugin-paginate-rest'
+
+export const context = new Context.Context()
+
+const baseUrl = Utils.getApiBaseUrl()
+const defaults = {
+  baseUrl,
+  request: {
+    agent: Utils.getProxyAgent(baseUrl)
+  }
+}
+
+export const GitHub = Octokit.plugin(
+  restEndpointMethods,
+  paginateRest
+).defaults(defaults)
+
+/**
+ * Convience function to correctly format Octokit Options to pass into the constructor.
+ *
+ * @param     token    the repo PAT or GITHUB_TOKEN
+ * @param     options  other options to set
+ */
+export function getOctokitOptions(
+  token: string,
+  options?: OctokitOptions
+): OctokitOptions {
+  const opts = Object.assign({}, options || {}) // Shallow clone - don't mutate the object provided by the caller
+
+  // Auth
+  const auth = Utils.getAuthString(token, opts)
+  if (auth) {
+    opts.auth = auth
+  }
+
+  return opts
+}


### PR DESCRIPTION
@actions/github is stuck on an older major version of `@octokit/rest` due to the way we extended the class. Let's move away from extending the Octokit class so we don't encounter this again, and move towards the plugin/defaults model all the JS libraries have been using.

This allows us to customize the octokit is a variety of ways, and reuse existing plugins easily.
In particular,  we currently were using `@octokit/rest` which is just @octokit/core with [3 plugins layered on top](https://github.com/octokit/rest.js/blob/master/src/index.ts):

- @octokit/plugin-paginate-rest - provides the paginate function to paginate rest calls
- @octokit/plugin-rest-endpoint-methods - provides the bulk of the rest apis accessible via functions
- @octokit/plugin-request-log - provides additional logging for rest calls

We don't really need the latter, so we can use `@octokit/core` to set up a custom octokit with the paginate and rest endpoint plugins and set sane defaults using environmental variables to automatically handle proxy and GHES url scenarios. 

We can also choose to implement our own custom plugins as needed going forward, or reuse some of the existing plugins, like [GHES api plugins](https://www.npmjs.com/package/@octokit/plugin-enterprise-rest)


Why don't we just keep using `@octokit/rest`?
The core library is really intended to be used if you are [extending the plugin model](https://github.com/octokit/core.js#corejs). Type information does not carry well over multiple exports when using plugins, and this offers far more flexibility (at the cost of having to update more packages)

Resolves #468 , #402 