### PR TITLE
doc: commands: add missing assignment char

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ steps:
   - name: Set the value
     id: step_one
     run: |
-        echo 'JSON_RESPONSE<<EOF' >> $GITHUB_ENV
+        echo 'JSON_RESPONSE=<<EOF' >> $GITHUB_ENV
         curl https://httpbin.org/json >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
 ```


### PR DESCRIPTION
this seemed like an error:

executing the snipped like:
```sh
GITHUB_ENV=/tmp/GITHUB_ENV

echo 'JSON_RESPONSE<<EOF' >> $GITHUB_ENV
curl https://httpbin.org/json >> $GITHUB_ENV
echo 'EOF' >> $GITHUB_ENV
```

produced output:

```
$ cat /tmp/GITHUB_ENV
JSON_RESPONSE<<EOF
{
  "slideshow": {
    "author": "Yours Truly",
    "date": "date of publication",
    "slides": [
      {
        "title": "Wake up to WonderWidgets!",
        "type": "all"
      },
      {
        "items": [
          "Why <em>WonderWidgets</em> are great",
          "Who <em>buys</em> WonderWidgets"
        ],
        "title": "Overview",
        "type": "all"
      }
    ],
    "title": "Sample Slide Show"
  }
}
EOF
```

while I think it should be `JSON_RESPONSE=<EOF`.
