### PR TITLE
Remove --save in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The GitHub Actions ToolKit provides a set of packages to make creating actions e
 Provides functions for inputs, outputs, results, logging, secrets and variables. Read more [here](packages/core)
 
 ```bash
-$ npm install @actions/core --save
+$ npm install @actions/core
 ```
 <br/>
 
@@ -33,7 +33,7 @@ $ npm install @actions/core --save
 Provides functions to exec cli tools and process output. Read more [here](packages/exec)
 
 ```bash
-$ npm install @actions/exec --save
+$ npm install @actions/exec
 ```
 <br/>
 
@@ -42,7 +42,7 @@ $ npm install @actions/exec --save
 Provides functions to search for files matching glob patterns. Read more [here](packages/glob)
 
 ```bash
-$ npm install @actions/glob --save
+$ npm install @actions/glob
 ```
 <br/>
 
@@ -51,7 +51,7 @@ $ npm install @actions/glob --save
 Provides disk i/o functions like cp, mv, rmRF, find etc. Read more [here](packages/io)
 
 ```bash
-$ npm install @actions/io --save
+$ npm install @actions/io
 ```
 <br/>
 
@@ -60,7 +60,7 @@ $ npm install @actions/io --save
 Provides functions for downloading and caching tools.  e.g. setup-* actions. Read more [here](packages/tool-cache)
 
 ```bash
-$ npm install @actions/tool-cache --save
+$ npm install @actions/tool-cache
 ```
 <br/>
 
@@ -69,7 +69,7 @@ $ npm install @actions/tool-cache --save
 Provides an Octokit client hydrated with the context that the current action is being run in. Read more [here](packages/github)
 
 ```bash
-$ npm install @actions/github --save
+$ npm install @actions/github
 ```
 <br/>
 
@@ -78,7 +78,7 @@ $ npm install @actions/github --save
 Provides functions to interact with actions artifacts. Read more [here](packages/artifact)
 
 ```bash
-$ npm install @actions/artifact --save
+$ npm install @actions/artifact
 ```
 <br/>
 


### PR DESCRIPTION
`--save` is deprecated and done by default. Should be removed.

See https://github.com/actions/toolkit/pull/448#discussion_r422217165 and https://github.com/actions/toolkit/pull/448#discussion_r424708066