### PR TITLE
Update @actions/core in remaining toolkit packages

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -41,3 +41,8 @@
 ### 0.4.0
 
 - Add option to specify custom retentions on artifacts
+
+### 0.4.1
+
+- Update to latest @actions/core version
+

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
-      "integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/http-client": {
       "version": "1.0.8",

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.1",
+    "@actions/core": "^1.2.6",
     "@actions/http-client": "^1.0.7",
     "@types/tmp": "^0.1.0",
     "tmp": "^0.1.0",

--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -3,3 +3,7 @@
 ### 0.1.0
 
 - Initial release
+
+### 0.1.1
+
+- Update @actions/core version

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -4,6 +4,11 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@actions/core": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+			"integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@actions/glob",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.0",
+    "@actions/core": "^1.2.6",
     "minimatch": "^3.0.4"
   }
 }

--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -1,7 +1,7 @@
 # @actions/tool-cache Releases
 
 ### 1.6.1
-- [Update @actions/core version](https://github.com/actions/toolkit/pull/207) 
+- [Update @actions/core version](https://github.com/actions/toolkit/pull/636) 
 
 ### 1.6.0
 - [Add extractXar function to extract XAR files](https://github.com/actions/toolkit/pull/207)

--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/tool-cache Releases
 
+### 1.6.1
+- [Update @actions/core version](https://github.com/actions/toolkit/pull/207) 
+
 ### 1.6.0
 - [Add extractXar function to extract XAR files](https://github.com/actions/toolkit/pull/207)
 

--- a/packages/tool-cache/package-lock.json
+++ b/packages/tool-cache/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@actions/core": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
-			"integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+			"integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
 		},
 		"@actions/exec": {
 			"version": "1.0.3",

--- a/packages/tool-cache/package-lock.json
+++ b/packages/tool-cache/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@actions/tool-cache",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/tool-cache",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Actions tool-cache lib",
   "keywords": [
     "github",

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.3",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.0",
     "@actions/http-client": "^1.0.8",
     "@actions/io": "^1.0.1",


### PR DESCRIPTION
Currently, none of the toolkit packages use the [commands that are being deprecated on November 16th](https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/).

However, they do include other versions of `@actions/core`, that contain that vulnerability even if they aren't invoking it. Let's update these packages to use the latest version.