### PR TITLE
feat: Check if action run `hasInput`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,6 +27,12 @@ const myMultilineInput = core.getMultilineInput('multilineInputName', { required
 core.setOutput('outputKey', 'outputVal');
 ```
 
+##### `hasInput`
+
+The `getInput` method will always return a string, even in cases where a value 
+has not been provided in the Workflow. To deterine if a value has been provided
+the `hasInput` method should be used.
+
 #### Exporting variables
 
 Since each step runs in a separate process, you can use `exportVariable` to add it to this step and future steps environment blocks.

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -17,6 +17,7 @@ const testEnvVars = {
   // Set inputs
   INPUT_MY_INPUT: 'val',
   INPUT_MISSING: '',
+  INPUT_EMPTY_STRING: '',
   'INPUT_SPECIAL_CHARS_\'\t"\\': '\'\t"\\ response ',
   INPUT_MULTIPLE_SPACES_VARIABLE: 'I have multiple spaces',
   INPUT_BOOLEAN_INPUT: 'true',
@@ -215,6 +216,12 @@ describe('@actions/core', () => {
         `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``
     )
   })
+
+  it('hasInput determines presence of Input enviromment variable', () => {
+    expect(core.hasInput('my_input')).toBe(true)
+    expect(core.hasInput('empty_string')).toBe(true)
+    expect(core.hasInput('input_does_not_exist')).toBe(false)
+  });
 
   it('setOutput produces the correct command', () => {
     core.setOutput('some output', 'some value')

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -78,6 +78,16 @@ export function addPath(inputPath: string): void {
 }
 
 /**
+ * Determines if the Input has been provided.
+ *
+ * @param   name name of the input to check for presence of
+ * @returns boolean
+ */
+export function hasInput(name: string): boolean {
+  return inputEnvKey(name) in process.env
+}
+
+/**
  * Gets the value of an input.
  * Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
  * Returns an empty string if the value is not defined.
@@ -87,8 +97,8 @@ export function addPath(inputPath: string): void {
  * @returns   string
  */
 export function getInput(name: string, options?: InputOptions): string {
-  const val: string =
-    process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || ''
+  const val: string = process.env[inputEnvKey(name)] || ''
+
   if (options && options.required && !val) {
     throw new Error(`Input required and not supplied: ${name}`)
   }
@@ -98,6 +108,16 @@ export function getInput(name: string, options?: InputOptions): string {
   }
 
   return val.trim()
+}
+
+/**
+ * Create Environment Variable key for input by name.
+ *
+ * @param     name     name of the input to generate Environment Key for.
+ * @returns   string
+ */
+function inputEnvKey(name: string): string {
+  return `INPUT_${name.replace(/ /g, '_').toUpperCase()}`
 }
 
 /**


### PR DESCRIPTION
I am trying to determine if an input has been provided in an action where an empty string is a valid value, unfortunately an empty string is treated the same as no input by `getInput`. I would _ideally_ like to change `getInput` to distinguish between "no value" and "empty value" but that would be a breaking change: the introduction of `hasInput` is a safe middle-ground that enables this determination _without_ any breaking changes.

--- 

An alternative I considered was introducing a `default` to `InputOptions` which would help bring `InputOptions` and `action.yml` in line but I think that introduces more questions (should `trimWhitespace` be an option in `action.yml`?) so I went for the simpler option.