### PR TITLE
Fix namespace for `WebhookPayloadPush`

### DIFF
--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -70,7 +70,7 @@ import * as github from '@actions/github'
 import * as Webhooks from '@octokit/webhooks'
 if (github.context.eventName === 'push') {
   const pushPayload = github.context.payload as Webhooks.EventPayloads.WebhookPayloadPush
-  core.info(`The head commit is: ${pushPayload.head}`)
+  core.info(`The head commit is: ${pushPayload.after}`)
 }
 ```
 

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -69,7 +69,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import * as Webhooks from '@octokit/webhooks'
 if (github.context.eventName === 'push') {
-  const pushPayload = github.context.payload as Webhooks.WebhookPayloadPush
+  const pushPayload = github.context.payload as Webhooks.EventPayloads.WebhookPayloadPush
   core.info(`The head commit is: ${pushPayload.head}`)
 }
 ```


### PR DESCRIPTION
I think the `WebhookPayloadPush` is available under the `EventPayloads` name?

https://github.com/octokit/webhooks.js/blob/db6bd160ee93cb7bf48c02eae1a07fa8fce50cf5/src/index.ts#L72
https://github.com/octokit/webhooks.js/blob/db6bd160ee93cb7bf48c02eae1a07fa8fce50cf5/src/generated/event-payloads.ts#L1058-L1074