### PR TITLE
Explicitly exclude DS store files

### DIFF
--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -17,7 +17,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!.DS_Store"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -17,7 +17,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!.DS_Store"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!.DS_Store"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -16,7 +16,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!.DS_Store"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -15,7 +15,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!.DS_Store"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -17,7 +17,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "!.DS_Store"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Related to this npm issue: 
https://github.com/npm/cli/issues/440#issuecomment-552069243

We published a release of `@actions/github` that included a DS_STORE file. It appears that the default .npmignore is overwritten by the files list. So we can add !.DS_Store to this list to ensure we don't publish any more DS_STORE files. 

Tested locally using `npm publish --dry-run` and `npm pack --dry-run`
Resolves #491 