### PR TITLE
Add an option to specify retention days for artifacts

### DIFF
--- a/packages/artifact/README.md
+++ b/packages/artifact/README.md
@@ -39,6 +39,10 @@ Method Name: `uploadArtifact`
     - If set to `false`, and an error is encountered, all other uploads will stop and any files that were queued will not be attempted to be uploaded. The partial artifact available will only include files up until the failure.
     - If set to `true` and an error is encountered, the failed file will be skipped and ignored and all other queued files will be attempted to be uploaded. There will be an artifact available for download at the end with everything excluding the file that failed to upload
     - Optional, defaults to `true` if not specified
+- `retentionDays`
+    - Durantion after which artifact will expire in days
+    - Minimum value: 1
+    - Maximum value: 90 unless changed by settings
 
 #### Example using Absolute File Paths
 

--- a/packages/artifact/README.md
+++ b/packages/artifact/README.md
@@ -43,7 +43,7 @@ Method Name: `uploadArtifact`
     - Duration after which artifact will expire in days
     - Minimum value: 1
     - Maximum value: 90 unless changed by repository setting
-    - If this is set to a greater value than the retention settings allowed, the retention on artifacts will be reduced to match the max value allowed on server, and the upload process will continue. An input of 0 assumes default retention value.
+    - If this is set to a greater value than the retention settings allowed, the retention on artifacts will be reduced to match the max value allowed on the server, and the upload process will continue. An input of 0 assumes default retention value.
 
 #### Example using Absolute File Paths
 

--- a/packages/artifact/README.md
+++ b/packages/artifact/README.md
@@ -40,9 +40,10 @@ Method Name: `uploadArtifact`
     - If set to `true` and an error is encountered, the failed file will be skipped and ignored and all other queued files will be attempted to be uploaded. There will be an artifact available for download at the end with everything excluding the file that failed to upload
     - Optional, defaults to `true` if not specified
 - `retentionDays`
-    - Durantion after which artifact will expire in days
+    - Duration after which artifact will expire in days
     - Minimum value: 1
-    - Maximum value: 90 unless changed by settings
+    - Maximum value: 90 unless changed by repository setting
+    - If this is set to a greater value than the retention settings allowed, the retention on artifacts will be reduced to match the max value allowed on server, and the upload process will continue. An input of 0 assumes default retention value.
 
 #### Example using Absolute File Paths
 

