### PR TITLE
Only run codeql on main branch pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,8 @@ name: "Code Scanning - Action"
 
 on:
   push:
+    branches:    
+      - main
   pull_request:
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
We already run on PR so we should catch any changes pushed by devs in this repo. Dependabot doesn't have permission to run on push, so we end up failing this job, and its kind of pointless because a pr will just be opened, so lets just skip it.