### PR TITLE
Handle non-successful responses from uploadChunk

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -26,3 +26,7 @@
 - Use http-client v1.0.9
 - Fixes error handling so retries are not attempted on non-retryable errors (409 Conflict, for example)
 - Adds 5 second delay between retry attempts
+
+### 1.0.4
+- Use @actions/core v1.2.6
+- Fixes uploadChunk to throw an error if any unsuccessful response code is received

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@actions/cache",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/exec": {
       "version": "1.0.4",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [
@@ -37,7 +37,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.1",
     "@actions/glob": "^0.1.0",
     "@actions/http-client": "^1.0.9",

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -194,7 +194,7 @@ async function uploadChunk(
     'Content-Range': getContentRange(start, end)
   }
 
-  await retryHttpClientResponse(
+  const uploadChunkResponse = await retryHttpClientResponse(
     `uploadChunk (start: ${start}, end: ${end})`,
     async () =>
       httpClient.sendStream(
@@ -204,6 +204,12 @@ async function uploadChunk(
         additionalHeaders
       )
   )
+
+  if (!isSuccessStatusCode(uploadChunkResponse.message.statusCode)) {
+    throw new Error(
+      `Cache service responded with ${uploadChunkResponse.message.statusCode} during upload chunk.`
+    )
+  }
 }
 
 async function uploadFile(


### PR DESCRIPTION
`uploadChunk` is not handling non-successful status codes.  As a result, if the upload fails it will still try to seal the cache.  This ultimately fails, but is adding unnecessary calls to the service as well as creating noise in our telemetry.