### PR TITLE
Updates to logging for artifact uploads

### DIFF
--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -74,8 +74,7 @@ export class DefaultArtifactClient implements ArtifactClient {
   ): Promise<UploadResponse> {
     core.info(
       `Starting artifact upload
- 
-      For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging`
+For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging`
     )
     checkArtifactName(name)
 
@@ -110,7 +109,9 @@ export class DefaultArtifactClient implements ArtifactClient {
       }
 
       core.debug(`Upload Resource URL: ${response.fileContainerResourceUrl}`)
-      core.info(`Container for artifact: ${name} successfully created. Starting upload of file(s)`)
+      core.info(
+        `Container for artifact "${name}" successfully created. Starting upload of file(s)`
+      )
 
       // Upload each of the files that were found concurrently
       const uploadResult = await uploadHttpClient.uploadArtifactToFileContainer(
@@ -121,22 +122,25 @@ export class DefaultArtifactClient implements ArtifactClient {
 
       // Update the size of the artifact to indicate we are done uploading
       // The uncompressed size is used for display when downloading a zip of the artifact from the UI
-      core.info(`File upload process has finished. Finalizing the artifact upload`)
+      core.info(
+        `File upload process has finished. Finalizing the artifact upload`
+      )
       await uploadHttpClient.patchArtifactSize(uploadResult.totalSize, name)
 
-      if(uploadResult.failedItems.length > 0){
-        core.info(`Upload finished. There were ${uploadResult.failedItems.length} items that failed to upload`)
+      if (uploadResult.failedItems.length > 0) {
+        core.info(
+          `Upload finished. There were ${uploadResult.failedItems.length} items that failed to upload`
+        )
       } else {
-        core.info(`All files have been successfully uploaded!`)
+        core.info(`Artifact has been finalized. All files have been successfully uploaded!`)
       }
 
       core.info(
-        `Finished artifact upload. 
-        
-        The raw size of all the files that were specified for upload is ${uploadResult.totalSize}
-        The size of all the files that were uploaded (this takes into account any gzip compression used to reduce the upload size and storage of individual files) is ${uploadResult.uploadSize}
-        
-        \u001b[1mNote, files are uploaded individually however a zip file is dynamically created for each artifact when a download is started from the GitHub UI or API (to aggregate uploads that have more than one uploaded file). The size of the dynamically created zip file can differ significantly from the reported size.`
+        `
+The raw size of all the files that were specified for upload is ${uploadResult.totalSize} bytes
+The size of all the files that were uploaded is ${uploadResult.uploadSize} bytes. This takes into account any gzip compression used to reduce the upload size, time and storage
+
+Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads \r\n`
       )
 
       uploadResponse.artifactItems = uploadSpecification.map(

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -132,7 +132,9 @@ For more detailed logs during the artifact upload process, enable step-debugging
           `Upload finished. There were ${uploadResult.failedItems.length} items that failed to upload`
         )
       } else {
-        core.info(`Artifact has been finalized. All files have been successfully uploaded!`)
+        core.info(
+          `Artifact has been finalized. All files have been successfully uploaded!`
+        )
       }
 
       core.info(

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -131,7 +131,12 @@ export class DefaultArtifactClient implements ArtifactClient {
       }
 
       core.info(
-        `Finished artifact upload. The raw size of all files (pre-compression) that were uploaded is ${uploadResult.uploadSize} bytes.`
+        `Finished artifact upload. 
+        
+        The raw size of all the files that were specified for upload is ${uploadResult.totalSize}
+        The size of all the files that were uploaded (this takes into account any gzip compression used to reduce the upload size and storage of individual files) is ${uploadResult.uploadSize}
+        
+        \u001b[1mNote, files are uploaded individually however a zip file is dynamically created for each artifact when a download is started from the GitHub UI or API (to aggregate uploads that have more than one uploaded file). The size of the dynamically created zip file can differ significantly from the reported size.`
       )
 
       uploadResponse.artifactItems = uploadSpecification.map(

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -74,7 +74,7 @@ export class DefaultArtifactClient implements ArtifactClient {
   ): Promise<UploadResponse> {
     core.info(
       `Starting artifact upload
-For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging`
+For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging`
     )
     checkArtifactName(name)
 

--- a/packages/artifact/src/internal/contracts.ts
+++ b/packages/artifact/src/internal/contracts.ts
@@ -30,7 +30,7 @@ export interface PatchArtifactSizeSuccessResponse {
 
 export interface UploadResults {
   /**
-   * The size in bytes of data that was transferred during the upload process to the actions backend service. This takes into account possible 
+   * The size in bytes of data that was transferred during the upload process to the actions backend service. This takes into account possible
    * gzip compression to reduce the amount of data that needs to be transferred
    */
   uploadSize: number

--- a/packages/artifact/src/internal/contracts.ts
+++ b/packages/artifact/src/internal/contracts.ts
@@ -29,8 +29,20 @@ export interface PatchArtifactSizeSuccessResponse {
 }
 
 export interface UploadResults {
+  /**
+   * The size in bytes of data that was transferred during the upload process to the actions backend service. This takes into account possible 
+   * gzip compression to reduce the amount of data that needs to be transferred
+   */
   uploadSize: number
+
+  /**
+   * The raw size of the files that were specified for upload
+   */
   totalSize: number
+
+  /**
+   * An array of files that failed to upload
+   */
   failedItems: string[]
 }
 

--- a/packages/artifact/src/internal/upload-http-client.ts
+++ b/packages/artifact/src/internal/upload-http-client.ts
@@ -231,7 +231,7 @@ export class UploadHttpClient {
     if (totalFileSize < 65536) {
       const buffer = await createGZipFileInBuffer(parameters.file)
 
-      //An open stream is needed in the event of a failure and we need to retry. If a NodeJS.ReadableStream is directly passed in,
+      // An open stream is needed in the event of a failure and we need to retry. If a NodeJS.ReadableStream is directly passed in,
       // it will not properly get reset to the start of the stream if a chunk upload needs to be retried
       let openUploadStream: () => NodeJS.ReadableStream
 

--- a/packages/artifact/src/internal/upload-specification.ts
+++ b/packages/artifact/src/internal/upload-specification.ts
@@ -19,8 +19,7 @@ export function getUploadSpecification(
   rootDirectory: string,
   artifactFiles: string[]
 ): UploadSpecification[] {
-  checkArtifactName(artifactName)
-
+  // artifact name was checked earlier on
   const specifications: UploadSpecification[] = []
 
   if (!fs.existsSync(rootDirectory)) {

--- a/packages/artifact/src/internal/upload-specification.ts
+++ b/packages/artifact/src/internal/upload-specification.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import {debug} from '@actions/core'
 import {join, normalize, resolve} from 'path'
-import {checkArtifactName, checkArtifactFilePath} from './utils'
+import {checkArtifactFilePath} from './utils'
 
 export interface UploadSpecification {
   absoluteFilePath: string
@@ -19,7 +19,7 @@ export function getUploadSpecification(
   rootDirectory: string,
   artifactFiles: string[]
 ): UploadSpecification[] {
-  // artifact name was checked earlier on
+  // artifact name was checked earlier on, no need to check again
   const specifications: UploadSpecification[] = []
 
   if (!fs.existsSync(rootDirectory)) {

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -30,7 +30,7 @@ export function getExponentialRetryTimeInMilliseconds(
   const maxTime = minTime * getRetryMultiplier()
 
   // returns a random number between the minTime (inclusive) and the maxTime (exclusive)
-  return Math.random() * (maxTime - minTime) + minTime
+  return Math.trunc(Math.random() * (maxTime - minTime) + minTime)
 }
 
 /**
@@ -263,10 +263,16 @@ export function checkArtifactName(name: string): void {
   for (const invalidChar of invalidArtifactNameCharacters) {
     if (name.includes(invalidChar)) {
       throw new Error(
-        `Artifact name is not valid: ${name}. Contains character: "${invalidChar}". Invalid artifact name characters include: ${invalidArtifactNameCharacters.toString()}.`
+        `Artifact name is not valid: ${name}. Contains the following character: "${invalidChar}".
+        
+        Invalid characters include: ${invalidArtifactNameCharacters.toString()}.
+        
+        These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.`
       )
     }
   }
+
+  info(`Artifact name is valid!`)
 }
 
 /**
@@ -280,7 +286,10 @@ export function checkArtifactFilePath(path: string): void {
   for (const invalidChar of invalidArtifactFilePathCharacters) {
     if (path.includes(invalidChar)) {
       throw new Error(
-        `Artifact path is not valid: ${path}. Contains character: "${invalidChar}". Invalid characters include: ${invalidArtifactFilePathCharacters.toString()}.`
+        `Artifact path is not valid: ${path}. Contains the following character: "${invalidChar}". Invalid characters include: ${invalidArtifactFilePathCharacters.toString()}.
+        
+        The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
+        `
       )
     }
   }

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -265,9 +265,9 @@ export function checkArtifactName(name: string): void {
       throw new Error(
         `Artifact name is not valid: ${name}. Contains the following character: "${invalidChar}".
         
-        Invalid characters include: ${invalidArtifactNameCharacters.toString()}.
+Invalid characters include: ${invalidArtifactNameCharacters.toString()}.
         
-        These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.`
+These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.`
       )
     }
   }


### PR DESCRIPTION
This fixes a bunch of small things that make the upload process better
- Clarifications around the upload size
- Improved debug logs around gzip behavior
- truncate millisecond time with error message during exponential back-off is in-progress
- Improve logs to be be a bit more verbose 
- Links to how to enable debug logs + link to limitations around gzip behavior

---

Improved logs (with step debugs enabled): https://github.com/konradpabjan/artifact-test/runs/4359261863?check_suite_focus=true

![image](https://user-images.githubusercontent.com/16109154/143955356-5169d0e7-6e38-4135-999e-88c9e6f09682.png)

Older logs for comparison: https://github.com/konradpabjan/artifact-test/runs/4266680264?check_suite_focus=true

![image](https://user-images.githubusercontent.com/16109154/143955455-fb957b26-0714-4b60-8bda-68b5114330c3.png)

---

Closes:
https://github.com/actions/upload-artifact/issues/208

More clear error message to close out:
https://github.com/actions/upload-artifact/issues/243