### PR TITLE
Allow specifying arbitrary headers when downloading tools to the tool cache.

### DIFF
--- a/packages/tool-cache/__tests__/tool-cache.test.ts
+++ b/packages/tool-cache/__tests__/tool-cache.test.ts
@@ -763,6 +763,61 @@ describe('@actions/tool-cache', function() {
       expect(err.toString()).toContain('404')
     }
   })
+
+  it('supports authorization headers', async function() {
+    nock('http://example.com', {
+      reqheaders: {
+        authorization: 'token abc123'
+      }
+    })
+      .get('/some-file-that-needs-authorization')
+      .reply(200, undefined)
+
+    await tc.downloadTool(
+      'http://example.com/some-file-that-needs-authorization',
+      undefined,
+      'token abc123'
+    )
+  })
+
+  it('supports custom headers', async function() {
+    nock('http://example.com', {
+      reqheaders: {
+        accept: 'application/octet-stream'
+      }
+    })
+      .get('/some-file-that-needs-headers')
+      .reply(200, undefined)
+
+    await tc.downloadTool(
+      'http://example.com/some-file-that-needs-headers',
+      undefined,
+      undefined,
+      {
+        accept: 'application/octet-stream'
+      }
+    )
+  })
+
+  it('supports authorization and custom headers', async function() {
+    nock('http://example.com', {
+      reqheaders: {
+        accept: 'application/octet-stream',
+        authorization: 'token abc123'
+      }
+    })
+      .get('/some-file-that-needs-authorization-and-headers')
+      .reply(200, undefined)
+
+    await tc.downloadTool(
+      'http://example.com/some-file-that-needs-authorization-and-headers',
+      undefined,
+      'token abc123',
+      {
+        accept: 'application/octet-stream'
+      }
+    )
+  })
 })
 
 /**


### PR DESCRIPTION
This change allows specifying arbitrary headers when downloading items to the toolcache.

This is useful for some URLs that require things like a particular `Accept` header to be present to deliver the right content.