### PR TITLE
HashFiles should not create an annotation/warn on no files

### DIFF
--- a/packages/glob/src/internal-hash-files.ts
+++ b/packages/glob/src/internal-hash-files.ts
@@ -36,7 +36,7 @@ export async function hashFiles(globber: Globber): Promise<string> {
     core.debug(`Found ${count} files to hash.`)
     return result.digest('hex')
   } else {
-    core.warning(`No matches found for glob`)
+    core.debug(`No matches found for glob`)
     return ''
   }
 }


### PR DESCRIPTION
It already returns the empty string, the action author can decide if they want to log or not.