### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/artifact-tests.yml
+++ b/.github/workflows/artifact-tests.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   build:
@@ -21,68 +21,69 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    # In order to upload & download artifacts from a shell script, certain env variables need to be set that are only available in the
-    # node context. This runs a local action that gets and sets the necessary env variables that are needed
-    - name: Set env variables
-      uses: ./packages/artifact/__tests__/ci-test-action/
+      # In order to upload & download artifacts from a shell script, certain env variables need to be set that are only available in the
+      # node context. This runs a local action that gets and sets the necessary env variables that are needed
+      - name: Set env variables
+        uses: ./packages/artifact/__tests__/ci-test-action/
 
-    # Need root node_modules because certain npm packages like jest are configured for the entire repository and it won't be possible
-    # without these to just compile the artifacts package
-    - name: Install root npm packages
-      run: npm ci
+      # Need root node_modules because certain npm packages like jest are configured for the entire repository and it won't be possible
+      # without these to just compile the artifacts package
+      - name: Install root npm packages
+        run: npm ci
 
-    - name: Compile artifact package
-      run: |
-        npm ci
-        npm run tsc
-      working-directory: packages/artifact
-    
-    - name: Set artifact file contents
-      shell: bash
-      run: |
-        echo "non-gzip-artifact-content=hello" >> $GITHUB_ENV
-        echo "gzip-artifact-content=Some large amount of text that has a compression ratio that is greater than 100%. If greater than 100%, gzip is used to upload the file" >> $GITHUB_ENV
+      - name: Compile artifact package
+        run: |
+          npm ci
+          npm run tsc
+        working-directory: packages/artifact
 
-    - name: Create files that will be uploaded
-      run: |
-        mkdir artifact-path 
-        echo ${{ env.non-gzip-artifact-content }} > artifact-path/world.txt
-        echo ${{ env.gzip-artifact-content }} > artifact-path/gzip.txt
+      - name: Set artifact file contents
+        shell: bash
+        run: |
+          echo "non-gzip-artifact-content=hello" >> $GITHUB_ENV
+          echo "gzip-artifact-content=Some large amount of text that has a compression ratio that is greater than 100%. If greater than 100%, gzip is used to upload the file" >> $GITHUB_ENV
 
-    # We're using node -e to call the functions directly available in the @actions/artifact package
-    - name: Upload artifacts using uploadArtifact()
-      run: |
-        node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().uploadArtifact('my-artifact-1',['artifact-path/world.txt'], '${{ github.workspace }}'))"
-        node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().uploadArtifact('my-artifact-2',['artifact-path/gzip.txt'], '${{ github.workspace }}'))"
+      - name: Create files that will be uploaded
+        run: |
+          mkdir artifact-path 
+          echo ${{ env.non-gzip-artifact-content }} > artifact-path/world.txt
+          echo ${{ env.gzip-artifact-content }} > artifact-path/gzip.txt
 
-    - name: Download artifacts using downloadArtifact()
-      run: |
-        mkdir artifact-1-directory
-        node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().downloadArtifact('my-artifact-1','artifact-1-directory'))"
-        mkdir artifact-2-directory
-        node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().downloadArtifact('my-artifact-2','artifact-2-directory'))"
-    
-    - name: Verify downloadArtifact()
-      shell: bash
-      run: |
-        packages/artifact/__tests__/test-artifact-file.sh "artifact-1-directory/artifact-path/world.txt" "${{ env.non-gzip-artifact-content }}"
-        packages/artifact/__tests__/test-artifact-file.sh "artifact-2-directory/artifact-path/gzip.txt" "${{ env.gzip-artifact-content }}"
+      # We're using node -e to call the functions directly available in the @actions/artifact package
+      - name: Upload artifacts using uploadArtifact()
+        run: |
+          node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().uploadArtifact('my-artifact-1',['artifact-path/world.txt'], '${{ github.workspace }}'))"
+          node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().uploadArtifact('my-artifact-2',['artifact-path/gzip.txt'], '${{ github.workspace }}'))"
 