--- a/packages/artifact/__tests__/upload.test.ts
+++ b/packages/artifact/__tests__/upload.test.ts
@@ -108,7 +108,7 @@ describe('Upload Tests', () => {
   })
 
   it('Create Artifact - Retention Less Than Min Value Error', async () => {
-    const artifactName = 'invalid-artifact-name'
+    const artifactName = 'valid-artifact-name'
     const options: UploadOptions = {
       retentionDays: -1
     }

--- a/packages/artifact/__tests__/upload.test.ts
+++ b/packages/artifact/__tests__/upload.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/internal/contracts'
 import {UploadSpecification} from '../src/internal/upload-specification'
 import {getArtifactUrl} from '../src/internal/utils'
+import {UploadOptions} from '../src/internal/upload-options'
 
 const root = path.join(__dirname, '_temp', 'artifact-upload')
 const file1Path = path.join(root, 'file1.txt')
@@ -104,6 +105,17 @@ describe('Upload Tests', () => {
         `Unable to create a container for the artifact invalid-artifact-name at ${getArtifactUrl()}`
       )
     )
+  })
+
+  it('Create Artifact - Retention Less Than Min Value Error', async () => {
+    const artifactName = 'invalid-artifact-name'
+    const options: UploadOptions = {
+      retentionDays: -1
+    }
+    const uploadHttpClient = new UploadHttpClient()
+    expect(
+      uploadHttpClient.createArtifactInFileContainer(artifactName, options)
+    ).rejects.toEqual(new Error('Invalid retention, minimum value is 1.'))
   })
 
   it('Create Artifact - Storage Quota Error', async () => {

--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -106,6 +106,20 @@ describe('Utils', () => {
     }
   })
 
+  it('Test negative artifact retention throws', () => {
+    expect(() => {
+      utils.getProperRetention(-1, undefined)
+    }).toThrow()
+  })
+
+  it('Test no setting specified take artifact retention inpput', () => {
+    expect(utils.getProperRetention(180, undefined)).toEqual(180)
+  })
+
+  it('Test artifact retention must conform to max allowed', () => {
+    expect(utils.getProperRetention(180, '45')).toEqual(45)
+  })
+
   it('Test constructing artifact URL', () => {
     const runtimeUrl = getRuntimeUrl()
     const runId = getWorkFlowRunId()

--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -112,7 +112,7 @@ describe('Utils', () => {
     }).toThrow()
   })
 
-  it('Test no setting specified take artifact retention inpput', () => {
+  it('Test no setting specified takes artifact retention input', () => {
     expect(utils.getProperRetention(180, undefined)).toEqual(180)
   })
 

--- a/packages/artifact/src/internal/__mocks__/config-variables.ts
+++ b/packages/artifact/src/internal/__mocks__/config-variables.ts
@@ -45,3 +45,7 @@ export function getRuntimeUrl(): string {
 export function getWorkFlowRunId(): string {
   return '15'
 }
+
+export function getRetentionDays(): string | undefined {
+  return '45'
+}

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -94,7 +94,8 @@ export class DefaultArtifactClient implements ArtifactClient {
     } else {
       // Create an entry for the artifact in the file container
       const response = await uploadHttpClient.createArtifactInFileContainer(
-        name
+        name,
+        options
       )
       if (!response.fileContainerResourceUrl) {
         core.debug(response.toString())

--- a/packages/artifact/src/internal/config-variables.ts
+++ b/packages/artifact/src/internal/config-variables.ts
@@ -1,5 +1,3 @@
-import { countReset } from "console"
-
 // The number of concurrent uploads that happens at the same time
 export function getUploadFileConcurrency(): number {
   return 2
@@ -65,5 +63,5 @@ export function getWorkSpaceDirectory(): string {
 }
 
 export function getRetentionDays(): string | undefined {
-  return process.env['GITHUB_RETENTION_DAYS'] 
+  return process.env['GITHUB_RETENTION_DAYS']
 }

--- a/packages/artifact/src/internal/config-variables.ts
+++ b/packages/artifact/src/internal/config-variables.ts
@@ -1,3 +1,5 @@
+import { countReset } from "console"
+
 // The number of concurrent uploads that happens at the same time
 export function getUploadFileConcurrency(): number {
   return 2
@@ -60,4 +62,8 @@ export function getWorkSpaceDirectory(): string {
     throw new Error('Unable to get GITHUB_WORKSPACE env variable')
   }
   return workspaceDirectory
+}
+
+export function getRetentionDays(): string | undefined {
+  return process.env['GITHUB_RETENTION_DAYS'] 
 }

--- a/packages/artifact/src/internal/contracts.ts
+++ b/packages/artifact/src/internal/contracts.ts
@@ -11,6 +11,7 @@ export interface ArtifactResponse {
 export interface CreateArtifactParameters {
   Type: string
   Name: string
+  RetentionDays?: number
 }
 
 export interface PatchArtifactSize {

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -66,15 +66,18 @@ export class UploadHttpClient {
 
     // calculate retention period
     if (options && options.retentionDays) {
-      var retention = options.retentionDays;
-      const maxRetentionStr = getRetentionDays();
+      let retention = options.retentionDays
+      const maxRetentionStr = getRetentionDays()
       if (maxRetentionStr) {
-        const maxRetentions = parseInt(maxRetentionStr);
-        if (!isNaN(maxRetentions) && maxRetentions < retention) {
-          core.warning(`Retention days is greater than max value allowed by repository setting, reduce retention to ${maxRetentions} days`);
+        const maxRetention = parseInt(maxRetentionStr)
+        if (!isNaN(maxRetention) && maxRetention < retention) {
+          core.warning(
+            `Retention days is greater than max value allowed by repository setting, reduce retention to ${maxRetention} days`
+          )
+          retention = maxRetention
         }
       }
-      parameters.RetentionDays = retention;
+      parameters.RetentionDays = retention
     }
 
     const data: string = JSON.stringify(parameters, null, 2)

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -18,7 +18,8 @@ import {
   isForbiddenStatusCode,
   displayHttpDiagnostics,
   getExponentialRetryTimeInMilliseconds,
-  tryGetRetryAfterValueTimeInMilliseconds
+  tryGetRetryAfterValueTimeInMilliseconds,
+  getProperRetention
 } from './utils'
 import {
   getUploadChunkSize,
@@ -66,18 +67,11 @@ export class UploadHttpClient {
 
     // calculate retention period
     if (options && options.retentionDays) {
-      let retention = options.retentionDays
       const maxRetentionStr = getRetentionDays()
-      if (maxRetentionStr) {
-        const maxRetention = parseInt(maxRetentionStr)
-        if (!isNaN(maxRetention) && maxRetention < retention) {
-          core.warning(
-            `Retention days is greater than max value allowed by repository setting, reduce retention to ${maxRetention} days`
-          )
-          retention = maxRetention
-        }
-      }
-      parameters.RetentionDays = retention
+      parameters.RetentionDays = getProperRetention(
+        options.retentionDays,
+        maxRetentionStr
+      )
     }
 
     const data: string = JSON.stringify(parameters, null, 2)

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -55,12 +55,19 @@ export class UploadHttpClient {
    * @returns The response from the Artifact Service if the file container was successfully created
    */
   async createArtifactInFileContainer(
-    artifactName: string
+    artifactName: string,
+    options?: UploadOptions | undefined
   ): Promise<ArtifactResponse> {
     const parameters: CreateArtifactParameters = {
       Type: 'actions_storage',
       Name: artifactName
     }
+
+    // calculate retention period
+    if (options && options.retentionDays) {
+      parameters.RetentionDays = options.retentionDays
+    }
+
     const data: string = JSON.stringify(parameters, null, 2)
     const artifactUrl = getArtifactUrl()
 

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -23,7 +23,8 @@ import {
 import {
   getUploadChunkSize,
   getUploadFileConcurrency,
-  getRetryLimit
+  getRetryLimit,
+  getRetentionDays
 } from './config-variables'
 import {promisify} from 'util'
 import {URL} from 'url'
@@ -65,7 +66,15 @@ export class UploadHttpClient {
 
     // calculate retention period
     if (options && options.retentionDays) {
-      parameters.RetentionDays = options.retentionDays
+      var retention = options.retentionDays;
+      const maxRetentionStr = getRetentionDays();
+      if (maxRetentionStr) {
+        const maxRetentions = parseInt(maxRetentionStr);
+        if (!isNaN(maxRetentions) && maxRetentions < retention) {
+          core.warning(`Retention days is greater than max value allowed by repository setting, reduce retention to ${maxRetentions} days`);
+        }
+      }
+      parameters.RetentionDays = retention;
     }
 
     const data: string = JSON.stringify(parameters, null, 2)

--- a/packages/artifact/src/internal/upload-options.ts
+++ b/packages/artifact/src/internal/upload-options.ts
@@ -15,4 +15,22 @@ export interface UploadOptions {
    *
    */
   continueOnError?: boolean
+
+  /**
+   * Durantion after which artifact will expire in days.
+   *
+   * By default artifact expires after 90 days:
+   * https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#downloading-and-deleting-artifacts-after-a-workflow-run-is-complete
+   *
+   * Use this option to override the default expiry.
+   *
+   * Min value: 1
+   * Max value: 90 unless changed by repository setting
+   *
+   * If this is set to a greater value than the retention settings allowed, the retention on artifacts
+   * will be reduced to match the max value allowed on server, and the upload process will continue. An
+   * input of 0 assumes default retention setting.
+   */
+
+  retentionDays?: number
 }

--- a/packages/artifact/src/internal/upload-options.ts
+++ b/packages/artifact/src/internal/upload-options.ts
@@ -17,7 +17,7 @@ export interface UploadOptions {
   continueOnError?: boolean
 
   /**
-   * Durantion after which artifact will expire in days.
+   * Duration after which artifact will expire in days.
    *
    * By default artifact expires after 90 days:
    * https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#downloading-and-deleting-artifacts-after-a-workflow-run-is-complete
@@ -31,6 +31,5 @@ export interface UploadOptions {
    * will be reduced to match the max value allowed on server, and the upload process will continue. An
    * input of 0 assumes default retention setting.
    */
-
   retentionDays?: number
 }

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -1,4 +1,4 @@
-import {debug, info} from '@actions/core'
+import {debug, info, warning} from '@actions/core'
 import {promises as fs} from 'fs'
 import {HttpCodes, HttpClient} from '@actions/http-client'
 import {BearerCredentialHandler} from '@actions/http-client/auth'
@@ -301,4 +301,25 @@ export async function createEmptyFilesForArtifact(
   for (const filePath of emptyFilesToCreate) {
     await (await fs.open(filePath, 'w')).close()
   }
+}
+
+export function getProperRetention(
+  retentionInput: number,
+  retentionSetting: string | undefined
+): number {
+  if (retentionInput < 0) {
+    throw new Error('Invalid retention, minimum value is 1.')
+  }
+
+  let retention = retentionInput
+  if (retentionSetting) {
+    const maxRetention = parseInt(retentionSetting)
+    if (!isNaN(maxRetention) && maxRetention < retention) {
+      warning(
+        `Retention days is greater than max value allowed by the repository setting, reduce retention to ${maxRetention} days`
+      )
+      retention = maxRetention
+    }
+  }
+  return retention
 }

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -316,7 +316,7 @@ export function getProperRetention(
     const maxRetention = parseInt(retentionSetting)
     if (!isNaN(maxRetention) && maxRetention < retention) {
       warning(
-        `Retention days is greater than max value allowed by the repository setting, reduce retention to ${maxRetention} days`
+        `Retention days is greater than the max value allowed by the repository setting, reduce retention to ${maxRetention} days`
       )
       retention = maxRetention
     }


### PR DESCRIPTION
Introducing an option to reduce the default retention period for uploaded artifacts.

Today all artifacts have a 90 days retention value and there is no knob to reduce the value.  We are revamping the experience so we can set custom expiry on individual artifact.

The new minimum value is `1` day.  
 