### PR TITLE
Add GITHUB_REF_TYPE support to github context

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -12,6 +12,7 @@ export class Context {
   eventName: string
   sha: string
   ref: string
+  ref_type: string
   workflow: string
   action: string
   actor: string
@@ -40,6 +41,7 @@ export class Context {
     this.eventName = process.env.GITHUB_EVENT_NAME as string
     this.sha = process.env.GITHUB_SHA as string
     this.ref = process.env.GITHUB_REF as string
+    this.ref_type = process.env.GITHUB_REF_TYPE as string
     this.workflow = process.env.GITHUB_WORKFLOW as string
     this.action = process.env.GITHUB_ACTION as string
     this.actor = process.env.GITHUB_ACTOR as string


### PR DESCRIPTION
Hope it is all changes required to pass ref_type info from env to github context.
It's first time I touch actions toolkit and I'm not sure if I hadn't miss something.