-    - name: Download artifacts using downloadAllArtifacts()
-      run: |
-        mkdir multi-artifact-directory
-        node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().downloadAllArtifacts('multi-artifact-directory'))"
+      - name: Download artifacts using downloadArtifact()
+        run: |
+          mkdir artifact-1-directory
+          node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().downloadArtifact('my-artifact-1','artifact-1-directory'))"
+          mkdir artifact-2-directory
+          node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().downloadArtifact('my-artifact-2','artifact-2-directory'))"
 
-    - name: Verify downloadAllArtifacts()
-      shell: bash
-      run: |
-        packages/artifact/__tests__/test-artifact-file.sh "multi-artifact-directory/my-artifact-1/artifact-path/world.txt" "${{ env.non-gzip-artifact-content }}"
-        packages/artifact/__tests__/test-artifact-file.sh "multi-artifact-directory/my-artifact-2/artifact-path/gzip.txt" "${{ env.gzip-artifact-content }}"
+      - name: Verify downloadArtifact()
+        shell: bash
+        run: |
+          packages/artifact/__tests__/test-artifact-file.sh "artifact-1-directory/artifact-path/world.txt" "${{ env.non-gzip-artifact-content }}"
+          packages/artifact/__tests__/test-artifact-file.sh "artifact-2-directory/artifact-path/gzip.txt" "${{ env.gzip-artifact-content }}"
+
+      - name: Download artifacts using downloadAllArtifacts()
+        run: |
+          mkdir multi-artifact-directory
+          node -e "Promise.resolve(require('./packages/artifact/lib/artifact-client').create().downloadAllArtifacts('multi-artifact-directory'))"
+
+      - name: Verify downloadAllArtifacts()
+        shell: bash
+        run: |
+          packages/artifact/__tests__/test-artifact-file.sh "multi-artifact-directory/my-artifact-1/artifact-path/world.txt" "${{ env.non-gzip-artifact-content }}"
+          packages/artifact/__tests__/test-artifact-file.sh "multi-artifact-directory/my-artifact-2/artifact-path/gzip.txt" "${{ env.gzip-artifact-content }}"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,36 +4,38 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
-
   build:
     name: Audit
 
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    - name: npm install
-      run: npm install
+      - name: npm install
+        run: npm install
 
-    - name: Bootstrap
-      run: npm run bootstrap
+      - name: Bootstrap
+        run: npm run bootstrap
 
-    - name: audit tools
-      # `|| npm audit` to pretty-print the output if vulnerabilies are found after filtering.
-      run: npm audit --audit-level=moderate --json | scripts/audit-allow-list || npm audit --audit-level=moderate
+      - name: audit tools
+        # `|| npm audit` to pretty-print the output if vulnerabilies are found after filtering.
+        run:
+          npm audit --audit-level=moderate --json | scripts/audit-allow-list || npm
+          audit --audit-level=moderate
 
-    - name: audit packages
-      run: npm run audit-all
+      - name: audit packages
+        run: npm run audit-all

--- a/.github/workflows/cache-tests.yml
+++ b/.github/workflows/cache-tests.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   build:
@@ -21,71 +21,73 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    # In order to save & restore cache from a shell script, certain env variables need to be set that are only available in the
-    # node context. This runs a local action that gets and sets the necessary env variables that are needed
-    - name: Set env variables
-      uses: ./packages/cache/__tests__/__fixtures__/
+      # In order to save & restore cache from a shell script, certain env variables need to be set that are only available in the
+      # node context. This runs a local action that gets and sets the necessary env variables that are needed
+      - name: Set env variables
+        uses: ./packages/cache/__tests__/__fixtures__/
 
-    # Need root node_modules because certain npm packages like jest are configured for the entire repository and it won't be possible
-    # without these to just compile the cache package
-    - name: Install root npm packages
-      run: npm ci
+      # Need root node_modules because certain npm packages like jest are configured for the entire repository and it won't be possible
+      # without these to just compile the cache package
+      - name: Install root npm packages
+        run: npm ci
 
