### PR TITLE
Fix authorization header for tool-cache

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -94,7 +94,7 @@ async function downloadToolAttempt(
   if (auth) {
     core.debug('set auth')
     headers = {
-      authorization: auth
+      Authorization: auth
     }
   }
 


### PR DESCRIPTION
## What
Bug fix.
I couldn't download private repo's assets and I realized that the auth header is `authorization` not `Authorization`.

Sorry if I misunderstanding, I think it should  `Authorization`.

that HTTP Header field names are case-sen

Should solve https://github.com/actions/toolkit/issues/681.