### PR TITLE
[core] docs(README): fix minor formatting issue

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,10 +62,9 @@ catch (err) {
   // setFailed logs the message and sets a failing exit code
   core.setFailed(`Action failed with error ${err}`);
 }
+```
 
 Note that `setNeutral` is not yet implemented in actions V2 but equivalent functionality is being planned.
-
-```
 
 #### Logging
 


### PR DESCRIPTION
I've found this little formatting typo.
I was uncertain whether to comment the whole line and leave it in the code block or to move it outside of it: I moved it outside because of the code formatting used for `setNatural`