-    - name: Compile cache package
-      run: |
-        npm ci
-        npm run tsc
-      working-directory: packages/cache
-    
-    - name: Generate files in working directory
-      shell: bash
-      run: packages/cache/__tests__/create-cache-files.sh ${{ runner.os }} test-cache
+      - name: Compile cache package
+        run: |
+          npm ci
+          npm run tsc
+        working-directory: packages/cache
 
-    - name: Generate files outside working directory
-      shell: bash
-      run: packages/cache/__tests__/create-cache-files.sh ${{ runner.os }} ~/test-cache
+      - name: Generate files in working directory
+        shell: bash
+        run: packages/cache/__tests__/create-cache-files.sh ${{ runner.os }} test-cache
 
-    # We're using node -e to call the functions directly available in the @actions/cache package
-    - name: Save cache using saveCache()
-      run: |
-        node -e "Promise.resolve(require('./packages/cache/lib/cache').saveCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
+      - name: Generate files outside working directory
+        shell: bash
+        run: packages/cache/__tests__/create-cache-files.sh ${{ runner.os }}
+          ~/test-cache
 
-    - name: Delete cache folders before restoring
-      shell: bash
-      run: |
-        rm -rf test-cache
-        rm -rf ~/test-cache
+      # We're using node -e to call the functions directly available in the @actions/cache package
+      - name: Save cache using saveCache()
+        run: |
+          node -e "Promise.resolve(require('./packages/cache/lib/cache').saveCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
 
-    - name: Restore cache using restoreCache() with http-client
-      run: |
-        node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}',[],{useAzureSdk: false}))"
+      - name: Delete cache folders before restoring
+        shell: bash
+        run: |
+          rm -rf test-cache
+          rm -rf ~/test-cache
 
-    - name: Verify cache restored with http-client
-      shell: bash
-      run: |
-        packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} test-cache
-        packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
+      - name: Restore cache using restoreCache() with http-client
+        run: |
+          node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}',[],{useAzureSdk: false}))"
 
-    - name: Delete cache folders before restoring
-      shell: bash
-      run: |
-        rm -rf test-cache
-        rm -rf ~/test-cache
+      - name: Verify cache restored with http-client
+        shell: bash
+        run: |
+          packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} test-cache
+          packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
 
-    - name: Restore cache using restoreCache() with Azure SDK
-      run: |
-        node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
+      - name: Delete cache folders before restoring
+        shell: bash
+        run: |
+          rm -rf test-cache
+          rm -rf ~/test-cache
 
-    - name: Verify cache restored with Azure SDK
-      shell: bash
-      run: |
-        packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} test-cache
-        packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
+      - name: Restore cache using restoreCache() with Azure SDK
+        run: |
+          node -e "Promise.resolve(require('./packages/cache/lib/cache').restoreCache(['test-cache','~/test-cache'],'test-${{ runner.os }}-${{ github.run_id }}'))"
+
+      - name: Verify cache restored with Azure SDK
+        shell: bash
+        run: |
+          packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} test-cache
+          packages/cache/__tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,13 +4,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
-
   build:
     name: Build
 
@@ -22,30 +21,31 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    - name: npm install
-      run: npm install
+      - name: npm install
+        run: npm install
 
-    - name: Bootstrap
-      run: npm run bootstrap
+      - name: Bootstrap
+        run: npm run bootstrap
 
-    - name: Compile
-      run: npm run build
+      - name: Compile
+        run: npm run build
 
-    - name: npm test
-      run: npm test
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      - name: npm test
+        run: npm test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
-    - name: Lint
-      run: npm run lint
+      - name: Lint
+        run: npm run lint
 
-    - name: Format
-      run: npm run format-check
+      - name: Format
+        run: npm run format-check


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
