### PR TITLE
Set npmrc to use the NPM Token

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -50,12 +50,15 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ github.event.inputs.package }}
-      
-      - name: publish
-        run: npm publish *.tgz
+
+      - name: setup authentication
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
         env: 
           NPM_TOKEN: ${{ secrets.TOKEN }}
-      
+
+      - name: publish
+        run: npm publish *.tgz
+
       - name: notify slack on failure
         if: failure()
         run: |


### PR DESCRIPTION
Fixes an issue where npm fails to authenticate when publishing [example](https://github.com/actions/toolkit/actions/runs/723483158)