### PR TITLE
Change `var` to `const`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -203,7 +203,7 @@ In action's `cleanup.js`:
 ```js
 const core = require('@actions/core');
 
-var pid = core.getState("pidToKill");
+const pid = core.getState("pidToKill");
 
 process.kill(pid);
 ```


### PR DESCRIPTION
We shouldn't use `var`, especially in user-facing documentation wherein it is likely to be be copy-pasted.