### PR TITLE
Add test for large stdline output

### DIFF
--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -286,6 +286,34 @@ describe('@actions/exec', () => {
     expect(stderrCalled).toBeTruthy()
   })
 
+  it('Handles large stdline', async () => {
+    
+    const stdlinePath: string = path.join(
+      __dirname,
+      'scripts',
+      'stdlineoutput.js'
+    )
+    const nodePath: string = await io.which('node', true)
+
+    const _testExecOptions = getExecOptions()
+    let largeLine = ''
+    _testExecOptions.listeners = {
+      stdline: (line: string) => {
+        largeLine = line
+        
+      }
+    }
+
+    let exitCode = await exec.exec(
+      `"${nodePath}"`,
+      [stdlinePath],
+      _testExecOptions
+    )
+    expect(exitCode).toBe(0)
+    expect(Buffer.byteLength(largeLine)).toEqual(2**16 + 1)
+
+  })
+
   it('Handles stdin shell', async () => {
     let command: string
     if (IS_WINDOWS) {

--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -287,7 +287,6 @@ describe('@actions/exec', () => {
   })
 
   it('Handles large stdline', async () => {
-    
     const stdlinePath: string = path.join(
       __dirname,
       'scripts',
@@ -300,18 +299,16 @@ describe('@actions/exec', () => {
     _testExecOptions.listeners = {
       stdline: (line: string) => {
         largeLine = line
-        
       }
     }
 
-    let exitCode = await exec.exec(
+    const exitCode = await exec.exec(
       `"${nodePath}"`,
       [stdlinePath],
       _testExecOptions
     )
     expect(exitCode).toBe(0)
-    expect(Buffer.byteLength(largeLine)).toEqual(2**16 + 1)
-
+    expect(Buffer.byteLength(largeLine)).toEqual(2 ** 16 + 1)
   })
 
   it('Handles stdin shell', async () => {

--- a/packages/exec/__tests__/scripts/stdlineoutput.js
+++ b/packages/exec/__tests__/scripts/stdlineoutput.js
@@ -1,0 +1,3 @@
+//Default highWaterMark for readable stream buffers us 64K (2^16)
+//so we go over that to get more than a buffer's worth
+process.stdout.write('a'.repeat(2**16 + 1) + '\n');

--- a/packages/exec/__tests__/scripts/stdlineoutput.js
+++ b/packages/exec/__tests__/scripts/stdlineoutput.js
@@ -1,5 +1,5 @@
 //Default highWaterMark for readable stream buffers us 64K (2^16)
 //so we go over that to get more than a buffer's worth
-import * as os from 'os'
+const os = require('os')
 
 process.stdout.write('a'.repeat(2**16 + 1) + os.EOL);

--- a/packages/exec/__tests__/scripts/stdlineoutput.js
+++ b/packages/exec/__tests__/scripts/stdlineoutput.js
@@ -1,3 +1,5 @@
 //Default highWaterMark for readable stream buffers us 64K (2^16)
 //so we go over that to get more than a buffer's worth
-process.stdout.write('a'.repeat(2**16 + 1) + '\n');
+import * as os from 'os'
+
+process.stdout.write('a'.repeat(2**16 + 1) + os.EOL);


### PR DESCRIPTION
A followup to #773. This test that a very large line can be sent over the `stdline` listener. 