### PR TITLE
Avoid version corruption by passing loose option to semver.clean in the tool-cache package

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -381,7 +381,7 @@ export async function cacheDir(
   version: string,
   arch?: string
 ): Promise<string> {
-  version = semver.clean(version) || version
+  version = semver.clean(version, {loose: true}) || version
   arch = arch || os.arch()
   core.debug(`Caching tool ${tool} ${version} ${arch}`)
 
@@ -422,7 +422,7 @@ export async function cacheFile(
   version: string,
   arch?: string
 ): Promise<string> {
-  version = semver.clean(version) || version
+  version = semver.clean(version, {loose: true}) || version
   arch = arch || os.arch()
   core.debug(`Caching tool ${tool} ${version} ${arch}`)
 
@@ -478,7 +478,7 @@ export function find(
   // check for the explicit version in the cache
   let toolPath = ''
   if (versionSpec) {
-    versionSpec = semver.clean(versionSpec) || ''
+    versionSpec = semver.clean(versionSpec, {loose: true}) || ''
     const cachePath = path.join(
       _getCacheDirectory(),
       toolName,
@@ -626,7 +626,7 @@ async function _createToolPath(
   const folderPath = path.join(
     _getCacheDirectory(),
     tool,
-    semver.clean(version) || version,
+    semver.clean(version, {loose: true}) || version,
     arch || ''
   )
   core.debug(`destination ${folderPath}`)
@@ -641,7 +641,7 @@ function _completeToolPath(tool: string, version: string, arch?: string): void {
   const folderPath = path.join(
     _getCacheDirectory(),
     tool,
-    semver.clean(version) || version,
+    semver.clean(version, {loose: true}) || version,
     arch || ''
   )
   const markerPath = `${folderPath}.complete`
@@ -650,7 +650,7 @@ function _completeToolPath(tool: string, version: string, arch?: string): void {
 }
 
 function _isExplicitVersion(versionSpec: string): boolean {
-  const c = semver.clean(versionSpec) || ''
+  const c = semver.clean(versionSpec, {loose: true}) || ''
   core.debug(`isExplicit: ${c}`)
 
   const valid = semver.valid(c) != null


### PR DESCRIPTION
This is probably an unintended implementation. I think it's faster to read the documentation for details, but the problem here is that if you use `semver.clean` with beta release, the cache will be stored as a stable release.
https://github.com/npm/node-semver#clean
In general, alpha and beta releases are often used before stable releases, and even if you intend to use a stable release in the future, it's clear that this issue can lead to inadvertently misuse previous alpha and beta releases.
In the first place, using the semver library itself is a wrong choice, given that not all software versions in the world are strictly semver-compliant. (That said, it would be a relatively reasonable choice by adding a loose option.) What do you think?