### PR TITLE
Prevent accidental file matching when glob contains trailing slash

### DIFF
--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -97,6 +97,27 @@ describe('globber', () => {
     ])
   })
 
+  it('does not match file with trailing slash when implicitDescendants=true', async () => {
+    // Create the following layout:
+    //   <root>
+    //   <root>/file
+    const root = path.join(
+      getTestTemp(),
+      'defaults-to-implicit-descendants-true'
+    )
+
+    const filePath = path.join(root, 'file')
+    
+    await fs.mkdir(root, {recursive: true})
+    await fs.writeFile(filePath, 'test file content')
+
+    const pattern = `${filePath}/`
+    console.log(`=== pattern: ${pattern}`)
+    
+    const itemPaths = await glob(pattern, {})
+    expect(itemPaths).toEqual([])
+  })
+
   it('defaults to omitBrokenSymbolicLinks=true', async () => {
     // Create the following layout:
     //   <root>

--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -107,14 +107,11 @@ describe('globber', () => {
     )
 
     const filePath = path.join(root, 'file')
-    
+
     await fs.mkdir(root, {recursive: true})
     await fs.writeFile(filePath, 'test file content')
 
-    const pattern = `${filePath}/`
-    console.log(`=== pattern: ${pattern}`)
-    
-    const itemPaths = await glob(pattern, {})
+    const itemPaths = await glob(`${filePath}/`, {})
     expect(itemPaths).toEqual([])
   })
 

--- a/packages/glob/__tests__/internal-pattern.test.ts
+++ b/packages/glob/__tests__/internal-pattern.test.ts
@@ -26,7 +26,7 @@ describe('pattern', () => {
   it('escapes homedir', async () => {
     const home = path.join(getTestTemp(), 'home-with-[and]')
     await fs.mkdir(home, {recursive: true})
-    const pattern = new Pattern('~/m*', undefined, home)
+    const pattern = new Pattern('~/m*', false, undefined, home)
 
     expect(pattern.searchPath).toBe(home)
     expect(pattern.match(path.join(home, 'match'))).toBeTruthy()

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -66,23 +66,31 @@ export class DefaultGlobber implements Globber {
   async *globGenerator(): AsyncGenerator<string, void> {
     // Fill in defaults options
     const options = globOptionsHelper.getOptions(this.options)
-
+    // this.patterns.map((p) => p.segments.join('/')).forEach((p) => {
+    //   console.log(`this.Pattern: ${p}`)
+    // })
     // Implicit descendants?
     const patterns: Pattern[] = []
     for (const pattern of this.patterns) {
+      // core.debug(`=== Pattern search path: ${pattern.searchPath}`)
+      // core.debug(`=== Pattern.trailingSeparator: ${pattern.trailingSeparator}`)
       patterns.push(pattern)
       if (
         options.implicitDescendants &&
         (pattern.trailingSeparator ||
           pattern.segments[pattern.segments.length - 1] !== '**')
       ) {
+        // core.debug(`=== Pushing negate pattern`)
         patterns.push(
-          new Pattern(pattern.negate, pattern.segments.concat('**'))
+          new Pattern(pattern.negate, pattern.segments.concat('**'), undefined, pattern.trailingSeparator)
         )
       }
     }
 
+    // core.debug(`=== Patterns: ${JSON.stringify(patterns)}`)
     // Push the search paths
+
+    // console.log(`=== patternHelper.getsearchpath: ${JSON.stringify(patternHelper.getSearchPaths(patterns))}`)
     const stack: SearchState[] = []
     for (const searchPath of patternHelper.getSearchPaths(patterns)) {
       core.debug(`Search path '${searchPath}'`)
@@ -102,6 +110,8 @@ export class DefaultGlobber implements Globber {
       stack.unshift(new SearchState(searchPath, 1))
     }
 
+
+
     // Search
     const traversalChain: string[] = [] // used to detect cycles
     while (stack.length) {
@@ -110,6 +120,7 @@ export class DefaultGlobber implements Globber {
 
       // Match?
       const match = patternHelper.match(patterns, item.path)
+      core.debug(`=== Match: ${match}, patterns: ${JSON.stringify(patterns)} `)
       const partialMatch =
         !!match || patternHelper.partialMatch(patterns, item.path)
       if (!match && !partialMatch) {
@@ -180,6 +191,8 @@ export class DefaultGlobber implements Globber {
     }
 
     result.searchPaths.push(...patternHelper.getSearchPaths(result.patterns))
+
+    console.log(`result.patterns[0]: ${JSON.stringify(result.patterns[0])}`)
     return result
   }
 

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -66,31 +66,23 @@ export class DefaultGlobber implements Globber {
   async *globGenerator(): AsyncGenerator<string, void> {
     // Fill in defaults options
     const options = globOptionsHelper.getOptions(this.options)
-    // this.patterns.map((p) => p.segments.join('/')).forEach((p) => {
-    //   console.log(`this.Pattern: ${p}`)
-    // })
     // Implicit descendants?
     const patterns: Pattern[] = []
     for (const pattern of this.patterns) {
-      // core.debug(`=== Pattern search path: ${pattern.searchPath}`)
-      // core.debug(`=== Pattern.trailingSeparator: ${pattern.trailingSeparator}`)
       patterns.push(pattern)
       if (
         options.implicitDescendants &&
         (pattern.trailingSeparator ||
           pattern.segments[pattern.segments.length - 1] !== '**')
       ) {
-        // core.debug(`=== Pushing negate pattern`)
         patterns.push(
-          new Pattern(pattern.negate, pattern.segments.concat('**'), undefined, pattern.trailingSeparator)
+          new Pattern(pattern.negate, true, pattern.segments.concat('**'))
         )
       }
     }
 
-    // core.debug(`=== Patterns: ${JSON.stringify(patterns)}`)
     // Push the search paths
 
-    // console.log(`=== patternHelper.getsearchpath: ${JSON.stringify(patternHelper.getSearchPaths(patterns))}`)
     const stack: SearchState[] = []
     for (const searchPath of patternHelper.getSearchPaths(patterns)) {
       core.debug(`Search path '${searchPath}'`)
@@ -110,8 +102,6 @@ export class DefaultGlobber implements Globber {
       stack.unshift(new SearchState(searchPath, 1))
     }
 
-
-
     // Search
     const traversalChain: string[] = [] // used to detect cycles
     while (stack.length) {
@@ -120,7 +110,6 @@ export class DefaultGlobber implements Globber {
 
       // Match?
       const match = patternHelper.match(patterns, item.path)
-      core.debug(`=== Match: ${match}, patterns: ${JSON.stringify(patterns)} `)
       const partialMatch =
         !!match || patternHelper.partialMatch(patterns, item.path)
       if (!match && !partialMatch) {
@@ -192,7 +181,6 @@ export class DefaultGlobber implements Globber {
 
     result.searchPaths.push(...patternHelper.getSearchPaths(result.patterns))
 
-    console.log(`result.patterns[0]: ${JSON.stringify(result.patterns[0])}`)
     return result
   }
 

--- a/packages/glob/src/internal-pattern.ts
+++ b/packages/glob/src/internal-pattern.ts
@@ -162,10 +162,7 @@ export class Pattern {
 
     // Match
     if (this.minimatch.match(itemPath)) {
-      const matchValue = this.trailingSeparator
-        ? MatchKind.Directory
-        : MatchKind.All
-      return matchValue
+      return this.trailingSeparator ? MatchKind.Directory : MatchKind.All
     }
 
     return MatchKind.None

--- a/packages/glob/src/internal-pattern.ts
+++ b/packages/glob/src/internal-pattern.ts
@@ -43,20 +43,33 @@ export class Pattern {
    */
   private readonly rootRegExp: RegExp
 
+  /**
+   * Indicates that the pattern is implicitly added as opposed to user specified.
+   */
+  private readonly isImplicitPattern: boolean
+
   /* eslint-disable no-dupe-class-members */
   // Disable no-dupe-class-members due to false positive for method overload
   // https://github.com/typescript-eslint/typescript-eslint/issues/291
 
-  private readonly implicitTrailing: boolean
-
   constructor(pattern: string)
-  constructor(pattern: string, segments: undefined, homedir: string)
-  constructor(negate: boolean, segments: string[], homedir?: string, implicitTrailing?: boolean)
+  constructor(
+    pattern: string,
+    isImplicitPattern: boolean,
+    segments: undefined,
+    homedir: string
+  )
+  constructor(
+    negate: boolean,
+    isImplicitPattern: boolean,
+    segments: string[],
+    homedir?: string
+  )
   constructor(
     patternOrNegate: string | boolean,
+    isImplicitPattern: boolean = false,
     segments?: string[],
-    homedir?: string,
-    implicitTrailing?: boolean
+    homedir?: string
   ) {
     // Pattern overload
     let pattern: string
@@ -110,7 +123,7 @@ export class Pattern {
       IS_WINDOWS ? 'i' : ''
     )
 
-    this.implicitTrailing = implicitTrailing || false
+    this.isImplicitPattern = isImplicitPattern
 
     // Create minimatch
     const minimatchOptions: IMinimatchOptions = {
@@ -119,7 +132,7 @@ export class Pattern {
       nocase: IS_WINDOWS,
       nocomment: true,
       noext: true,
-      nonegate: true,
+      nonegate: true
     }
     pattern = IS_WINDOWS ? pattern.replace(/\\/g, '/') : pattern
     this.minimatch = new Minimatch(pattern, minimatchOptions)
@@ -137,7 +150,7 @@ export class Pattern {
       // Append a trailing slash. Otherwise Minimatch will not match the directory immediately
       // preceding the globstar. For example, given the pattern `/foo/**`, Minimatch returns
       // false for `/foo` but returns true for `/foo/`. Append a trailing slash to handle that quirk.
-      if (!itemPath.endsWith(path.sep) && !this.implicitTrailing) {
+      if (!itemPath.endsWith(path.sep) && this.isImplicitPattern === false) {
         // Note, this is safe because the constructor ensures the pattern has an absolute root.
         // For example, formats like C: and C:foo on Windows are resolved to an absolute root.
         itemPath = `${itemPath}${path.sep}`
@@ -149,9 +162,9 @@ export class Pattern {
 
     // Match
     if (this.minimatch.match(itemPath)) {
-      const matchValue =  this.trailingSeparator ? MatchKind.Directory : MatchKind.All
-      // console.log(`=== this.minimatch.pattern ${this.minimatch.pattern}`)
-      // console.log(`=== Match value: ${matchValue}, trailingSeparator: ${this.trailingSeparator}, itemPath: ${itemPath}`)
+      const matchValue = this.trailingSeparator
+        ? MatchKind.Directory
+        : MatchKind.All
       return matchValue
     }
 


### PR DESCRIPTION
Resolves #268 

Handles an odd case with `Minimatch` that we worked around before that inadvertently would match files when a trailing slash was added. 