### PR TITLE
@actions/artifact 0.5.1 release

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -54,3 +54,7 @@
 
 - Improved retry-ability for all http calls during artifact upload and download if an error is encountered
 
+### 0.5.1
+
+- Bump @actions/http-client to version 1.0.11 to fix proxy related issues during artifact upload and download
+

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
       "requires": {
         "tunnel": "0.0.6"
       }

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "@actions/http-client": "^1.0.7",
+    "@actions/http-client": "^1.0.11",
     "@types/tmp": "^0.1.0",
     "tmp": "^0.1.0",
     "tmp-promise": "^2.0.2"

--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -6,6 +6,7 @@ import * as stream from 'stream'
 import * as im from './interfaces'
 import * as io from '@actions/io'
 import * as ioUtil from '@actions/io/lib/io-util'
+import {setTimeout} from 'timers'
 
 /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "target": "es6",
     "sourceMap": true,
-    "lib": ["es6"]
+    "lib": ["es6","dom"]
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "strict": true,
     "declaration": true,
     "target": "es6",
-    "sourceMap": true,
-    "lib": ["es6","dom"]
+    "sourceMap": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Bump `@actions/http-client` to the latest version and create a new release fix a proxy related issue that is effecting some larger enterprise customers: https://github.com/actions/http-client/pull/42

