### PR TITLE
core: Update "core.error" documentation

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -121,7 +121,7 @@ const result = await core.group('Do something async', async () => {
 
 This library has 3 methods that will produce [annotations](https://docs.github.com/en/rest/reference/checks#create-a-check-run). 
 ```js
-core.error('This is a bad error. This will also fail the build.')
+core.error('This is a bad error, action may still succeed though.')
 
 core.warning('Something went wrong, but it\'s not bad enough to fail the build.')
 


### PR DESCRIPTION
Change the `core.error` documentation to say that it won't automatically fail the action. This matches the existing example in the "logging" section.

Fixes #902