### PR TITLE
Export isExplicitVersion and evaluateVersions

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -652,6 +652,11 @@ function _completeToolPath(tool: string, version: string, arch?: string): void {
   core.debug('finished caching tool')
 }
 
+/**
+ * Check if version string is explicit
+ *
+ * @param versionSpec      version string to check
+ */
 export function isExplicitVersion(versionSpec: string): boolean {
   const c = semver.clean(versionSpec) || ''
   core.debug(`isExplicit: ${c}`)
@@ -661,6 +666,13 @@ export function isExplicitVersion(versionSpec: string): boolean {
 
   return valid
 }
+
+/**
+ * Get the highest satisfiying semantic version in `versions` which satisfies `versionSpec`
+ *
+ * @param versions        array of versions to evaluate
+ * @param versionSpec     semantic version spec to satisfy
+ */
 
 export function evaluateVersions(
   versions: string[],

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -472,9 +472,9 @@ export function find(
   arch = arch || os.arch()
 
   // attempt to resolve an explicit version
-  if (!_isExplicitVersion(versionSpec)) {
+  if (!isExplicitVersion(versionSpec)) {
     const localVersions: string[] = findAllVersions(toolName, arch)
-    const match = _evaluateVersions(localVersions, versionSpec)
+    const match = evaluateVersions(localVersions, versionSpec)
     versionSpec = match
   }
 
@@ -514,7 +514,7 @@ export function findAllVersions(toolName: string, arch?: string): string[] {
   if (fs.existsSync(toolPath)) {
     const children: string[] = fs.readdirSync(toolPath)
     for (const child of children) {
-      if (_isExplicitVersion(child)) {
+      if (isExplicitVersion(child)) {
         const fullPath = path.join(toolPath, child, arch || '')
         if (fs.existsSync(fullPath) && fs.existsSync(`${fullPath}.complete`)) {
           versions.push(child)
@@ -652,7 +652,7 @@ function _completeToolPath(tool: string, version: string, arch?: string): void {
   core.debug('finished caching tool')
 }
 
-function _isExplicitVersion(versionSpec: string): boolean {
+export function isExplicitVersion(versionSpec: string): boolean {
   const c = semver.clean(versionSpec) || ''
   core.debug(`isExplicit: ${c}`)
 
@@ -662,7 +662,7 @@ function _isExplicitVersion(versionSpec: string): boolean {
   return valid
 }
 
-function _evaluateVersions(versions: string[], versionSpec: string): string {
+export function evaluateVersions(versions: string[], versionSpec: string): string {
   let version = ''
   core.debug(`evaluating ${versions.length} versions`)
   versions = versions.sort((a, b) => {

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -662,7 +662,10 @@ export function isExplicitVersion(versionSpec: string): boolean {
   return valid
 }
 
-export function evaluateVersions(versions: string[], versionSpec: string): string {
+export function evaluateVersions(
+  versions: string[],
+  versionSpec: string
+): string {
   let version = ''
   core.debug(`evaluating ${versions.length} versions`)
   versions = versions.sort((a, b) => {


### PR DESCRIPTION
Closes #244 

Export version utility functions. Could be used [here](https://github.com/actions/setup-node/blob/9bb7038a073441f1f0c3c33070fc1601a2638b1e/src/installer.ts#L118) as an example. 