### PR TITLE
Fix bug downloading large files with the Azure SDK

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -15,3 +15,6 @@
 - Displays download progress
 - Includes changes that break compatibility with earlier versions, including:
   - `retry`, `retryTypedResponse`, and `retryHttpClientResponse` moved from `cacheHttpClient` to `requestUtils`
+
+### 1.0.1
+- Fix bug in downloading large files (> 2 GBs) with the Azure SDK

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -216,28 +216,6 @@
         "form-data": "^3.0.0"
       }
     },
-    "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
-    },
-    "@types/react": {
-      "version": "16.9.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.38.tgz",
-      "integrity": "sha512-pHAeZbjjNRa/hxyNuLrvbxhhnKyKNiLC6I5fRF2Zr/t/S6zS41MiyzH4+c+1I9vVfvuRt1VS2Lodjr4ZWnxrdA==",
-      "requires": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
-      }
-    },
-    "@types/react-native": {
-      "version": "0.62.13",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.13.tgz",
-      "integrity": "sha512-hs4/tSABhcJx+J8pZhVoXHrOQD89WFmbs8QiDLNSA9zNrD46pityAuBWuwk1aMjPk9I3vC5ewkJroVRHgRIfdg==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/semver": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
@@ -297,11 +275,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "csstype": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/src/internal/downloadUtils.ts
+++ b/packages/cache/src/internal/downloadUtils.ts
@@ -249,15 +249,18 @@ export async function downloadCacheStorageSDK(
       downloadProgress.startDisplayTimer()
 
       while (!downloadProgress.isDone()) {
+        const segmentStart =
+          downloadProgress.segmentOffset + downloadProgress.segmentSize
+
         const segmentSize = Math.min(
           maxSegmentSize,
-          contentLength - downloadProgress.segmentOffset
+          contentLength - segmentStart
         )
 
         downloadProgress.nextSegment(segmentSize)
 
         const result = await client.downloadToBuffer(
-          downloadProgress.segmentOffset,
+          segmentStart,
           segmentSize,
           {
             concurrency: options.downloadConcurrency,


### PR DESCRIPTION
The `segmentSize` calculation was incorrect as it was using the start of the previous segment instead of the start of the current segment, resulting in `419` errors indicating the range is invalid.