### PR TITLE
Bump artifact package version to v0.5.2

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -58,3 +58,6 @@
 
 - Bump @actions/http-client to version 1.0.11 to fix proxy related issues during artifact upload and download
 
+### 0.5.2
+
+- Add HTTP 500 as a retryable status code for artifact upload and download.

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [


### PR DESCRIPTION
Last version: https://github.com/actions/toolkit/pull/761

Changes since last version:
- https://github.com/actions/toolkit/pull/815 (no change in functionality to `artifact`)
- https://github.com/actions/toolkit/pull/833