### PR TITLE
Update email in octokit upgrade job

### DIFF
--- a/.github/workflows/update-github.yaml
+++ b/.github/workflows/update-github.yaml
@@ -22,7 +22,7 @@ jobs:
       run: | 
         if [[ "$(git status --porcelain)" != "" ]]; then 
         echo "::set-output name=createPR::true"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.email "github-actions@github.com"
         git config --global user.name "github-actions[bot]"
         git checkout -b bots/updateGitHubDependencies-${{github.run_number}}
         git add .


### PR DESCRIPTION
We are standardizing around the email `github-actions@github.com` until we a better way to associate a commit with the actions bot. This PR updates the octokit upgrade job to use that email.

fyi @ericsciple