### PR TITLE
Note multiline match limitation in Problem Matchers documentation

### DIFF
--- a/docs/problem-matchers.md
+++ b/docs/problem-matchers.md
@@ -100,6 +100,16 @@ The eslint-stylish problem matcher defined below catches that output, and create
 The first pattern matches the `test.js` line and records the file information. This line is not decorated in the UI.
 The second pattern loops through the remaining lines with `loop: true` until it fails to find a match, and surfaces these lines prominently in the UI.
 
+Note that the pattern matches must be on consecutive lines. The following would not result in any match findings.
+
+```
+test.js
+  extraneous log line of no interest
+  1:0   error  Missing "use strict" statement                 strict
+  5:10  error  'addOne' is defined but never used             no-unused-vars
+✖ 2 problems (2 errors, 0 warnings)
+```
+
 ## Adding and Removing Problem Matchers
 
 Problem Matchers are enabled and removed via the toolkit [commands](commands.md#problem-matchers).


### PR DESCRIPTION
Add detail on one dimension of multi-line match limitations - as I only discovered this after prototyping a Problem Matcher at some expense.