### PR TITLE
Core: Add trimWhiteSpace to getInput

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -27,6 +27,7 @@ const testEnvVars = {
   INPUT_BOOLEAN_INPUT_FALSE2: 'False',
   INPUT_BOOLEAN_INPUT_FALSE3: 'FALSE',
   INPUT_WRONG_BOOLEAN_INPUT: 'wrong',
+  INPUT_WITH_TRAILING_WHITESPACE: '  some val  ',
 
   // Save inputs
   STATE_TEST_1: 'state_val',
@@ -163,6 +164,22 @@ describe('@actions/core', () => {
     expect(core.getInput('multiple spaces variable')).toBe(
       'I have multiple spaces'
     )
+  })
+
+  it('getInput gets trims whitespace by default', () => {
+    expect(core.getInput('with trailing whitespace')).toBe('some val')
+  })
+
+  it('getInput gets trims whitespace when option is explicitly true', () => {
+    expect(
+      core.getInput('with trailing whitespace', {trimWhiteSpace: true})
+    ).toBe('some val')
+  })
+
+  it('getInput gets does not trim whitespace when option is false', () => {
+    expect(
+      core.getInput('with trailing whitespace', {trimWhiteSpace: false})
+    ).toBe('  some val  ')
   })
 
   it('getInput gets non-required boolean input', () => {

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -166,17 +166,17 @@ describe('@actions/core', () => {
     )
   })
 
-  it('getInput gets trims whitespace by default', () => {
+  it('getInput trims whitespace by default', () => {
     expect(core.getInput('with trailing whitespace')).toBe('some val')
   })
 
-  it('getInput gets trims whitespace when option is explicitly true', () => {
+  it('getInput trims whitespace when option is explicitly true', () => {
     expect(
       core.getInput('with trailing whitespace', {trimWhiteSpace: true})
     ).toBe('some val')
   })
 
-  it('getInput gets does not trim whitespace when option is false', () => {
+  it('getInput does not trim whitespace when option is false', () => {
     expect(
       core.getInput('with trailing whitespace', {trimWhiteSpace: false})
     ).toBe('  some val  ')

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -11,6 +11,9 @@ import * as path from 'path'
 export interface InputOptions {
   /** Optional. Whether the input is required. If required and not present, will throw. Defaults to false */
   required?: boolean
+
+  /** Optional. Whether whitespace will be trimmed for the input. Defaults to true */
+  trimWhiteSpace?: boolean
 }
 
 /**
@@ -86,6 +89,10 @@ export function getInput(name: string, options?: InputOptions): string {
     process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || ''
   if (options && options.required && !val) {
     throw new Error(`Input required and not supplied: ${name}`)
+  }
+
+  if (options && options.trimWhiteSpace === false) {
+    return val
   }
 
   return val.trim()

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -12,7 +12,7 @@ export interface InputOptions {
   /** Optional. Whether the input is required. If required and not present, will throw. Defaults to false */
   required?: boolean
 
-  /** Optional. Whether whitespace will be trimmed for the input. Defaults to true */
+  /** Optional. Whether leading/trailing whitespace will be trimmed for the input. Defaults to true */
   trimWhiteSpace?: boolean
 }
 


### PR DESCRIPTION
This adds an option to opt out of trimming leading/trailing whitespace for `core.getInput()`

Resolves #339 