### PR TITLE
Release @actions/github v.5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19336,9 +19336,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "lerna": "^3.18.4",
     "prettier": "^1.19.1",
     "ts-jest": "^25.4.0",
-    "typescript": "^3.7.4"
+    "typescript": "^3.9.9"
   }
 }

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -22,7 +22,7 @@ async function run() {
     // You can also pass in additional options as a second parameter to getOctokit
     // const octokit = github.getOctokit(myToken, {userAgent: "MyActionVersion1"});
 
-    const { data: pullRequest } = await octokit.pulls.get({
+    const { data: pullRequest } = await octokit.rest.pulls.get({
         owner: 'octokit',
         repo: 'rest.js',
         pull_number: 123,
@@ -50,7 +50,7 @@ const github = require('@actions/github');
 
 const context = github.context;
 
-const newIssue = await octokit.issues.create({
+const newIssue = await octokit.rest.issues.create({
   ...context.repo,
   title: 'New issue!',
   body: 'Hello Universe!'
@@ -90,7 +90,7 @@ const octokit = GitHub.plugin(enterpriseServer220Admin)
 const myToken = core.getInput('myToken');
 const myOctokit = new octokit(getOctokitOptions(token))
 // Create a new user
-myOctokit.enterpriseAdmin.createUser({
+myOctokit.rest.enterpriseAdmin.createUser({
   login: "testuser",
   email: "testuser@test.com",
 });

--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/github Releases
 
+### 5.0.0
+- [Update @actions/github to include latest octokit definitions]()
+
 ### 4.0.0
 - [Add execution state information to context](https://github.com/actions/toolkit/pull/499)
 - [Update Octokit Dependencies with some api breaking changes](https://github.com/actions/toolkit/pull/498) 

--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,7 +1,7 @@
 # @actions/github Releases
 
 ### 5.0.0
-- [Update @actions/github to include latest octokit definitions]()
+- [Update @actions/github to include latest octokit definitions](https://github.com/actions/toolkit/pull/783)
 
 ### 4.0.0
 - [Add execution state information to context](https://github.com/actions/toolkit/pull/499)

--- a/packages/github/__tests__/github.proxy.test.ts
+++ b/packages/github/__tests__/github.proxy.test.ts
@@ -49,7 +49,7 @@ describe('@actions/github', () => {
     }
 
     const octokit = getOctokit(token)
-    const branch = await octokit.repos.getBranch({
+    const branch = await octokit.rest.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
       branch: 'main'
@@ -85,7 +85,7 @@ describe('@actions/github', () => {
         agent: new https.Agent()
       }
     })
-    const branch = await octokit.repos.getBranch({
+    const branch = await octokit.rest.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
       branch: 'main'

--- a/packages/github/__tests__/github.test.ts
+++ b/packages/github/__tests__/github.test.ts
@@ -15,7 +15,7 @@ describe('@actions/github', () => {
     proxyServer = proxy()
     await new Promise(resolve => {
       const port = Number(proxyUrl.split(':')[2])
-      proxyServer.listen(port, () => resolve())
+      proxyServer.listen(port, () => resolve(null))
     })
     proxyServer.on('connect', req => {
       proxyConnects.push(req.url)
@@ -30,7 +30,7 @@ describe('@actions/github', () => {
   afterAll(async () => {
     // Stop proxy server
     await new Promise(resolve => {
-      proxyServer.once('close', () => resolve())
+      proxyServer.once('close', () => resolve(null))
       proxyServer.close()
     })
 
@@ -45,7 +45,7 @@ describe('@actions/github', () => {
       return
     }
     const octokit = new GitHub(getOctokitOptions(token))
-    const branch = await octokit.repos.getBranch({
+    const branch = await octokit.rest.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
       branch: 'main'
@@ -60,7 +60,7 @@ describe('@actions/github', () => {
       return
     }
     const octokit = getOctokit(token)
-    const branch = await octokit.repos.getBranch({
+    const branch = await octokit.rest.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
       branch: 'main'
@@ -77,7 +77,7 @@ describe('@actions/github', () => {
 
     // Valid token
     let octokit = new GitHub({auth: `token ${token}`})
-    const branch = await octokit.repos.getBranch({
+    const branch = await octokit.rest.repos.getBranch({
       owner: 'actions',
       repo: 'toolkit',
       branch: 'main'
@@ -89,7 +89,7 @@ describe('@actions/github', () => {
     octokit = new GitHub({auth: `token asdf`})
     let failed = false
     try {
-      await octokit.repos.getBranch({
+      await octokit.rest.repos.getBranch({
         owner: 'actions',
         repo: 'toolkit',
         branch: 'main'

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
       "requires": {
         "tunnel": "0.0.6"
       }
@@ -457,114 +457,98 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^6.0.3"
       }
     },
     "@octokit/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
       "requires": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/request": "^5.4.0",
-        "@octokit/types": "^5.0.0",
-        "before-after-hook": "^2.1.0",
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
-      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
       "requires": {
-        "@octokit/types": "^5.0.0",
-        "is-plain-object": "^4.0.0",
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
-      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^5.0.0",
+        "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
     },
+    "@octokit/openapi-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
+      "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
+    },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
-      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
       "requires": {
-        "@octokit/types": "^5.2.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.0.tgz",
-          "integrity": "sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==",
-          "requires": {
-            "@types/node": ">= 8"
-          }
-        }
+        "@octokit/types": "^6.11.0"
       }
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
-      "integrity": "sha512-PTI7wpbGEZ2IR87TVh+TNWaLcgX/RsZQalFbQCq8XxYUrQ36RHyERrHSNXFy5gkWpspUAOYRSV707JJv6BhqJA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.1.1.tgz",
+      "integrity": "sha512-u4zy0rVA8darm/AYsIeWkRalhQR99qPL1D/EXHejV2yaECMdHfxXiTXtba8NMBSajOJe8+C9g+EqMKSvysx0dg==",
       "requires": {
-        "@octokit/types": "^5.1.1",
+        "@octokit/types": "^6.14.1",
         "deprecation": "^2.3.1"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.0.tgz",
-          "integrity": "sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==",
-          "requires": {
-            "@types/node": ">= 8"
-          }
-        }
       }
     },
     "@octokit/request": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^5.0.0",
-        "deprecation": "^2.0.0",
-        "is-plain-object": "^4.0.0",
-        "node-fetch": "^2.3.0",
-        "once": "^1.4.0",
+        "@octokit/types": "^6.7.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
       "requires": {
-        "@octokit/types": "^5.0.1",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/types": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
-      "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
+      "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
       "requires": {
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^7.0.0"
       }
     },
     "@sinonjs/commons": {
@@ -647,11 +631,6 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1039,9 +1018,9 @@
       }
     },
     "before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2224,9 +2203,9 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-      "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-regex": {
       "version": "1.0.5",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Actions github lib",
   "keywords": [
     "github",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -38,10 +38,10 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/http-client": "^1.0.8",
-    "@octokit/core": "^3.1.2",
-    "@octokit/plugin-paginate-rest": "^2.3.0",
-    "@octokit/plugin-rest-endpoint-methods": "^4.1.2"
+    "@actions/http-client": "^1.0.11",
+    "@octokit/core": "^3.4.0",
+    "@octokit/plugin-paginate-rest": "^2.13.3",
+    "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
   },
   "devDependencies": {
     "jest": "^25.1.0",


### PR DESCRIPTION
### Description

- This pr updates the base octokit libraries to expose the newly added rest endpoints.
- However, it also changes the definition of the octokit object, the endpoints are now accessed via `octokit.rest.{endpoint}` rather then `octokit.{endpoint}`, so we need to major version this version and ship `@actions/github v5.0.0`