### PR TITLE
Use GNU tar on macOS if available

### DIFF
--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -11,6 +11,7 @@ jest.mock('@actions/exec')
 jest.mock('@actions/io')
 
 const IS_WINDOWS = process.platform === 'win32'
+const IS_MACOS = process.platform === 'darwin'
 
 function getTempDir(): string {
   return path.join(__dirname, '_temp', 'tar')
@@ -38,7 +39,7 @@ test('zstd extract tar', async () => {
     ? `${process.env['windir']}\\fakepath\\cache.tar`
     : 'cache.tar'
   const workspace = process.env['GITHUB_WORKSPACE']
-  const tarPath = 'tar'
+  const tarPath = IS_MACOS ? 'gtar' : 'tar'
 
   await tar.extractTar(archivePath, CompressionMethod.Zstd)
 

--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -73,7 +73,7 @@ test('gzip extract tar', async () => {
   expect(mkdirMock).toHaveBeenCalledWith(workspace)
   const tarPath = IS_WINDOWS
     ? `${process.env['windir']}\\System32\\tar.exe`
-    : defaultTarPath'
+    : defaultTarPath
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
     `"${tarPath}"`,

--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -133,7 +133,7 @@ test('zstd create tar', async () => {
 
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
-    `"${tarPath}"`,
+    `"${defaultTarPath}"`,
     [
       '--posix',
       '--use-compress-program',

--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -11,7 +11,8 @@ jest.mock('@actions/exec')
 jest.mock('@actions/io')
 
 const IS_WINDOWS = process.platform === 'win32'
-const IS_MACOS = process.platform === 'darwin'
+
+const defaultTarPath = process.platform === 'darwin' ? 'gtar' : 'tar'
 
 function getTempDir(): string {
   return path.join(__dirname, '_temp', 'tar')
@@ -39,14 +40,13 @@ test('zstd extract tar', async () => {
     ? `${process.env['windir']}\\fakepath\\cache.tar`
     : 'cache.tar'
   const workspace = process.env['GITHUB_WORKSPACE']
-  const tarPath = IS_MACOS ? 'gtar' : 'tar'
 
   await tar.extractTar(archivePath, CompressionMethod.Zstd)
 
   expect(mkdirMock).toHaveBeenCalledWith(workspace)
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
-    `"${tarPath}"`,
+    `"${defaultTarPath}"`,
     [
       '--use-compress-program',
       'zstd -d --long=30',
@@ -73,7 +73,7 @@ test('gzip extract tar', async () => {
   expect(mkdirMock).toHaveBeenCalledWith(workspace)
   const tarPath = IS_WINDOWS
     ? `${process.env['windir']}\\System32\\tar.exe`
-    : 'tar'
+    : defaultTarPath'
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
     `"${tarPath}"`,
@@ -126,7 +126,6 @@ test('zstd create tar', async () => {
   const archiveFolder = getTempDir()
   const workspace = process.env['GITHUB_WORKSPACE']
   const sourceDirectories = ['~/.npm/cache', `${workspace}/dist`]
-  const tarPath = 'tar'
 
   await fs.promises.mkdir(archiveFolder, {recursive: true})
 
@@ -166,7 +165,7 @@ test('gzip create tar', async () => {
 
   const tarPath = IS_WINDOWS
     ? `${process.env['windir']}\\System32\\tar.exe`
-    : 'tar'
+    : defaultTarPath
 
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
@@ -194,13 +193,12 @@ test('zstd list tar', async () => {
   const archivePath = IS_WINDOWS
     ? `${process.env['windir']}\\fakepath\\cache.tar`
     : 'cache.tar'
-  const tarPath = 'tar'
 
   await tar.listTar(archivePath, CompressionMethod.Zstd)
 
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
-    `"${tarPath}"`,
+    `"${defaultTarPath}"`,
     [
       '--use-compress-program',
       'zstd -d --long=30',
@@ -218,13 +216,12 @@ test('zstdWithoutLong list tar', async () => {
   const archivePath = IS_WINDOWS
     ? `${process.env['windir']}\\fakepath\\cache.tar`
     : 'cache.tar'
-  const tarPath = 'tar'
 
   await tar.listTar(archivePath, CompressionMethod.ZstdWithoutLong)
 
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
-    `"${tarPath}"`,
+    `"${defaultTarPath}"`,
     [
       '--use-compress-program',
       'zstd -d',
@@ -246,7 +243,7 @@ test('gzip list tar', async () => {
 
   const tarPath = IS_WINDOWS
     ? `${process.env['windir']}\\System32\\tar.exe`
-    : 'tar'
+    : defaultTarPath
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
     `"${tarPath}"`,

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -10,17 +10,28 @@ async function getTarPath(
   compressionMethod: CompressionMethod
 ): Promise<string> {
   const IS_WINDOWS = process.platform === 'win32'
-  if (IS_WINDOWS) {
-    const systemTar = `${process.env['windir']}\\System32\\tar.exe`
-    if (compressionMethod !== CompressionMethod.Gzip) {
-      // We only use zstandard compression on windows when gnu tar is installed due to
-      // a bug with compressing large files with bsdtar + zstd
-      args.push('--force-local')
-    } else if (existsSync(systemTar)) {
-      return systemTar
-    } else if (await utils.isGnuTarInstalled()) {
-      args.push('--force-local')
+  switch (process.platform) {
+    case 'win32': {
+      const systemTar = `${process.env['windir']}\\System32\\tar.exe`
+      if (compressionMethod !== CompressionMethod.Gzip) {
+        // We only use zstandard compression on windows when gnu tar is installed due to
+        // a bug with compressing large files with bsdtar + zstd
+        args.push('--force-local')
+      } else if (existsSync(systemTar)) {
+        return systemTar
+      } else if (await utils.isGnuTarInstalled()) {
+        args.push('--force-local')
+      }
+      break
     }
+    case 'darwin': {
+      const gnuTar = await io.which('gtar', false)
+      if (gnuTar) {
+        return gnuTar
+      }
+      break
+    }
+    default: break
   }
   return await io.which('tar', true)
 }

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -30,7 +30,8 @@ async function getTarPath(
       }
       break
     }
-    default: break
+    default:
+      break
   }
   return await io.which('tar', true)
 }

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -9,7 +9,6 @@ async function getTarPath(
   args: string[],
   compressionMethod: CompressionMethod
 ): Promise<string> {
-  const IS_WINDOWS = process.platform === 'win32'
   switch (process.platform) {
     case 'win32': {
       const systemTar = `${process.env['windir']}\\System32\\tar.exe`


### PR DESCRIPTION
As I understant this table: https://github.com/actions/virtual-environments#available-environments
And this comment: https://github.com/actions/virtual-environments/issues/1534#issuecomment-745804159
The 20210123 images are the first ones to contain GNU tar and they are at 90%+ rollout progress.

This aims to fix multiple people's issues with caching inside macOS actions:
https://github.com/actions/cache/issues/403
https://github.community/t/bizarre-issue-with-tar-archive-for-macos-build/145377
https://github.com/Cyberbeni/install-swift-tool/issues/69