### PR TITLE
Extend `WebhookPayload` interface with `inputs` property

### DIFF
--- a/packages/github/src/interfaces.ts
+++ b/packages/github/src/interfaces.ts
@@ -40,4 +40,7 @@ export interface WebhookPayload {
     id: number
     [key: string]: any
   }
+  inputs?: {
+    [key: string]: string | null | undefined
+  }
 }


### PR DESCRIPTION
# Description

`WebhookPayload` interface was extended with `inputs` property in order to handle webhook payload received from [workflow_dispatch](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch) event in a more type-safe and convenient way.