### PR TITLE
Retry artifact download when response stream is truncated

### DIFF
--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -264,6 +264,12 @@ export class DownloadHttpClient {
         const gunzip = zlib.createGunzip()
         response.message
           .pipe(gunzip)
+          .on('error', error => {
+            core.error(
+              `An error has been encountered while attempting to decompress a file`
+            )
+            reject(error)
+          })
           .pipe(destinationStream)
           .on('close', () => {
             resolve()

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -263,12 +263,20 @@ export class DownloadHttpClient {
       if (isGzip) {
         const gunzip = zlib.createGunzip()
         response.message
+          .on('error', error => {
+            core.error(
+              `An error occurred while attempting to read the response stream`
+            )
+            reject(error)
+            gunzip.close()
+          })
           .pipe(gunzip)
           .on('error', error => {
             core.error(
-              `An error has been encountered while attempting to decompress a file`
+              `An error occurred while attempting to decompress the response stream`
             )
             reject(error)
+            destinationStream.close()
           })
           .pipe(destinationStream)
           .on('close', () => {
@@ -276,19 +284,26 @@ export class DownloadHttpClient {
           })
           .on('error', error => {
             core.error(
-              `An error has been encountered while decompressing and writing a downloaded file to ${destinationStream.path}`
+              `An error occurred while writing a downloaded file to ${destinationStream.path}`
             )
             reject(error)
           })
       } else {
         response.message
+          .on('error', error => {
+            core.error(
+              `An error occurred while attempting to read the response stream`
+            )
+            reject(error)
+            destinationStream.close()
+          })
           .pipe(destinationStream)
           .on('close', () => {
             resolve()
           })
           .on('error', error => {
             core.error(
-              `An error has been encountered while writing a downloaded file to ${destinationStream.path}`
+              `An error occurred while writing a downloaded file to ${destinationStream.path}`
             )
             reject(error)
           })


### PR DESCRIPTION
Retry the artifact download when gunzip fails or the response stream is truncated.

Closes https://github.com/actions/download-artifact/issues/53 and https://github.com/actions/download-artifact/issues/55

- [x] Add tests
- [ ] Fix runtime code
- [x] Merge https://github.com/actions/toolkit/pull/651 first, since this PR builds on top of it.