### PR TITLE
README: Move setNeutral remark out of code block

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,10 +62,9 @@ catch (err) {
   // setFailed logs the message and sets a failing exit code
   core.setFailed(`Action failed with error ${err}`);
 }
-
-Note that `setNeutral` is not yet implemented in actions V2 but equivalent functionality is being planned.
-
 ```
+
+Note that `setNeutral` is not yet implemented in actions v2 but equivalent functionality is being planned.
 
 #### Logging
 


### PR DESCRIPTION
Looks like this was unintentional