### PR TITLE
Update to actions/core@1.2.6 in artifact, glob, and tool-cache packages

### DIFF
--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
-      "integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
+      "integrity": "sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==",
       "requires": {
         "tunnel": "0.0.6"
       }
@@ -111,9 +111,9 @@
       }
     },
     "tmp-promise": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
-      "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.1.1.tgz",
+      "integrity": "sha512-Z048AOz/w9b6lCbJUpevIJpRpUztENl8zdv1bmAKVHimfqRFl92ROkmT9rp7TVBnrEw2gtMTol/2Cp2S2kJa4Q==",
       "requires": {
         "tmp": "0.1.0"
       }
@@ -124,9 +124,9 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "wrappy": {

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -37,13 +37,13 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.1",
-    "@actions/http-client": "^1.0.7",
+    "@actions/core": "^1.2.6",
+    "@actions/http-client": "^1.0.9",
     "@types/tmp": "^0.1.0",
     "tmp": "^0.1.0",
-    "tmp-promise": "^2.0.2"
+    "tmp-promise": "^2.1.1"
   },
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.7"
   }
 }

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -4,6 +4,11 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@actions/core": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+			"integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.0",
+    "@actions/core": "^1.2.6",
     "minimatch": "^3.0.4"
   }
 }

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.3",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.0",
     "@actions/http-client": "^1.0.8",
     "@actions/io": "^1.0.1",


### PR DESCRIPTION
Avoid set-env or add-path blockage on… Nov 16... https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ https://github.com/actions/toolkit/issues/630

Note: cache depends on glob and should be fixed after glob is updated