### PR TITLE
Better Artifact Telemetry + Increase Upload chunk size

### DIFF
--- a/packages/artifact/src/internal/config-variables.ts
+++ b/packages/artifact/src/internal/config-variables.ts
@@ -6,7 +6,7 @@ export function getUploadFileConcurrency(): number {
 // When uploading large files that can't be uploaded with a single http call, this controls
 // the chunk size that is used during upload
 export function getUploadChunkSize(): number {
-  return 4 * 1024 * 1024 // 4 MB Chunks
+  return 8 * 1024 * 1024 // 8 MB Chunks
 }
 
 // The maximum number of retries that can be attempted before an upload or download fails

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -27,7 +27,10 @@ export class DownloadHttpClient {
   private statusReporter: StatusReporter
 
   constructor() {
-    this.downloadHttpManager = new HttpManager(getDownloadFileConcurrency())
+    this.downloadHttpManager = new HttpManager(
+      getDownloadFileConcurrency(),
+      'actions/download-artifact'
+    )
     // downloads are usually significantly faster than uploads so display status information every second
     this.statusReporter = new StatusReporter(1000)
   }

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -29,7 +29,7 @@ export class DownloadHttpClient {
   constructor() {
     this.downloadHttpManager = new HttpManager(
       getDownloadFileConcurrency(),
-      'actions/download-artifact'
+      'actions/artifact-download'
     )
     // downloads are usually significantly faster than uploads so display status information every second
     this.statusReporter = new StatusReporter(1000)

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -29,7 +29,7 @@ export class DownloadHttpClient {
   constructor() {
     this.downloadHttpManager = new HttpManager(
       getDownloadFileConcurrency(),
-      'actions/artifact-download'
+      '@actions/artifact-download'
     )
     // downloads are usually significantly faster than uploads so display status information every second
     this.statusReporter = new StatusReporter(1000)

--- a/packages/artifact/src/internal/http-manager.ts
+++ b/packages/artifact/src/internal/http-manager.ts
@@ -6,12 +6,14 @@ import {createHttpClient} from './utils'
  */
 export class HttpManager {
   private clients: HttpClient[]
+  private userAgent: string
 
-  constructor(clientCount: number) {
+  constructor(clientCount: number, userAgent: string) {
     if (clientCount < 1) {
       throw new Error('There must be at least one client')
     }
-    this.clients = new Array(clientCount).fill(createHttpClient())
+    this.userAgent = userAgent
+    this.clients = new Array(clientCount).fill(createHttpClient(userAgent))
   }
 
   getClient(index: number): HttpClient {
@@ -22,7 +24,7 @@ export class HttpManager {
   // for more information see: https://github.com/actions/http-client/blob/04e5ad73cd3fd1f5610a32116b0759eddf6570d2/index.ts#L292
   disposeAndReplaceClient(index: number): void {
     this.clients[index].dispose()
-    this.clients[index] = createHttpClient()
+    this.clients[index] = createHttpClient(this.userAgent)
   }
 
   disposeAndReplaceAllClients(): void {

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -42,7 +42,10 @@ export class UploadHttpClient {
   private statusReporter: StatusReporter
 
   constructor() {
-    this.uploadHttpManager = new HttpManager(getUploadFileConcurrency())
+    this.uploadHttpManager = new HttpManager(
+      getUploadFileConcurrency(),
+      'actions/upload-artifact'
+    )
     this.statusReporter = new StatusReporter(10000)
   }
 

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -44,7 +44,7 @@ export class UploadHttpClient {
   constructor() {
     this.uploadHttpManager = new HttpManager(
       getUploadFileConcurrency(),
-      'actions/upload-artifact'
+      'actions/artifact-upload'
     )
     this.statusReporter = new StatusReporter(10000)
   }

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -44,7 +44,7 @@ export class UploadHttpClient {
   constructor() {
     this.uploadHttpManager = new HttpManager(
       getUploadFileConcurrency(),
-      'actions/artifact-upload'
+      '@actions/artifact-upload'
     )
     this.statusReporter = new StatusReporter(10000)
   }

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -204,8 +204,8 @@ export function getUploadHeaders(
   return requestOptions
 }
 
-export function createHttpClient(): HttpClient {
-  return new HttpClient('actions/artifact', [
+export function createHttpClient(userAgent: string): HttpClient {
+  return new HttpClient(userAgent, [
     new BearerCredentialHandler(getRuntimeToken())
   ])
 }


### PR DESCRIPTION
When making any http calls during artifact upload or download, the user-agent string can be used to help differentiate between http-calls that get logged as part of internal telemetry. This PR changes the user-agent string to `@actions/artifact-upload` for any call that gets made during artifact upload and `@actions/artifact-download` for any call that gets made during download.

I really wanted to leverage the package version from `package.json` and then have the user-agent string be something like `@actions/artifact-0.3.2-upload` however there are a host of issues reading the version number from `package.json` since it's not included in the `rootDir` folder. More information here: https://stackoverflow.com/a/53836076

I'm also bumping up the upload chunk size from 4MB to 8MB to help improve artifact upload in GHES scenarios

