### PR TITLE
Switch extractZipNix to use the -n

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -360,7 +360,7 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
 
 async function extractZipNix(file: string, dest: string): Promise<void> {
   const unzipPath = await io.which('unzip', true)
-  const args = [file, '-n']
+  const args = ['-n', file]
   if (!core.isDebug()) {
     args.unshift('-q')
   }

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -360,7 +360,7 @@ async function extractZipWin(file: string, dest: string): Promise<void> {
 
 async function extractZipNix(file: string, dest: string): Promise<void> {
   const unzipPath = await io.which('unzip', true)
-  const args = [file]
+  const args = [file, '-n']
   if (!core.isDebug()) {
     args.unshift('-q')
   }


### PR DESCRIPTION
Without expressing a preference on whether to overwrite a file or not, unzip, by default, will prompt for user input on what it should do. Causing any CI actions that use this function to timeout, which is undesirable.

This causes issues in actions upstream such as https://github.com/actions-rs/install/issues/6

There is only two ways to change unzip's default and that is with `-n` and `-o` respectively, `-n` would probably be the preferred default, as otherwise, files may be unintentionally overwritten.

-----

Another approach to solving this problem would be to allow callers of `extractZip` to specify how they want to treat existing files, however that would require a change to the functions signature, as well as making more difficult to maintain two different platform behaviors.

(extract on what the options do from the unzip man page)
```
-n

never overwrite existing files. If a file already exists, skip the extraction of that file without prompting. By default unzip queries before extracting any file that already exists; the user may choose to overwrite only the current file, overwrite all files, skip extraction of the current file, skip extraction of all existing files, or rename the current file.
-o

overwrite existing files without prompting. This is a dangerous option, so use it with care. (It is often used with -f, however, and is the only way to overwrite directory EAs under OS/2.) 
```