### PR TITLE
Prefer using GNU tar

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -21,3 +21,6 @@
 
 ### 1.0.2
 - Use posix archive format to add support for some tools
+
+### 1.0.3
+- Prefer use of GNU tar to avoid junction point and zstd compression issues on Windows

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -35,9 +35,7 @@
       }
     },
     "@actions/io": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
-      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
+      "version": "1.0.3"
     },
     "@azure/abort-controller": {
       "version": "1.0.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [
@@ -41,7 +41,7 @@
     "@actions/exec": "^1.0.1",
     "@actions/glob": "^0.1.0",
     "@actions/http-client": "^1.0.8",
-    "@actions/io": "^1.0.1",
+    "@actions/io": "^1.0.3",
     "@azure/ms-rest-js": "^2.0.7",
     "@azure/storage-blob": "^12.1.2",
     "semver": "^6.1.0",

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -64,7 +64,7 @@ async function getVersion(app: string): Promise<string> {
   core.debug(`Checking ${app} --version`)
   let versionOutput = ''
   try {
-    await exec.exec(`${app} --version`, [], {
+    await exec.exec(`"${app}" --version`, [], {
       ignoreReturnCode: true,
       silent: true,
       listeners: {
@@ -109,9 +109,26 @@ export function getCacheFileName(compressionMethod: CompressionMethod): string {
     : CacheFilename.Zstd
 }
 
+export async function findGnuTar(): Promise<string> {
+  const tarPaths: string[] = await io.findInPath('tar')
+
+  if (tarPaths) {
+    for (const tarPath of tarPaths) {
+      const versionOutput = await getVersion(tarPath)
+
+      if (versionOutput.toLowerCase().includes('gnu tar')) {
+        core.debug(`Found GNU tar at ${tarPath}`)
+        return tarPath
+      }
+    }
+  }
+
+  return ''
+}
+
 export async function isGnuTarInstalled(): Promise<boolean> {
-  const versionOutput = await getVersion('tar')
-  return versionOutput.toLowerCase().includes('gnu tar')
+  const tarPath = await findGnuTar()
+  return tarPath !== null && tarPath !== ''
 }
 
 export function assertDefined<T>(name: string, value?: T): T {

--- a/packages/io/RELEASES.md
+++ b/packages/io/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/io Releases
 
+### 1.0.3
+
+- Adds `findInPath` method to locate all matching executables in the system path
+
 ### 1.0.2
 
 - [Add \"types\" to package.json](https://github.com/actions/toolkit/pull/221)

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/io",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Actions io lib",
   "keywords": [
     "github",

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -173,10 +173,6 @@ export async function mkdirP(fsPath: string): Promise<void> {
  * @returns   Promise<string>   path to tool
  */
 export async function which(tool: string, check?: boolean): Promise<string> {
-  if (!tool) {
-    throw new Error("parameter 'tool' is required")
-  }
-
   // recursive when check=true
   if (check) {
     const result: string = await which(tool, false)
@@ -192,69 +188,89 @@ export async function which(tool: string, check?: boolean): Promise<string> {
         )
       }
     }
+
+    return result
   }
 
   try {
-    // build the list of extensions to try
-    const extensions: string[] = []
-    if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-      for (const extension of process.env.PATHEXT.split(path.delimiter)) {
-        if (extension) {
-          extensions.push(extension)
-        }
-      }
-    }
+    const matches: string[] = await findInPath(tool)
 
-    // if it's rooted, return it if exists. otherwise return empty.
-    if (ioUtil.isRooted(tool)) {
-      const filePath: string = await ioUtil.tryGetExecutablePath(
-        tool,
-        extensions
-      )
-
-      if (filePath) {
-        return filePath
-      }
-
-      return ''
-    }
-
-    // if any path separators, return empty
-    if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
-      return ''
-    }
-
-    // build the list of directories
-    //
-    // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
-    // it feels like we should not do this. Checking the current directory seems like more of a use
-    // case of a shell, and the which() function exposed by the toolkit should strive for consistency
-    // across platforms.
-    const directories: string[] = []
-
-    if (process.env.PATH) {
-      for (const p of process.env.PATH.split(path.delimiter)) {
-        if (p) {
-          directories.push(p)
-        }
-      }
-    }
-
-    // return the first match
-    for (const directory of directories) {
-      const filePath = await ioUtil.tryGetExecutablePath(
-        directory + path.sep + tool,
-        extensions
-      )
-      if (filePath) {
-        return filePath
-      }
+    if (matches && matches.length > 0) {
+      return matches[0]
     }
 
     return ''
   } catch (err) {
     throw new Error(`which failed with message ${err.message}`)
   }
+}
+
+/**
+ * Returns a list of all occurrences of the given tool on the system path.
+ *
+ * @returns   Promise<string[]>  the paths of the tool
+ */
+export async function findInPath(tool: string): Promise<string[]> {
+  if (!tool) {
+    throw new Error("parameter 'tool' is required")
+  }
+
+  // build the list of extensions to try
+  const extensions: string[] = []
+  if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+    for (const extension of process.env.PATHEXT.split(path.delimiter)) {
+      if (extension) {
+        extensions.push(extension)
+      }
+    }
+  }
+
+  // if it's rooted, return it if exists. otherwise return empty.
+  if (ioUtil.isRooted(tool)) {
+    const filePath: string = await ioUtil.tryGetExecutablePath(tool, extensions)
+
+    if (filePath) {
+      return [filePath]
+    }
+
+    return []
+  }
+
+  // if any path separators, return empty
+  if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
+    return []
+  }
+
+  // build the list of directories
+  //
+  // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
+  // it feels like we should not do this. Checking the current directory seems like more of a use
+  // case of a shell, and the which() function exposed by the toolkit should strive for consistency
+  // across platforms.
+  const directories: string[] = []
+
+  if (process.env.PATH) {
+    for (const p of process.env.PATH.split(path.delimiter)) {
+      if (p) {
+        directories.push(p)
+      }
+    }
+  }
+
+  // find all matches
+  const matches: string[] = []
+
+  for (const directory of directories) {
+    const filePath = await ioUtil.tryGetExecutablePath(
+      directory + path.sep + tool,
+      extensions
+    )
+    if (filePath) {
+      matches.push(filePath)
+    }
+  }
+
+  return matches
 }
 
 function readCopyOptions(options: CopyOptions): Required<CopyOptions> {


### PR DESCRIPTION
Fixes a variety of [actions/cache](https://github.com/actions/cache) issues related to differences between BSD and GNU tar.

The old `which` function already scanned the system path for the executable, but would return the first hit.  This change moves most of this functionality into a new method, `findInPath`, which will return a list of all matches on the system path.  This allows the cache module to scan all available `tar` implementations to find GNU tar.

Fixes https://github.com/actions/toolkit/issues/552
Fixes https://github.com/actions/cache/issues/362 - OS-agnostic caches miss on Windows due to different compression (caused by zstd issue)
Fixes https://github.com/actions/cache/issues/315 - infinite recursion in `bsdtar` caused by junction points on windows
Fixes https://github.com/actions/cache/issues/301 - `zstd` hangs when used with `bsdtar`
