### PR TITLE
beta release of 1.6.0 for oidc preview

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.6.0",
+  "version": "1.6.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.6.0",
+  "version": "1.6.0-beta.0",
   "description": "Actions core lib",
   "keywords": [
     "github",


### PR DESCRIPTION
This Pr updates the tags for @actions/core so we can do a beta release of the oidc functionality in a preview npm tag