### PR TITLE
Pipe audit results to a json file so lerna does not overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ packages/*/node_modules/
 packages/*/lib/
 packages/*/__tests__/_temp/
 .DS_Store
+packages/*/audit.json

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/artifact"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/artifact"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/cache"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/cache"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/core"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/core"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/exec"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/exec"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/github"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "jest",
     "build": "tsc",
     "format": "prettier --write **/*.ts",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/github"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "jest",
     "build": "tsc",
     "format": "prettier --write **/*.ts",

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/glob"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/glob"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/io"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/io"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/tool-cache"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate",
+    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -28,7 +28,7 @@
     "directory": "packages/tool-cache"
   },
   "scripts": {
-    "audit-moderate": "npm install && npm audit --audit-level=moderate --json > audit.json",
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
     "test": "echo \"Error: run tests from root\" && exit 1",
     "tsc": "tsc"
   },


### PR DESCRIPTION
Our audit command is currently failing due to a lerna overflow issue. There's an open issue in lerna [here](https://github.com/lerna/lerna/issues/2384). For now, we should pipe the stdout to a json file, and have stderr display the results of the run.