### PR TITLE
Pass correct working directory from `cache` to `glob`.

### DIFF
--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -39,12 +39,20 @@ export function getArchiveFileSizeIsBytes(filePath: string): number {
   return fs.statSync(filePath).size
 }
 
+export function getWorkingDirectory(): string {
+  return process.env['GITHUB_WORKSPACE'] ?? process.cwd()
+}
+
 export async function resolvePaths(patterns: string[]): Promise<string[]> {
   const paths: string[] = []
-  const workspace = process.env['GITHUB_WORKSPACE'] ?? process.cwd()
-  const globber = await glob.create(patterns.join('\n'), {
-    implicitDescendants: false
-  })
+  const workspace = getWorkingDirectory()
+  const globber = await glob.create(
+    patterns.join('\n'),
+    {
+      implicitDescendants: false
+    },
+    workspace
+  )
 
   for await (const file of globber.globGenerator()) {
     const relativeFile = path.relative(workspace, file)

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -37,16 +37,12 @@ async function execTar(
   }
 }
 
-function getWorkingDirectory(): string {
-  return process.env['GITHUB_WORKSPACE'] ?? process.cwd()
-}
-
 export async function extractTar(
   archivePath: string,
   compressionMethod: CompressionMethod
 ): Promise<void> {
   // Create directory to extract tar into
-  const workingDirectory = getWorkingDirectory()
+  const workingDirectory = utils.getWorkingDirectory()
   await io.mkdirP(workingDirectory)
   // --d: Decompress.
   // --long=#: Enables long distance matching with # bits. Maximum is 30 (1GB) on 32-bit OS and 31 (2GB) on 64-bit.
@@ -84,7 +80,7 @@ export async function createTar(
     path.join(archiveFolder, manifestFilename),
     sourceDirectories.join('\n')
   )
-  const workingDirectory = getWorkingDirectory()
+  const workingDirectory = utils.getWorkingDirectory()
 
   // -T#: Compress using # working thread. If # is 0, attempt to detect and use the number of physical CPU cores.
   // --long=#: Enables long distance matching with # bits. Maximum is 30 (1GB) on 32-bit OS and 31 (2GB) on 64-bit.

--- a/packages/glob/src/glob.ts
+++ b/packages/glob/src/glob.ts
@@ -11,7 +11,8 @@ export {Globber, GlobOptions}
  */
 export async function create(
   patterns: string,
-  options?: GlobOptions
+  options?: GlobOptions,
+  workdir?: string
 ): Promise<Globber> {
-  return await DefaultGlobber.create(patterns, options)
+  return await DefaultGlobber.create(patterns, options, workdir)
 }

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -77,7 +77,12 @@ export class DefaultGlobber implements Globber {
           pattern.segments[pattern.segments.length - 1] !== '**')
       ) {
         patterns.push(
-          new Pattern(pattern.negate, pattern.segments.concat('**'))
+          new Pattern(
+            pattern.negate,
+            pattern.segments.concat('**'),
+            pattern.homedir,
+            pattern.workdir
+          )
         )
       }
     }
@@ -158,7 +163,8 @@ export class DefaultGlobber implements Globber {
    */
   static async create(
     patterns: string,
-    options?: GlobOptions
+    options?: GlobOptions,
+    workdir?: string
   ): Promise<DefaultGlobber> {
     const result = new DefaultGlobber(options)
 
@@ -175,7 +181,7 @@ export class DefaultGlobber implements Globber {
       }
       // Pattern
       else {
-        result.patterns.push(new Pattern(line))
+        result.patterns.push(new Pattern(line, undefined, undefined, workdir))
       }
     }
 


### PR DESCRIPTION
For testing Homebrew, we are re-using the Homebrew installation already present on the worker machines. For this we replace `GITHUB_WORKSPACE` with a symlink to the Homebrew installation.

This leads to the case where `GITHUB_WORKSPACE` is different from the current working directory, which breaks caching because the cache is created relative to the `GITHUB_WORKSPACE`, however the globbed paths are always relative to the current working directory.

This pull request ensures that globbed paths are also relative to `GITHUB_WORKSPACE` in the `cache` action.