### PR TITLE
Ability to overwrite base url in actions/cache

### DIFF
--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -32,7 +32,10 @@ const versionSalt = '1.0'
 
 function getCacheApiUrl(resource: string): string {
   // Ideally we just use ACTIONS_CACHE_URL
+  // For cases where ACTIONS_* cannot be overwritten, allow the usage
+  // of GITHUB_ACTIONS_CACHE_URL.
   const baseUrl: string = (
+    process.env['GITHUB_ACTIONS_CACHE_URL'] ||
     process.env['ACTIONS_CACHE_URL'] ||
     process.env['ACTIONS_RUNTIME_URL'] ||
     ''


### PR DESCRIPTION
As ACTIONS_CACHE_URL cannot be overwritten in actions/cache,
provide the ability to overwrite it using GITHUB_ACTIONS_CACHE_URL.

See https://github.com/actions/cache/pull/679 for more context