### PR TITLE
Reset processedCount when downloading all artifacts

### DIFF
--- a/packages/artifact/src/internal/status-reporter.ts
+++ b/packages/artifact/src/internal/status-reporter.ts
@@ -24,6 +24,7 @@ export class StatusReporter {
 
   setTotalNumberOfFilesToProcess(fileTotal: number): void {
     this.totalNumberOfFilesToProcess = fileTotal
+    this.processedCount = 0
   }
 
   start(): void {


### PR DESCRIPTION
Currently the `totalNumberOfFilesToProcess` was reset for each artifact but not the `processedCount` which lead to percentage values higher than 100% when downloading all artifacts. Also resetting the `processedCount` to `0` fixes that and scopes the counts to a single artifact.

Fixes https://github.com/actions/download-artifact/issues/95

Here is another output with > 100% percent in log output https://github.com/campersau/CefSharp/runs/3389459433?check_suite_focus=true#step:2:3. There are two artifacts with 4 files each:

```
No artifact name specified, downloading all artifacts
Creating an extra directory for each artifact that is being downloaded
Total number of files that will be downloaded: 4
Total file count: 4 ---- Processed file #3 (75.0%)
Total number of files that will be downloaded: 4
Total file count: 4 ---- Processed file #6 (150.0%) <!--- Total file count 4 but file 6!
There were 2 artifacts downloaded
Artifact netcore was downloaded to D:\a\CefSharp\CefSharp\netcore
Artifact netframework was downloaded to D:\a\CefSharp\CefSharp\netframework
Artifact download has finished successfully
```