### PR TITLE
Prevent INPUT_* env variables from leaking to child processes

### DIFF
--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -1,4 +1,5 @@
 import * as exec from '../src/exec'
+import * as tr from '../src/toolrunner'
 import * as im from '../src/interfaces'
 
 import * as childProcess from 'child_process'
@@ -618,6 +619,14 @@ describe('@actions/exec', () => {
       )
     }
     expect(output.trim()).toBe(`args[0]: "hello"${os.EOL}args[1]: "world"`)
+  })
+
+  it('tool runner strips INPUT_ params from environment for child process', () => {
+    const env = {INPUT_TEST: 'input value', SOME_OTHER_ENV: 'some other value'}
+    const sanitizedEnv = tr.stripInputEnvironmentVariables(env)
+
+    expect(sanitizedEnv).not.toHaveProperty('INPUT_TEST')
+    expect(sanitizedEnv).toHaveProperty('SOME_OTHER_ENV')
   })
 
   if (IS_WINDOWS) {

--- a/packages/exec/src/interfaces.ts
+++ b/packages/exec/src/interfaces.ts
@@ -6,7 +6,7 @@ export interface ExecOptions {
   /** optional working directory.  defaults to current */
   cwd?: string
 
-  /** optional envvar dictionary.  defaults to current process's env */
+  /** optional envvar dictionary.  defaults to current process's env with `INPUT_*` variables removed */
   env?: {[key: string]: string}
 
   /** optional.  defaults to false */

--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -377,7 +377,7 @@ export class ToolRunner extends events.EventEmitter {
     options = options || <im.ExecOptions>{}
     const result = <child.SpawnOptions>{}
     result.cwd = options.cwd
-    result.env = options.env
+    result.env = options.env || stripInputEnvironmentVariables(process.env)
     result['windowsVerbatimArguments'] =
       options.windowsVerbatimArguments || this._isCmdFile()
     if (options.windowsVerbatimArguments) {
@@ -598,6 +598,16 @@ export function argStringToArray(argString: string): string[] {
   }
 
   return args
+}
+
+// Strips INPUT_ environment variables to prevent them leaking to child processes
+export function stripInputEnvironmentVariables(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return Object.entries(env).filter(([key, value]) => {
+    return !key.startsWith('INPUT_')
+  }).reduce((obj: NodeJS.ProcessEnv, [key, value]) => {
+    obj[key] = value
+    return obj
+  }, {})
 }
 
 class ExecState extends events.EventEmitter {


### PR DESCRIPTION
Resolves #309 

By default, the [child_process](https://nodejs.org/api/child_process.html#child_process_child_process) module in Node [will use `process.env`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) if no environment is explicitly passed. 

For security purposes, we are filtering out the `INPUT_*` environment variables to prevent these from being passed to subprocesses by default. We do this by first filtering `process.env` and explicitly passing it to the `spawn` method. 