### PR TITLE
Include urls  in `@actions/github` context

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -18,6 +18,9 @@ export class Context {
   job: string
   runNumber: number
   runId: number
+  apiUrl: string
+  serverUrl: string
+  graphqlUrl: string
 
   /**
    * Hydrate the context from the environment
@@ -43,6 +46,9 @@ export class Context {
     this.job = process.env.GITHUB_JOB as string
     this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER as string, 10)
     this.runId = parseInt(process.env.GITHUB_RUN_ID as string, 10)
+    this.apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com" as string
+    this.serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com" as string
+    this.graphqlUrl = process.env.GITHUB_GRAPHQL_URL	 ?? "https://api.github.com/graphql" as string
   }
 
   get issue(): {owner: string; repo: string; number: number} {


### PR DESCRIPTION
Resolves https://github.com/actions/toolkit/issues/576

We have various env variables that are set to indicate the github endpoints for rest/graphql/web. These are typically the same for dotcom users, but for ghes, being able to programmatically get that information in an action is helpful. This pr adds those values to the github context, you can see the documentation on these variables [here](https://docs.github.com/en/actions/reference/environment-variables)