### PR TITLE
cache: bump uuid v8.3.2

### DIFF
--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -4336,6 +4336,11 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -4402,9 +4407,9 @@
       }
     },
     "@types/uuid": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
     },
     "abort-controller": {
@@ -4560,9 +4565,9 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "xml2js": {
       "version": "0.4.23",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -45,11 +45,11 @@
     "@azure/ms-rest-js": "^2.0.7",
     "@azure/storage-blob": "^12.1.2",
     "semver": "^6.1.0",
-    "uuid": "^3.3.3"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "typescript": "^3.8.3",
     "@types/semver": "^6.0.0",
-    "@types/uuid": "^3.4.5"
+    "@types/uuid": "^8.3.1",
+    "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
When I install `@actions/cache`, I get the following warning.

```
% npm install @actions/cache
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

added 59 packages, and audited 60 packages in 8s

found 0 vulnerabilities
```

This pull request fixes it.
ref. https://www.npmjs.com/package/uuid#upgrading-from-uuid3x