### PR TITLE
Adds option to download caches using AzCopy

### DIFF
--- a/.github/workflows/cache-tests.yml
+++ b/.github/workflows/cache-tests.yml
@@ -58,13 +58,13 @@ jobs:
       run: |
         node -e "Promise.resolve(require('./packages/cache/lib/cache').saveCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
 
-    - name: Restore cache using restoreCache()
+    - name: Restore cache using restoreCache() with http-client
+      env:
+        DISABLE_AZCOPY: true
       run: |
         node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
 
-    - name: Restore cache using restoreCache() with AzCopy enabled
-      env:
-        USE_AZCOPY: true
+    - name: Restore cache using restoreCache() with AzCopy
       run: |
         node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
 

--- a/.github/workflows/cache-tests.yml
+++ b/.github/workflows/cache-tests.yml
@@ -62,6 +62,12 @@ jobs:
       run: |
         node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
 
+    - name: Restore cache using restoreCache() with AzCopy enabled
+      env:
+        USE_AZCOPY: true
+      run: |
+        node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
+
     - name: Verify cache 
       shell: bash
       run: |

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -9,3 +9,6 @@
 
 ### 0.2.1
 - Fix to await async function getCompressionMethod
+
+### 0.3.0
+- Downloads Azure-hosted caches using AzCopy when available

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -263,12 +263,12 @@ export async function downloadCache(
   archivePath: string
 ): Promise<void> {
   const archiveUrl = new URL(archiveLocation)
-  const useAzCopy = process.env['USE_AZCOPY'] ?? ''
+  const disableAzCopy = process.env['DISABLE_AZCOPY'] ?? ''
 
-  // Use AzCopy to download caches hosted on Azure to improve reliability.
+  // Use AzCopy to download caches hosted on Azure to improve speed and reliability.
   if (
     archiveUrl.hostname.endsWith('.blob.core.windows.net') &&
-    useAzCopy === 'true'
+    disableAzCopy !== 'true'
   ) {
     const command = await utils.getAzCopyCommand()
 

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -116,12 +116,14 @@ export async function isGnuTarInstalled(): Promise<boolean> {
 
 export async function getAzCopyCommand(): Promise<string | undefined> {
   // Always prefer the azcopy10 alias first, which is the correct version on Ubuntu.
-  if ((await getVersion('azcopy10')).toLowerCase().startsWith('azcopy version')) {
+  let versionOutput = await getVersion('azcopy10')
+
+  if (versionOutput.toLowerCase().startsWith('azcopy version')) {
     return 'azcopy10'
   }
 
   // Fall back to any azcopy that is version 10 or newer.
-  const versionOutput = await getVersion('azcopy')
+  versionOutput = await getVersion('azcopy')
 
   if (versionOutput.toLowerCase().startsWith('azcopy version')) {
     const version = versionOutput.substring(15)

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -113,3 +113,14 @@ export async function isGnuTarInstalled(): Promise<boolean> {
   const versionOutput = await getVersion('tar')
   return versionOutput.toLowerCase().includes('gnu tar')
 }
+
+export async function getAzCopyCommand(): Promise<string | undefined> {
+  // On Ubuntu, azcopy points to an earlier version, so prefer the azcopy10 alias
+  if ((await getVersion('azcopy10')).toLowerCase().includes('azcopy')) {
+    return 'azcopy10'
+  } else if ((await getVersion('azcopy')).toLowerCase().includes('azcopy')) {
+    return 'azcopy'
+  } else {
+    return undefined
+  }
+}


### PR DESCRIPTION
Adds option to download caches using AzCopy.  This improves download speed and helps reduce flakiness.  AzCopy downloads the file in 4 MB chunks, so it has more granular control over retries and parallelism.

This download option is selected when
1. The cache URL is from Azure blob storage
2. The `DISABLE_AZCOPY` env var is *not* set (used to test the http-client download path)
3. `azcopy` is available on the runner

For hosted runners, `azcopy` is available on Ubuntu and Mac, but not Windows.  On Ubuntu, we use the `azcopy10` alias since `azcopy` refers to a much earlier version (7.x.x).

### Stats

The table below shows the average time to download a 1 GB file from an EastUS storage account to a VM hosted in EastUS2 or WestUS:

```
Client           EastUS2 VM          WestUS VM
---------------  ------------------  ----------------
http-client      43.6 s              141 s
azcopy           7.5 s               22.4 s
```

### TODO
- [ ] Get AzCopy installed on Windows runners (https://github.com/actions/virtual-environments/issues/1004)