### PR TITLE
Documentation around colored output in logs

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,6 +113,61 @@ const result = await core.group('Do something async', async () => {
 })
 ```
 
+#### Styling output
+
+Colored output is supported in the Action logs via standard [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code). 3/4 bit, 8 bit and 24 bit colors are all supported.
+
+Foreground colors:
+```js
+// 3/4 bit
+core.info('\u001b[35mThis foreground will be magenta')
+
+// 8 bit
+core.info('\u001b[38;5;6mThis foreground will be cyan')
+
+// 24 bit
+core.info('\u001b[38;2;255;0;0mThis foreground will be bright red')
+```
+
+Background colors:
+```js
+// 3/4 bit
+core.info('\u001b[43mThis background will be yellow');
+
+// 8 bit
+core.info('\u001b[48;5;6mThis background will be cyan')
+
+// 24 bit
+core.info('\u001b[48;2;255;0;0mThis background will be bright red')
+```
+
+Special styles:
+
+```js
+core.info('\u001b[1mBold text')
+core.info('\u001b[3mItalic text')
+core.info('\u001b[4mUnderlined text')
+```
+
+ANSI escape codes can be combined with one another:
+
+```js
+core.info('\u001b[31;46mRed foreground with a cyan background and \u001b[1mbold text at the end');
+```
+
+> Note: Escape codes reset at the start of each line
+```js
+core.info('\u001b[35mThis foreground will be magenta')
+core.info('This foreground will reset to the default')
+```
+
+Manually typing escape codes can be a little difficult, but you can use third party modules such as [ansi-styles](https://github.com/chalk/ansi-styles).
+
+```js
+const style = require('ansi-styles');
+core.info(style.color.ansi16m.hex('#abcdef') + 'Hello world!')
+```
+
 #### Action state
 
 You can use this library to save state and get state for sharing information between a given wrapper action: 


### PR DESCRIPTION
Resolves: https://github.com/github/c2c-actions-service/issues/1402

Improvements to action logs are now out for everyone! 
https://github.blog/changelog/2020-09-23-github-actions-log-improvements/

One of the new features is proper support for 3/4 bit, 8 bit and 24 bit color. Action authors should have information about how to use this.

This PR adds some documentation to the `core` package README. There is some existing documentation about logging so this felt like the most logical place to add this new information. Colored output works with the normal `console.log` method, but it's best to document it with our `core.info` method.

🖌[Rendered](https://github.com/actions/toolkit/blob/konradpabjan/logs-color-documentation/packages/core/README.md#styling-output) 🖼

There are a bunch of NPM packages that can be used to assist with this, but I intentionally choose to document the raw ANSI codes. Towards the end I call out one NPM package that I tested and have found to work pretty well. Some popular ones such as [chalk](https://github.com/chalk/chalk) don't work because of how they handle string prototypes.

## Testing

![image](https://user-images.githubusercontent.com/16109154/94073704-33bd9280-fdf8-11ea-9efd-cd150053beb0.png)
