### PR TITLE
Export GitHub type

### DIFF
--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -4,6 +4,7 @@ import {GitHub, getOctokitOptions} from './utils'
 // octokit + plugins
 import {OctokitOptions} from '@octokit/core/dist-types/types'
 
+export {GitHub};
 export const context = new Context.Context()
 
 /**


### PR DESCRIPTION
As a user I want to use the `GitHub` type to pass the octokit instace between functions using TypeScript.

```javascript
import {context, GitHub} from '@actions/github';

const addLabels = async (octokit: GitHub, prNumber: number, labels: Set<string>): Promise<void> => {
  await octokit.rest.issues.addLabels({
    owner: context.repo.owner,
    repo: context.repo.repo,
    issue_number: prNumber,
    labels: [...labels],
  });
};
```