### PR TITLE
Add getExecOutput function

### DIFF
--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -767,6 +767,35 @@ describe('@actions/exec', () => {
     expect(listenerErr).toBe('this is output to stderr')
   })
 
+  it('correctly outputs for getExecOutput with multi-byte characters', async () => {
+    const stdOutPath: string = path.join(
+      __dirname,
+      'scripts',
+      'stdoutputspecial.js'
+    )
+
+    const nodePath: string = await io.which('node', true)
+    let listenerOut = ''
+    let numStdOutBufferCalls = 0
+    const {exitCode: exitCodeOut, stdout} = await exec.getExecOutput(
+      `"${nodePath}"`,
+      [stdOutPath],
+      {
+        ...getExecOptions(),
+        listeners: {
+          stdout: _ => {
+            numStdOutBufferCalls += 1
+          }
+        }
+      }
+    )
+
+    expect(exitCodeOut).toBe(0)
+    //one call for each half of the © character, ensuring it was actually split and not sent together
+    expect(numStdOutBufferCalls).toBe(2)
+    expect(stdout).toBe('©')
+  })
+
   if (IS_WINDOWS) {
     it('Exec roots relative tool path using process.cwd (Windows path separator)', async () => {
       let exitCode: number

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -775,7 +775,6 @@ describe('@actions/exec', () => {
     )
 
     const nodePath: string = await io.which('node', true)
-    let listenerOut = ''
     let numStdOutBufferCalls = 0
     const {exitCode: exitCodeOut, stdout} = await exec.getExecOutput(
       `"${nodePath}"`,
@@ -783,7 +782,7 @@ describe('@actions/exec', () => {
       {
         ...getExecOptions(),
         listeners: {
-          stdout: _ => {
+          stdout: () => {
             numStdOutBufferCalls += 1
           }
         }

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -952,6 +952,46 @@ describe('@actions/exec', () => {
           'args[22]: "<quote>hello:<quote><quote>world again<quote><quote><quote>"\r\n' +
           'args[23]: "<quote>hello world\\\\<quote>"'
       )
+
+      it('Handles output callbacks', async () => {
+        const stdErrPath: string = path.join(
+          __dirname,
+          'scripts',
+          'stderroutput.js'
+        )
+        const stdOutPath: string = path.join(
+          __dirname,
+          'scripts',
+          'stdoutoutput.js'
+        )
+        const nodePath: string = await io.which('node', true)
+        let stdoutCalled = false
+        let stderrCalled = false
+    
+        const _testExecOptions = getExecOptions()
+        _testExecOptions.listeners = {
+          stdout: (data: Buffer) => {
+            expect(data).toEqual(Buffer.from('this is output to stdout'))
+            stdoutCalled = true
+          },
+          stderr: (data: Buffer) => {
+            expect(data).toEqual(Buffer.from('this is output to stderr'))
+            stderrCalled = true
+          }
+        }
+    
+        let exitCode = await exec.exec(
+          `"${nodePath}"`,
+          [stdOutPath],
+          _testExecOptions
+        )
+        expect(exitCode).toBe(0)
+        exitCode = await exec.exec(`"${nodePath}"`, [stdErrPath], _testExecOptions)
+        expect(exitCode).toBe(0)
+    
+        expect(stdoutCalled).toBeTruthy()
+        expect(stderrCalled).toBeTruthy()
+      })
     })
   }
 })

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -746,8 +746,8 @@ describe('@actions/exec', () => {
     )
 
     expect(exitCodeOut).toBe(0)
-    expect(Buffer.byteLength(stdout || '', 'utf8')).toBe(2 ** 24)
-    expect(Buffer.byteLength(listenerOut, 'utf8')).toBe(2 ** 24)
+    expect(Buffer.byteLength(stdout || '', 'utf8')).toBe(2 ** 25)
+    expect(Buffer.byteLength(listenerOut, 'utf8')).toBe(2 ** 25)
 
     let listenerErr = ''
     const {exitCode: exitCodeErr, stderr} = await exec.getExecOutput(

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -679,7 +679,6 @@ describe('@actions/exec', () => {
       'stdoutoutput.js'
     )
 
-    let numberOfBuffers = 0
     const nodePath: string = await io.which('node', true)
     let listenerOut = ''
 
@@ -691,7 +690,6 @@ describe('@actions/exec', () => {
         listeners: {
           stdout: data => {
             listenerOut = data.toString()
-            numberOfBuffers += 1
           }
         }
       }
@@ -700,7 +698,6 @@ describe('@actions/exec', () => {
     expect(exitCodeOut).toBe(0)
     expect(stdout).toBe('this is output to stdout')
     expect(listenerOut).toBe('this is output to stdout')
-    expect(numberOfBuffers).toBe(1)
 
     let listenerErr = ''
     const {exitCode: exitCodeErr, stderr} = await exec.getExecOutput(
@@ -732,7 +729,6 @@ describe('@actions/exec', () => {
       'stdoutoutputlarge.js'
     )
 
-    let numFullBuffers = 0
     const nodePath: string = await io.which('node', true)
     let listenerOut = ''
 
@@ -743,7 +739,6 @@ describe('@actions/exec', () => {
         ...getExecOptions(),
         listeners: {
           stdout: data => {
-            numFullBuffers += 1
             listenerOut += data.toString()
           }
         }
@@ -751,9 +746,8 @@ describe('@actions/exec', () => {
     )
 
     expect(exitCodeOut).toBe(0)
-    expect(Buffer.byteLength(stdout || '', 'utf8')).toBe(2 ** 32)
-    expect(Buffer.byteLength(listenerOut, 'utf8')).toBe(2 ** 32)
-    expect(numFullBuffers).toBeGreaterThan(1)
+    expect(Buffer.byteLength(stdout || '', 'utf8')).toBe(2 ** 24)
+    expect(Buffer.byteLength(listenerOut, 'utf8')).toBe(2 ** 24)
 
     let listenerErr = ''
     const {exitCode: exitCodeErr, stderr} = await exec.getExecOutput(

--- a/packages/exec/__tests__/scripts/stdoutoutputlarge.js
+++ b/packages/exec/__tests__/scripts/stdoutoutputlarge.js
@@ -1,3 +1,3 @@
 //Default highWaterMark for readable stream buffers us 64K (2^16)
 //so we go over that to get more than a buffer's worth
-process.stdout.write('a'.repeat(2**24));
+process.stdout.write('a\n'.repeat(2**24));

--- a/packages/exec/__tests__/scripts/stdoutoutputlarge.js
+++ b/packages/exec/__tests__/scripts/stdoutoutputlarge.js
@@ -1,3 +1,3 @@
 //Default highWaterMark for readable stream buffers us 64K (2^16)
 //so we go over that to get more than a buffer's worth
-process.stdout.write('a'.repeat(2**32));
+process.stdout.write('a'.repeat(2**24));

--- a/packages/exec/__tests__/scripts/stdoutoutputlarge.js
+++ b/packages/exec/__tests__/scripts/stdoutoutputlarge.js
@@ -1,0 +1,3 @@
+//Default highWaterMark for readable stream buffers us 64K (2^16)
+//so we go over that to get more than a buffer's worth
+process.stdout.write('a'.repeat(2**32));

--- a/packages/exec/__tests__/scripts/stdoutputspecial.js
+++ b/packages/exec/__tests__/scripts/stdoutputspecial.js
@@ -1,4 +1,5 @@
-process.stdout.write(Buffer.from([0xC2])) //first half of © character
-process.stdout.emit('drain') //force first byte to be sent and not appended with next one
-process.stdout.write(Buffer.from([0xA9])) //second half of © character
-
+//first half of © character
+process.stdout.write(Buffer.from([0xC2]), (err) => {
+    //write in the callback so that the second byte is sent separately
+    process.stdout.write(Buffer.from([0xA9])) //second half of © character
+})

--- a/packages/exec/__tests__/scripts/stdoutputspecial.js
+++ b/packages/exec/__tests__/scripts/stdoutputspecial.js
@@ -1,0 +1,4 @@
+process.stdout.write(Buffer.from([0xC2])) //first half of © character
+process.stdout.emit('drain') //force first byte to be sent and not appended with next one
+process.stdout.write(Buffer.from([0xA9])) //second half of © character
+

--- a/packages/exec/src/exec.ts
+++ b/packages/exec/src/exec.ts
@@ -29,40 +29,43 @@ export async function exec(
   return runner.exec()
 }
 
-export async function getExecOutput(commandLine: string, args?: string[], options?: ExecOptions): Promise<ExecOutput> {
-  type BufferListener = (data: Buffer) => void
+export async function getExecOutput(
+  commandLine: string,
+  args?: string[],
+  options?: ExecOptions
+): Promise<ExecOutput> {
   let stdout = ''
   let stderr = ''
-  
+
   const originalStdoutListener = options?.listeners?.stdout
   const originalStdErrListener = options?.listeners?.stderr
-  
-  const stdErrListener = (data: Buffer) => {
+
+  const stdErrListener = (data: Buffer): void => {
     stderr += data.toString()
     if (originalStdErrListener) {
       originalStdErrListener(data)
     }
   }
 
-  const stdOutListener = (data: Buffer) => {
+  const stdOutListener = (data: Buffer): void => {
     stdout += data.toString()
     if (originalStdoutListener) {
       originalStdoutListener(data)
     }
   }
-  
-  const listeners: ExecListeners = { 
+
+  const listeners: ExecListeners = {
     ...options?.listeners,
     stdout: stdOutListener,
     stderr: stdErrListener
   }
 
-  const exitCode = await exec(commandLine, args, {...options, listeners} )
+  const exitCode = await exec(commandLine, args, {...options, listeners})
 
   //return undefined for stdout/stderr if they are empty
   return {
-    exitCode, 
-    stdout: stdout || undefined, 
-    stderr: stderr || undefined 
+    exitCode,
+    stdout: stdout || undefined,
+    stderr: stderr || undefined
   }
 }

--- a/packages/exec/src/exec.ts
+++ b/packages/exec/src/exec.ts
@@ -50,8 +50,8 @@ export async function getExecOutput(
   let stderr = ''
 
   //Using string decoder covers the case where a mult-byte character is split
-  let stdoutDecoder = new StringDecoder('utf8')
-  let stderrDecoder = new StringDecoder('utf8')
+  const stdoutDecoder = new StringDecoder('utf8')
+  const stderrDecoder = new StringDecoder('utf8')
 
   const originalStdoutListener = options?.listeners?.stdout
   const originalStdErrListener = options?.listeners?.stderr

--- a/packages/exec/src/exec.ts
+++ b/packages/exec/src/exec.ts
@@ -1,3 +1,4 @@
+import {StringDecoder} from 'string_decoder'
 import {ExecOptions, ExecOutput, ExecListeners} from './interfaces'
 import * as tr from './toolrunner'
 
@@ -29,6 +30,17 @@ export async function exec(
   return runner.exec()
 }
 
+/**
+ * Exec a command and get the output.
+ * Output will be streamed to the live console.
+ * Returns promise with the exit code and collected stdout and stderr
+ *
+ * @param     commandLine           command to execute (can include additional args). Must be correctly escaped.
+ * @param     args                  optional arguments for tool. Escaping is handled by the lib.
+ * @param     options               optional exec options.  See ExecOptions
+ * @returns   Promise<ExecOutput>   exit code, stdout, and stderr
+ */
+
 export async function getExecOutput(
   commandLine: string,
   args?: string[],
@@ -37,18 +49,22 @@ export async function getExecOutput(
   let stdout = ''
   let stderr = ''
 
+  //Using string decoder covers the case where a mult-byte character is split
+  let stdoutDecoder = new StringDecoder('utf8')
+  let stderrDecoder = new StringDecoder('utf8')
+
   const originalStdoutListener = options?.listeners?.stdout
   const originalStdErrListener = options?.listeners?.stderr
 
   const stdErrListener = (data: Buffer): void => {
-    stderr += data.toString()
+    stderr += stderrDecoder.write(data)
     if (originalStdErrListener) {
       originalStdErrListener(data)
     }
   }
 
   const stdOutListener = (data: Buffer): void => {
-    stdout += data.toString()
+    stdout += stdoutDecoder.write(data)
     if (originalStdoutListener) {
       originalStdoutListener(data)
     }
@@ -62,10 +78,14 @@ export async function getExecOutput(
 
   const exitCode = await exec(commandLine, args, {...options, listeners})
 
+  //flush any remaining characters
+  stdout += stdoutDecoder.end()
+  stderr += stderrDecoder.end()
+
   //return undefined for stdout/stderr if they are empty
   return {
     exitCode,
-    stdout: stdout || undefined,
-    stderr: stderr || undefined
+    stdout,
+    stderr
   }
 }

--- a/packages/exec/src/interfaces.ts
+++ b/packages/exec/src/interfaces.ts
@@ -45,10 +45,10 @@ export interface ExecOutput {
   exitCode: number
 
   /**The entire stdout of the process as a string */
-  stdout?: string
+  stdout: string
 
   /**The entire stderr of the process as a string */
-  stderr?: string
+  stderr: string
 }
 
 /**

--- a/packages/exec/src/interfaces.ts
+++ b/packages/exec/src/interfaces.ts
@@ -37,20 +37,36 @@ export interface ExecOptions {
   listeners?: ExecListeners
 }
 
+/**
+ * Interface for the output of getExecOutput()
+ */
 export interface ExecOutput {
+  /**The exit code of the process */
   exitCode: number
+
+  /**The entire stdout of the process as a string */
   stdout?: string
+
+  /**The entire stderr of the process as a string */
   stderr?: string
 }
 
+/**
+ * The user defined listeners for an exec call
+ */
 export interface ExecListeners {
+  /** A call back for each buffer of stdout */
   stdout?: (data: Buffer) => void
 
+  /** A call back for each buffer of stderr */
   stderr?: (data: Buffer) => void
 
+  /** A call back for each line of stdout */
   stdline?: (data: string) => void
 
+  /** A call back for each line of stderr */
   errline?: (data: string) => void
 
+  /** A call back for each debug log */
   debug?: (data: string) => void
 }

--- a/packages/exec/src/interfaces.ts
+++ b/packages/exec/src/interfaces.ts
@@ -34,15 +34,23 @@ export interface ExecOptions {
   input?: Buffer
 
   /** optional. Listeners for output. Callback functions that will be called on these events */
-  listeners?: {
-    stdout?: (data: Buffer) => void
+  listeners?: ExecListeners
+}
 
-    stderr?: (data: Buffer) => void
+export interface ExecOutput {
+  exitCode: number
+  stdout?: string
+  stderr?: string
+}
 
-    stdline?: (data: string) => void
+export interface ExecListeners {
+  stdout?: (data: Buffer) => void
 
-    errline?: (data: string) => void
+  stderr?: (data: Buffer) => void
 
-    debug?: (data: string) => void
-  }
+  stdline?: (data: string) => void
+
+  errline?: (data: string) => void
+
+  debug?: (data: string) => void
 }

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -17,7 +17,6 @@ export interface CopyOptions {
   /** Optional. Whether to copy the source directory along with all the files. Only takes effect when recursive=true and copying a directory. Default is true*/
   copySourceDirectory?: boolean
 }
-
 /**
  * Interface for cp/mv options
  */

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -17,6 +17,7 @@ export interface CopyOptions {
   /** Optional. Whether to copy the source directory along with all the files. Only takes effect when recursive=true and copying a directory. Default is true*/
   copySourceDirectory?: boolean
 }
+
 /**
  * Interface for cp/mv options
  */


### PR DESCRIPTION
Adds a convenience function go more easily get the output of an exec command. Rather than having to explicitly define listeners in `ExecOptions` this method will return the collected output of `stdOut` and `stdErr` in addition to the exit code. This should make usage a little less awkward in situations where users need the output of an `exec` command. 

Resolves #769 

