### PR TITLE
Overwrite files when extracting with GNU tar

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -269,6 +269,9 @@ export async function extractTar(
   if (isGnuTar) {
     // Suppress warnings when using GNU tar to extract archives created by BSD tar
     args.push('--warning=no-unknown-keyword')
+
+    // Make sure any existing files are overwritten
+    args.push('--overwrite')
   }
 
   args.push('-C', destArg, '-f', fileArg)


### PR DESCRIPTION
When using GNU tar, if a file already exists, from a previous run or
another cached action, it results in a slew of warning messages that
can cause issues for the run.

Non-GNU versions appear to automatically overwrite existing files.
From the BSD tar manpage:

```
-x    Extract to disk from the archive.  If a file with the same name
      appears more than once in the archive, each copy will be
      extracted, with later copies overwriting (replacing) earlier
      copies.
```

This change adds the use of `--overwrite` when using GNU tar so that
any existing files will just be overwritten as well.

This is to help address issues encountered with golangci/golangci-lint-action
documented here:

https://github.com/golangci/golangci-lint-action/issues/135