### PR TITLE
Use Azure storage client if cache is hosted on Azure

### DIFF
--- a/.github/workflows/cache-tests.yml
+++ b/.github/workflows/cache-tests.yml
@@ -61,6 +61,13 @@ jobs:
     - name: Restore cache using restoreCache()
       run: |
         node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
+        
+    - name: Restore cache using restoreCache() with the Azure client library
+      env:
+        AZURE_CLIENT_DOWNLOAD: true
+      run: |
+        node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
+
 
     - name: Verify cache 
       shell: bash

--- a/.github/workflows/cache-tests.yml
+++ b/.github/workflows/cache-tests.yml
@@ -64,7 +64,7 @@ jobs:
         
     - name: Restore cache using restoreCache() with the Azure client library
       env:
-        AZURE_CLIENT_DOWNLOAD: true
+        USE_AZURE_CLIENT: true
       run: |
         node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
 

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -1,6 +1,9 @@
 import {promises as fs} from 'fs'
 import * as path from 'path'
 import * as cacheUtils from '../src/internal/cacheUtils'
+import * as execUtils from '../src/internal/execUtils'
+
+jest.mock('../src/internal/execUtils')
 
 test('getArchiveFileSizeIsBytes returns file size', () => {
   const filePath = path.join(__dirname, '__fixtures__', 'helloWorld.txt')
@@ -23,4 +26,46 @@ test('unlinkFile unlinks file', async () => {
   await expect(fs.stat(testFile)).rejects.toThrow()
 
   await fs.rmdir(testDirectory)
+})
+
+test('getAzCopyCommand returns undefined if azcopy not installed', async () => {
+  jest.spyOn(execUtils, 'getVersion').mockImplementation(async (app) => '')
+  expect(await cacheUtils.getAzCopyCommand()).toBeUndefined()
+})
+
+test('getAzCopyCommand returns azcopy10 when available', async () => {
+  jest.spyOn(execUtils, 'getVersion').mockImplementation(async (app) => {
+    if (app == 'azcopy') {
+      return 'azcopy version 10.4.3'
+    } else {
+      return ''
+    }
+  })
+  expect(await cacheUtils.getAzCopyCommand()).toBe('azcopy')
+})
+
+test('getAzCopyCommand returns azcopy10 when available', async () => {
+  jest.spyOn(execUtils, 'getVersion').mockImplementation(async (app) => {
+    if (app == 'azcopy') {
+      return 'azcopy version 7.3.0'
+    } else if (app == 'azcopy10') {
+      return 'azcopy version 10.4.3'
+    } else {
+      return ''
+    }
+  })
+  expect(await cacheUtils.getAzCopyCommand()).toBe('azcopy10')
+})
+
+test('getAzCopyCommand returns latest version of azcopy', async () => {
+  jest.spyOn(execUtils, 'getVersion').mockImplementation(async (app) => {
+    if (app == 'azcopy') {
+      return 'azcopy version 10.4.4'
+    } else if (app == 'azcopy10') {
+      return 'azcopy version 10.4.3'
+    } else {
+      return ''
+    }
+  })
+  expect(await cacheUtils.getAzCopyCommand()).toBe('azcopy')
 })

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -39,17 +39,162 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
+    "@azure/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.2.tgz",
+      "integrity": "sha512-IUbP/f3v96dpHgXUwsAjUwDzjlUjawyUhWhGKKB6Qxy+iqppC/pVBPyc6kdpyTe7H30HN+4H3f0lar7Wp9Hx6A==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@opentelemetry/api": "^0.6.1",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.1.2.tgz",
+      "integrity": "sha512-xeZpTs6caBIrRipqZs70jgrA+mAFxII5XrBzbOCELPs18n4QWfchB20F94ITAk3GuFVDaSBsOhVL3GP1J+ncGg==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.1.2",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.6.1",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "cross-env": "^6.0.3",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^3.0.1",
+        "tslib": "^1.10.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.2.tgz",
+      "integrity": "sha512-Yr0JD7GKryOmbcb5wHCQoQ4KCcH5QJWRNorofid+UvudLaxnbCfvKh/cUfQsGUqRjO9L/Bw4X7FP824DcHdMxw==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.1.1",
+        "events": "^3.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.1.tgz",
+      "integrity": "sha512-hqEJBEGKan4YdOaL9ZG/GRG6PXaFd/Wb3SSjQW4LWotZzgl6xqG00h6wmkrpd2NNkbBkD1erLHBO3lPHApv+iQ==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.8.tgz",
+      "integrity": "sha512-ZKUpCd7Dlyfn7bdc+/zC/sf0aRIaNQMDuSj2RhYRFe3p70hVAnYGp3TX4cnG2yoEALp/LTj/XnZGQ8Xzf6Ja/Q==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.6.1",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-g2qLDgvmhyIxR3JVS8N67CyIOeFRKQlX/llxYJQr1OSGQqM3HTpVP8MjmjcEKbL/OIt2N9C9UFaNQuKOw1laOA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.1.2.tgz",
+      "integrity": "sha512-PCHgG4r3xLt5FaFj+uiMqrRpuzD3TD17cvxCeA1JKK2bJEf8b07H3QRLQVf0DM1MmvYY8FgQagkWZTp+jr9yew==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.1.1",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.6.1",
+        "events": "^3.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.6.1.tgz",
+      "integrity": "sha512-wpufGZa7tTxw7eAsjXJtiyIQ42IWQdX9iUQp7ACJcKo1hCtuhLU+K2Nv1U6oRwT1oAlZTE6m4CgWKZBhOiau3Q==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.6.1"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.6.1.tgz",
+      "integrity": "sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ=="
+    },
+    "@types/node": {
+      "version": "14.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.9.tgz",
+      "integrity": "sha512-0sCTiXKXELOBxvZLN4krQ0FPOAA7ij+6WwvD0k/PHd9/KAkr4dXel5J9fh6F4x1FwAQILqAWkmpeuS6mjf1iKA=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/semver": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
       "integrity": "sha512-+beqKQOh9PYxuHvijhVl+tIHvT6tuwOrE9m14zd+MT2A38KoKZhh7pYJ0SNleLtwDsiIxHDsIk9bv01oOxvSvA==",
       "dev": true
     },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/uuid": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
       "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==",
       "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -65,10 +210,79 @@
         "concat-map": "0.0.1"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "events": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -78,10 +292,68 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "tough-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "requires": {
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tunnel": {
       "version": "0.0.6",
@@ -98,6 +370,28 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -41,6 +41,7 @@
     "@actions/glob": "^0.1.0",
     "@actions/http-client": "^1.0.8",
     "@actions/io": "^1.0.1",
+    "@azure/storage-blob": "^12.0.0",
     "semver": "^6.1.0",
     "uuid": "^3.3.3"
   },

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -384,7 +384,7 @@ async function uploadFile(
                 })
                 .on('error', error => {
                   throw new Error(
-                    `Cache upload failed because file read failed with ${error.Message}`
+                    `Cache upload failed because file read failed with ${error.message}`
                   )
                 }),
             start,

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -273,8 +273,10 @@ export async function downloadCache(
   const archiveUrl = new URL(archiveLocation)
   const azureClientDownload = process.env['AZURE_CLIENT_DOWNLOAD'] ?? ''
 
-  if (archiveUrl.hostname.endsWith('core.blob.windows.net') &&
-   azureClientDownload === 'true') {
+  if (
+    archiveUrl.hostname.endsWith('.core.blob.windows.net') &&
+    azureClientDownload === 'true'
+  ) {
     core.debug('Downloading using Azure client')
     await downloadCacheAzure(archiveLocation, archivePath)
   } else {

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -271,7 +271,7 @@ export async function downloadCache(
   archivePath: string
 ): Promise<void> {
   const archiveUrl = new URL(archiveLocation);
-  core.debug(`Downloading cache from ${archiveUrl.hostname}`);
+  core.info(`Downloading cache from ${archiveUrl.hostname}`);
 
   if (archiveUrl.hostname.endsWith("core.blob.windows.net")) {
     await downloadCacheAzure(archiveLocation, archivePath);

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -274,10 +274,10 @@ export async function downloadCache(
   const azureClientDownload = process.env['AZURE_CLIENT_DOWNLOAD'] ?? ''
 
   if (
-    archiveUrl.hostname.endsWith('.core.blob.windows.net') &&
+    archiveUrl.hostname.endsWith('.blob.core.windows.net') &&
     azureClientDownload === 'true'
   ) {
-    core.debug('Downloading using Azure client')
+    core.info('Downloading using Azure client')
     await downloadCacheAzure(archiveLocation, archivePath)
   } else {
     await downloadCacheDirect(archiveLocation, archivePath)

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -262,21 +262,23 @@ async function downloadCacheAzure(
   archiveLocation: string,
   archivePath: string
 ): Promise<void> {
-  const client = new BlockBlobClient(archiveLocation);
-  await client.downloadToFile(archivePath);
+  const client = new BlockBlobClient(archiveLocation)
+  await client.downloadToFile(archivePath)
 }
 
 export async function downloadCache(
   archiveLocation: string,
   archivePath: string
 ): Promise<void> {
-  const archiveUrl = new URL(archiveLocation);
-  core.info(`Downloading cache from ${archiveUrl.hostname}`);
+  const archiveUrl = new URL(archiveLocation)
+  const azureClientDownload = process.env['AZURE_CLIENT_DOWNLOAD'] ?? ''
 
-  if (archiveUrl.hostname.endsWith("core.blob.windows.net")) {
-    await downloadCacheAzure(archiveLocation, archivePath);
+  if (archiveUrl.hostname.endsWith('core.blob.windows.net') &&
+   azureClientDownload === 'true') {
+    core.debug('Downloading using Azure client')
+    await downloadCacheAzure(archiveLocation, archivePath)
   } else {
-    await downloadCacheDirect(archiveLocation, archivePath);
+    await downloadCacheDirect(archiveLocation, archivePath)
   }
 }
 

--- a/packages/cache/src/internal/execUtils.ts
+++ b/packages/cache/src/internal/execUtils.ts
@@ -1,0 +1,23 @@
+import * as core from '@actions/core'
+import * as exec from '@actions/exec'
+
+export async function getVersion(app: string): Promise<string> {
+  core.debug(`Checking ${app} --version`)
+  let versionOutput = ''
+  try {
+    await exec.exec(`${app} --version`, [], {
+      ignoreReturnCode: true,
+      silent: true,
+      listeners: {
+        stdout: (data: Buffer): string => (versionOutput += data.toString()),
+        stderr: (data: Buffer): string => (versionOutput += data.toString())
+      }
+    })
+  } catch (err) {
+    core.debug(err.message)
+  }
+
+  versionOutput = versionOutput.trim()
+  core.debug(versionOutput)
+  return versionOutput
+}


### PR DESCRIPTION
We have seen networking issues causing the cache downloads to fail.  These errors tend to be more prominent on larger files and when the distance from the storage account to the VM increases (e.g., EastUS to EastUS2 is much more reliable than EastUS to WestUS).

I've opened an IcM with Azure to investigate the network flakiness which is still ongoing, but one suggestion they had is to use AzCopy, or in this case, we will use the official Azure storage NodeJS library.  This should provide several advantages over using HTTP client.

Using HTTP client (NodeJS sockets) to download the URL ends up downloading the file in one large stream.  If the download fails at any point, the download is lost.  The Azure storage library on the other hand downloads the file in 4 MB chunks, which can both be parallelized and retried at a more granular level.

Currently, this PR uses an environment variable, `AZURE_CLIENT_DOWNLOAD`, to enable this new feature.  It will also fall back to the HTTP client if the download URL is not an Azure storage endpoint.