### PR TITLE
Check for newlines and carriage return in artifact paths and name

### DIFF
--- a/packages/artifact/__tests__/path-and-artifact-name-validation.test.ts
+++ b/packages/artifact/__tests__/path-and-artifact-name-validation.test.ts
@@ -1,0 +1,78 @@
+import {
+  checkArtifactName,
+  checkArtifactFilePath
+} from '../src/internal/path-and-artifact-name-validation'
+import * as core from '@actions/core'
+
+describe('Path and artifact name validation', () => {
+  beforeAll(() => {
+    // mock all output so that there is less noise when running tests
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(core, 'debug').mockImplementation(() => {})
+    jest.spyOn(core, 'info').mockImplementation(() => {})
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+  })
+
+  it('Check Artifact Name for any invalid characters', () => {
+    const invalidNames = [
+      'my\\artifact',
+      'my/artifact',
+      'my"artifact',
+      'my:artifact',
+      'my<artifact',
+      'my>artifact',
+      'my|artifact',
+      'my*artifact',
+      'my?artifact',
+      ''
+    ]
+    for (const invalidName of invalidNames) {
+      expect(() => {
+        checkArtifactName(invalidName)
+      }).toThrow()
+    }
+
+    const validNames = [
+      'my-normal-artifact',
+      'myNormalArtifact',
+      'm¥ñðrmålÄr†ï£å¢†'
+    ]
+    for (const validName of validNames) {
+      expect(() => {
+        checkArtifactName(validName)
+      }).not.toThrow()
+    }
+  })
+
+  it('Check Artifact File Path for any invalid characters', () => {
+    const invalidNames = [
+      'some/invalid"artifact/path',
+      'some/invalid:artifact/path',
+      'some/invalid<artifact/path',
+      'some/invalid>artifact/path',
+      'some/invalid|artifact/path',
+      'some/invalid*artifact/path',
+      'some/invalid?artifact/path',
+      'some/invalid\rartifact/path',
+      'some/invalid\nartifact/path',
+      'some/invalid\r\nartifact/path',
+      ''
+    ]
+    for (const invalidName of invalidNames) {
+      expect(() => {
+        checkArtifactFilePath(invalidName)
+      }).toThrow()
+    }
+
+    const validNames = [
+      'my/perfectly-normal/artifact-path',
+      'my/perfectly\\Normal/Artifact-path',
+      'm¥/ñðrmål/Är†ï£å¢†'
+    ]
+    for (const validName of validNames) {
+      expect(() => {
+        checkArtifactFilePath(validName)
+      }).not.toThrow()
+    }
+  })
+})

--- a/packages/artifact/__tests__/util.test.ts
+++ b/packages/artifact/__tests__/util.test.ts
@@ -46,66 +46,6 @@ describe('Utils', () => {
     }
   })
 
