### PR TITLE
Add `getCommandOutput`

### DIFF
--- a/packages/exec/RELEASES.md
+++ b/packages/exec/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/exec Releases
 
+### 1.1.0
+
+- [Add `getCommandOutput`](https://github.com/actions/toolkit/pull/770)
+
 ### 1.0.3
 
 - [Add \"types\" to package.json](https://github.com/actions/toolkit/pull/221)

--- a/packages/exec/src/exec.ts
+++ b/packages/exec/src/exec.ts
@@ -28,3 +28,36 @@ export async function exec(
   const runner: tr.ToolRunner = new tr.ToolRunner(toolPath, args, options)
   return runner.exec()
 }
+
+/**
+ * Get command output
+ * Returns promise with stdout
+ *
+ * @param     commandLine        command to execute (can include additional args). Must be correctly escaped.
+ * @param     args               optional arguments for tool. Escaping is handled by the lib.
+ * @param     options            optional exec options.  See ExecOptions
+ * @returns   Promise<string>    exit code
+ */
+export async function getCommandOutput(
+  commandLine: string,
+  args?: [],
+  options: Omit<ExecOptions, 'listeners'> = {}
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let out = ''
+    let err = ''
+
+    const opts = {
+      ...options,
+      listeners: {
+        stdout: (data: Buffer) => (out += data.toString()),
+        stderr: (data: Buffer) => (err += data.toString())
+      }
+    }
+
+    exec(commandLine, args, opts).then(() => {
+      if (err) return reject(err)
+      resolve(out)
+    })
+  })
+}


### PR DESCRIPTION
Hello 👋

This pull request fixes #769 which is about making it easier to get the output from a command.

Few things we probably want to handle before landing:

- I didn't add a way to retrieve the exit code, do we want that?
- If we want exit code, how? As an object (e.g. `{ exitCode: number, stdout: string }`)?