### PR TITLE
Retry artifact download when response stream is truncated (continued)

### DIFF
--- a/packages/artifact/__tests__/download.test.ts
+++ b/packages/artifact/__tests__/download.test.ts
@@ -196,7 +196,6 @@ describe('Download Tests', () => {
     const targetPath = path.join(root, 'FileD.txt')
 
     setupDownloadItemResponse(true, 200, true, fileContents, true)
-    setupThrowWhenReadingStream()
     const downloadHttpClient = new DownloadHttpClient()
 
     const items: DownloadItem[] = []
@@ -290,18 +289,6 @@ describe('Download Tests', () => {
         })
       })
     })
-  }
-
-  function setupThrowWhenReadingStream(): void {
-    jest
-      .spyOn(DownloadHttpClient.prototype, 'pipeResponseToFile')
-      .mockImplementationOnce(async () => {
-        return new Promise<void>(() => {
-          throw new Error(
-            'simulate GZip reading truncated buffer and throw Z_BUF_ERROR'
-          )
-        })
-      })
   }
 
   /**

--- a/packages/artifact/__tests__/download.test.ts
+++ b/packages/artifact/__tests__/download.test.ts
@@ -293,10 +293,10 @@ describe('Download Tests', () => {
   }
 
   function setupThrowWhenReadingStream(): void {
-    const spyInstance = jest
+    jest
       .spyOn(DownloadHttpClient.prototype, 'pipeResponseToFile')
       .mockImplementationOnce(async () => {
-        return new Promise<void>(resolve => {
+        return new Promise<void>(() => {
           throw new Error(
             'simulate GZip reading truncated buffer and throw Z_BUF_ERROR'
           )

--- a/packages/artifact/__tests__/download.test.ts
+++ b/packages/artifact/__tests__/download.test.ts
@@ -124,7 +124,7 @@ describe('Download Tests', () => {
     )
     const targetPath = path.join(root, 'FileA.txt')
 
-    setupDownloadItemResponse(true, 200, false, fileContents, false)
+    setupDownloadItemResponse(fileContents, true, 200, false, false)
     const downloadHttpClient = new DownloadHttpClient()
 
     const items: DownloadItem[] = []
@@ -147,7 +147,7 @@ describe('Download Tests', () => {
     )
     const targetPath = path.join(root, 'FileB.txt')
 
-    setupDownloadItemResponse(false, 200, false, fileContents, false)
+    setupDownloadItemResponse(fileContents, false, 200, false, false)
     const downloadHttpClient = new DownloadHttpClient()
 
     const items: DownloadItem[] = []
@@ -171,7 +171,7 @@ describe('Download Tests', () => {
       const fileContents = Buffer.from('try, try again\n', defaultEncoding)
       const targetPath = path.join(root, `FileC-${statusCode}.txt`)
 
-      setupDownloadItemResponse(false, statusCode, false, fileContents, true)
+      setupDownloadItemResponse(fileContents, false, statusCode, false, true)
       const downloadHttpClient = new DownloadHttpClient()
 
       const items: DownloadItem[] = []
@@ -195,7 +195,7 @@ describe('Download Tests', () => {
     )
     const targetPath = path.join(root, 'FileD.txt')
 
-    setupDownloadItemResponse(true, 200, true, fileContents, true)
+    setupDownloadItemResponse(fileContents, true, 200, true, true)
     const downloadHttpClient = new DownloadHttpClient()
 
     const items: DownloadItem[] = []
@@ -218,7 +218,7 @@ describe('Download Tests', () => {
     )
     const targetPath = path.join(root, 'FileE.txt')
 
-    setupDownloadItemResponse(false, 200, true, fileContents, true)
+    setupDownloadItemResponse(fileContents, false, 200, true, true)
     const downloadHttpClient = new DownloadHttpClient()
 
     const items: DownloadItem[] = []
@@ -297,10 +297,10 @@ describe('Download Tests', () => {
    * @param firstHttpResponseCode the http response code that should be returned
    */
   function setupDownloadItemResponse(
+    fileContents: Buffer,
     isGzip: boolean,
     firstHttpResponseCode: number,
     truncateFirstResponse: boolean,
-    fileContents: Buffer,
     retryExpected: boolean
   ): void {
     const spyInstance = jest

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -220,10 +220,10 @@ export class DownloadHttpClient {
     }
 
     const resetDestinationStream = async (
-      downloadPath: string
+      fileDownloadPath: string
     ): Promise<void> => {
-      await rmFile(downloadPath)
-      destinationStream = fs.createWriteStream(downloadPath)
+      await rmFile(fileDownloadPath)
+      destinationStream = fs.createWriteStream(fileDownloadPath)
     }
 
     // keep trying to download a file until a retry limit has been reached

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -213,11 +213,7 @@ export class DownloadHttpClient {
         !received ||
         process.env['ACTIONS_ARTIFACT_SKIP_DOWNLOAD_VALIDATION']
       ) {
-        if (process.env['ACTIONS_ARTIFACT_SKIP_DOWNLOAD_VALIDATION']) {
-          core.info(
-            'Skipping download validation since environment variable is set'
-          )
-        }
+        core.info('Skipping download validation.')
         return true
       }
 

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -315,16 +315,17 @@ export class DownloadHttpClient {
             core.error(
               `An error occurred while attempting to read the response stream`
             )
-            reject(error)
             gunzip.close()
+            destinationStream.close()
+            reject(error)
           })
           .pipe(gunzip)
           .on('error', error => {
             core.error(
               `An error occurred while attempting to decompress the response stream`
             )
-            reject(error)
             destinationStream.close()
+            reject(error)
           })
           .pipe(destinationStream)
           .on('close', () => {
@@ -342,8 +343,8 @@ export class DownloadHttpClient {
             core.error(
               `An error occurred while attempting to read the response stream`
             )
-            reject(error)
             destinationStream.close()
+            reject(error)
           })
           .pipe(destinationStream)
           .on('close', () => {

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -264,6 +264,12 @@ export class DownloadHttpClient {
         const gunzip = zlib.createGunzip()
         response.message
           .pipe(gunzip)
+          .on('error', error => {
+            core.error(
+              `An error has been encountered while attempting to decompress a file`
+            )
+            reject(error)
+          })
           .pipe(destinationStream)
           .on('close', () => {
             resolve()

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -213,6 +213,11 @@ export class DownloadHttpClient {
         !received ||
         process.env['ACTIONS_ARTIFACT_SKIP_DOWNLOAD_VALIDATION']
       ) {
+        if (process.env['ACTIONS_ARTIFACT_SKIP_DOWNLOAD_VALIDATION']) {
+          core.info(
+            'Skipping download validation since environment variable is set'
+          )
+        }
         return true
       }
 
@@ -231,6 +236,9 @@ export class DownloadHttpClient {
       let response: IHttpClientResponse
       try {
         response = await makeDownloadRequest()
+        if (core.isDebug()) {
+          displayHttpDiagnostics(response)
+        }
       } catch (error) {
         // if an error is caught, it is usually indicative of a timeout so retry the download
         core.info('An error occurred while attempting to download a file')

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -219,7 +219,9 @@ export class DownloadHttpClient {
       return parseInt(expected) === received
     }
 
-    const resetDestinationStream = async (downloadPath: string) => {
+    const resetDestinationStream = async (
+      downloadPath: string
+    ): Promise<void> => {
       await rmFile(downloadPath)
       destinationStream = fs.createWriteStream(downloadPath)
     }

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -263,12 +263,20 @@ export class DownloadHttpClient {
       if (isGzip) {
         const gunzip = zlib.createGunzip()
         response.message
+          .on('error', error => {
+            core.error(
+              `An error occurred while attempting to read the response stream`
+            )
+            reject(error)
+            gunzip.close()
+          })
           .pipe(gunzip)
           .on('error', error => {
             core.error(
-              `An error has been encountered while attempting to decompress a file`
+              `An error occurred while attempting to decompress the response stream`
             )
             reject(error)
+            destinationStream.close()
           })
           .pipe(destinationStream)
           .on('close', () => {
@@ -276,19 +284,26 @@ export class DownloadHttpClient {
           })
           .on('error', error => {
             core.error(
-              `An error has been encountered while decompressing and writing a downloaded file to ${destinationStream.path}`
+              `An error occurred while writing a downloaded file to ${destinationStream.path}`
             )
             reject(error)
           })
       } else {
         response.message
+          .on('error', error => {
+            core.error(
+              `An error occurred while attempting to read the response stream`
+            )
+            reject(error)
+            destinationStream.close()
+          })
           .pipe(destinationStream)
           .on('close', () => {
             resolve()
           })
           .on('error', error => {
             core.error(
-              `An error has been encountered while writing a downloaded file to ${destinationStream.path}`
+              `An error occurred while writing a downloaded file to ${destinationStream.path}`
             )
             reject(error)
           })

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -223,6 +223,7 @@ export class DownloadHttpClient {
     const resetDestinationStream = async (
       fileDownloadPath: string
     ): Promise<void> => {
+      destinationStream.close()
       await rmFile(fileDownloadPath)
       destinationStream = fs.createWriteStream(fileDownloadPath)
     }

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -305,6 +305,9 @@ export async function createEmptyFilesForArtifact(
 
 export async function getFileSize(filePath: string): Promise<number> {
   const stats = await fs.stat(filePath)
+  debug(
+    `${filePath} size:(${stats.size}) blksize:(${stats.blksize}) blocks:(${stats.blocks})`
+  )
   return stats.size
 }
 

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -303,6 +303,15 @@ export async function createEmptyFilesForArtifact(
   }
 }
 
+export async function getFileSize(filePath: string): Promise<number> {
+  const stats = await fs.stat(filePath)
+  return stats.size
+}
+
+export async function rmFile(filePath: string): Promise<void> {
+  await fs.unlink(filePath)
+}
+
 export function getProperRetention(
   retentionInput: number,
   retentionSetting: string | undefined


### PR DESCRIPTION
Continuation of https://github.com/actions/toolkit/pull/652

Closes actions/download-artifact#53 and actions/download-artifact#55

We retry when we receive some non success http status code such as 409, 503, etc.  However even if we received a 200 success status code but the response stream were interrupted during download, we should also retry.  

When we stream down the file, we could stream with gzip compression, and if we do, we rely on gzip processing to detect the stream is corrupted.  If the stream is not gzip compressed, we will verify the downloaded file is of the same size specified in `Content-Length` header. 