-  it('Check Artifact Name for any invalid characters', () => {
-    const invalidNames = [
-      'my\\artifact',
-      'my/artifact',
-      'my"artifact',
-      'my:artifact',
-      'my<artifact',
-      'my>artifact',
-      'my|artifact',
-      'my*artifact',
-      'my?artifact',
-      ''
-    ]
-    for (const invalidName of invalidNames) {
-      expect(() => {
-        utils.checkArtifactName(invalidName)
-      }).toThrow()
-    }
-
-    const validNames = [
-      'my-normal-artifact',
-      'myNormalArtifact',
-      'm¥ñðrmålÄr†ï£å¢†'
-    ]
-    for (const validName of validNames) {
-      expect(() => {
-        utils.checkArtifactName(validName)
-      }).not.toThrow()
-    }
-  })
-
-  it('Check Artifact File Path for any invalid characters', () => {
-    const invalidNames = [
-      'some/invalid"artifact/path',
-      'some/invalid:artifact/path',
-      'some/invalid<artifact/path',
-      'some/invalid>artifact/path',
-      'some/invalid|artifact/path',
-      'some/invalid*artifact/path',
-      'some/invalid?artifact/path',
-      ''
-    ]
-    for (const invalidName of invalidNames) {
-      expect(() => {
-        utils.checkArtifactFilePath(invalidName)
-      }).toThrow()
-    }
-
-    const validNames = [
-      'my/perfectly-normal/artifact-path',
-      'my/perfectly\\Normal/Artifact-path',
-      'm¥/ñðrmål/Är†ï£å¢†'
-    ]
-    for (const validName of validNames) {
-      expect(() => {
-        utils.checkArtifactFilePath(validName)
-      }).not.toThrow()
-    }
-  })
-
   it('Test negative artifact retention throws', () => {
     expect(() => {
       utils.getProperRetention(-1, undefined)

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -9,10 +9,10 @@ import {UploadOptions} from './upload-options'
 import {DownloadOptions} from './download-options'
 import {DownloadResponse} from './download-response'
 import {
-  checkArtifactName,
   createDirectoriesForArtifact,
   createEmptyFilesForArtifact
 } from './utils'
+import {checkArtifactName} from './path-and-artifact-name-validation'
 import {DownloadHttpClient} from './download-http-client'
 import {getDownloadSpecification} from './download-specification'
 import {getWorkSpaceDirectory} from './config-variables'

--- a/packages/artifact/src/internal/path-and-artifact-name-validation.ts
+++ b/packages/artifact/src/internal/path-and-artifact-name-validation.ts
@@ -20,7 +20,7 @@ const invalidArtifactFilePathCharacters = new Map<string, string>([
   ['\n', ' Line feed \\n']
 ])
 
-let invalidArtifactNameCharacters = new Map<string, string>([
+const invalidArtifactNameCharacters = new Map<string, string>([
   ...invalidArtifactFilePathCharacters,
   ['\\', ' Backslash \\'],
   ['/', ' Forward slash /']

--- a/packages/artifact/src/internal/path-and-artifact-name-validation.ts
+++ b/packages/artifact/src/internal/path-and-artifact-name-validation.ts
@@ -55,8 +55,7 @@ These characters are not allowed in the artifact name due to limitations with ce
 }
 
 /**
- * Scans the name of the filePath used to make sure there are no illegal characters. If a file with an illegal character
- * is attempted to be uploaded an error will be returned from the server fail so this must be checked on the client-side first
+ * Scans the name of the filePath used to make sure there are no illegal characters
  */
 export function checkArtifactFilePath(path: string): void {
   if (!path) {

--- a/packages/artifact/src/internal/path-and-artifact-name-validation.ts
+++ b/packages/artifact/src/internal/path-and-artifact-name-validation.ts
@@ -9,7 +9,7 @@ import {info} from '@actions/core'
  * FilePaths can include characters such as \ and / which are not permitted in the artifact name alone
  */
 const invalidArtifactFilePathCharacters = new Map<string, string>([
-  ['"', 'Double quote "'], // no spacing at the start of "Double" so that text in errors annotations lines up nicely
+  ['"', ' Double quote "'],
   [':', ' Colon :'],
   ['<', ' Less than <'],
   ['>', ' Greater than >'],

--- a/packages/artifact/src/internal/path-and-artifact-name-validation.ts
+++ b/packages/artifact/src/internal/path-and-artifact-name-validation.ts
@@ -1,0 +1,83 @@
+import {info} from '@actions/core'
+
+/**
+ * Invalid characters that cannot be in the artifact name or an uploaded file. Will be rejected
+ * from the server if attempted to be sent over. These characters are not allowed due to limitations with certain
+ * file systems such as NTFS. To maintain platform-agnostic behavior, all characters that are not supported by an
+ * individual filesystem/platform will not be supported on all fileSystems/platforms
+ *
+ * FilePaths can include characters such as \ and / which are not permitted in the artifact name alone
+ */
+const invalidArtifactFilePathCharacters = new Map<string, string>([
+  ['"', 'Double quote "'],
+  [':', ' Colon :'],
+  ['<', ' Less than <'],
+  ['>', ' Greater than >'],
+  ['|', ' Vertical bar |'],
+  ['*', ' Asterisk *'],
+  ['?', ' Question mark ?'],
+  ['\r', ' Carriage return \\r'],
+  ['\n', ' Line feed \\n']
+])
+
+let invalidArtifactNameCharacters = new Map<string, string>([
+  ...invalidArtifactFilePathCharacters,
+  ['\\', ' Backslash \\'],
+  ['/', ' Forward slash /']
+])
+
+/**
+ * Scans the name of the artifact to make sure there are no illegal characters
+ */
+export function checkArtifactName(name: string): void {
+  if (!name) {
+    throw new Error(`Artifact name: ${name}, is incorrectly provided`)
+  }
+
+  for (const [
+    invalidCharacterKey,
+    errorMessageForCharacter
+  ] of invalidArtifactNameCharacters) {
+    if (name.includes(invalidCharacterKey)) {
+      throw new Error(
+        `Artifact name is not valid: ${name}. Contains the following character: ${errorMessageForCharacter}
+          
+Invalid characters include: ${Array.from(
+          invalidArtifactNameCharacters.values()
+        ).toString()}
+          
+These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.`
+      )
+    }
+  }
+
+  info(`Artifact name is valid!`)
+}
+
+/**
+ * Scans the name of the filePath used to make sure there are no illegal characters. If a file with an illegal character
+ * is attempted to be uploaded an error will be returned from the server fail so this must be checked on the client-side first
+ */
+export function checkArtifactFilePath(path: string): void {
+  if (!path) {
+    throw new Error(`Artifact path: ${path}, is incorrectly provided`)
+  }
+
+  for (const [
+    invalidCharacterKey,
+    errorMessageForCharacter
+  ] of invalidArtifactFilePathCharacters) {
+    if (path.includes(invalidCharacterKey)) {
+      throw new Error(
+        `Artifact path is not valid: ${path}. Contains the following character: ${errorMessageForCharacter}
+          
+Invalid characters include: ${Array.from(
+          invalidArtifactFilePathCharacters.values()
+        ).toString()}
+          
+The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
+          `
+      )
+    }
+  }
+}

--- a/packages/artifact/src/internal/path-and-artifact-name-validation.ts
+++ b/packages/artifact/src/internal/path-and-artifact-name-validation.ts
@@ -9,7 +9,7 @@ import {info} from '@actions/core'
  * FilePaths can include characters such as \ and / which are not permitted in the artifact name alone
  */
 const invalidArtifactFilePathCharacters = new Map<string, string>([
-  ['"', 'Double quote "'],
+  ['"', 'Double quote "'], // no spacing at the start of "Double" so that text in errors annotations lines up nicely
   [':', ' Colon :'],
   ['<', ' Less than <'],
   ['>', ' Greater than >'],

--- a/packages/artifact/src/internal/upload-specification.ts
+++ b/packages/artifact/src/internal/upload-specification.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import {debug} from '@actions/core'
 import {join, normalize, resolve} from 'path'
-import {checkArtifactFilePath} from './utils'
+import {checkArtifactFilePath} from './path-and-artifact-name-validation'
 
 export interface UploadSpecification {
   absoluteFilePath: string

--- a/packages/artifact/src/internal/utils.ts
+++ b/packages/artifact/src/internal/utils.ts
@@ -237,64 +237,6 @@ Header Information: ${JSON.stringify(response.message.headers, undefined, 2)}
   )
 }
 
-/**
- * Invalid characters that cannot be in the artifact name or an uploaded file. Will be rejected
- * from the server if attempted to be sent over. These characters are not allowed due to limitations with certain
- * file systems such as NTFS. To maintain platform-agnostic behavior, all characters that are not supported by an
- * individual filesystem/platform will not be supported on all fileSystems/platforms
- *
- * FilePaths can include characters such as \ and / which are not permitted in the artifact name alone
- */
-const invalidArtifactFilePathCharacters = ['"', ':', '<', '>', '|', '*', '?']
-const invalidArtifactNameCharacters = [
-  ...invalidArtifactFilePathCharacters,
-  '\\',
-  '/'
-]
-
-/**
- * Scans the name of the artifact to make sure there are no illegal characters
- */
-export function checkArtifactName(name: string): void {
-  if (!name) {
-    throw new Error(`Artifact name: ${name}, is incorrectly provided`)
-  }
-
-  for (const invalidChar of invalidArtifactNameCharacters) {
-    if (name.includes(invalidChar)) {
-      throw new Error(
-        `Artifact name is not valid: ${name}. Contains the following character: "${invalidChar}".
-        
-Invalid characters include: ${invalidArtifactNameCharacters.toString()}.
-        
-These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.`
-      )
-    }
-  }
-
-  info(`Artifact name is valid!`)
-}
-
-/**
- * Scans the name of the filePath used to make sure there are no illegal characters
- */
-export function checkArtifactFilePath(path: string): void {
-  if (!path) {
-    throw new Error(`Artifact path: ${path}, is incorrectly provided`)
-  }
-
-  for (const invalidChar of invalidArtifactFilePathCharacters) {
-    if (path.includes(invalidChar)) {
-      throw new Error(
-        `Artifact path is not valid: ${path}. Contains the following character: "${invalidChar}". Invalid characters include: ${invalidArtifactFilePathCharacters.toString()}.
-        
-        The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
-        `
-      )
-    }
-  }
-}
-
 export async function createDirectoriesForArtifact(
   directories: string[]
 ): Promise<void> {


### PR DESCRIPTION
Enforce checking for newline characters and carriage returns in the artifact name and file paths that are uploaded

Will close out: https://github.com/actions/upload-artifact/issues/183

- Restructuring some files + tests so that all the code for validating artifact names + paths is in a single file (not in `utils.ts`) 
- Make the error output more readible, the old code would split the message into multiple lines because the actual newline characters were displayed 
- Add tests for `\\r` and `\\n` 

For invalid artifact name: https://github.com/konradpabjan/artifact-test/actions/runs/1527098177
![image](https://user-images.githubusercontent.com/16109154/144293245-e7137f57-76c6-48a2-a034-78eb992cb313.png)

For invalid path: https://github.com/konradpabjan/artifact-test/actions/runs/1527052660
![image](https://user-images.githubusercontent.com/16109154/144293398-f630ba4b-a893-4fbc-8584-648c1ce07db8.png)

