### PR TITLE
Add release notes for `actions/github` 4.0.0

### DIFF
--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -2,8 +2,9 @@
 
 ### 4.0.0
 - [Add execution state information to context](https://github.com/actions/toolkit/pull/499)
-- [Update Octokit Dependencies with breaking changes](https://github.com/actions/toolkit/pull/375) 
+- [Update Octokit Dependencies with some api breaking changes](https://github.com/actions/toolkit/pull/498) 
   - The full list of api changes are [here](https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v4.0.0)
+  - `GitHub.plugin()` no longer supports an array as first argument. Multiple args must be passed in instead.
 
 ### 3.0.0
 - [Swap to @octokit/core and use plugins to leverage lastest octokit apis](https://github.com/actions/toolkit/pull/453)

--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,5 +1,10 @@
 # @actions/github Releases
 
+### 4.0.0
+- [Add execution state information to context](https://github.com/actions/toolkit/pull/499)
+- [Update Octokit Dependencies with breaking changes](https://github.com/actions/toolkit/pull/375) 
+  - The full list of api changes are [here](https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v4.0.0)
+
 ### 3.0.0
 - [Swap to @octokit/core and use plugins to leverage lastest octokit apis](https://github.com/actions/toolkit/pull/453)
 - [Add comment field to payload context](https://github.com/actions/toolkit/pull/375) 

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Actions github lib",
   "keywords": [
     "github",


### PR DESCRIPTION
We are releasing a new version of actions/github. Due to some octokit changes, we need to major version as there are some minor compat breaks. Details can be found in the release notes!