### PR TITLE
chore(core): use TypeScript parameter properties

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -36,18 +36,14 @@ export function issue(name: string, message = ''): void {
 const CMD_STRING = '::'
 
 class Command {
-  private readonly command: string
-  private readonly message: string
-  private readonly properties: CommandProperties
-
-  constructor(command: string, properties: CommandProperties, message: string) {
+  constructor(
+    private readonly command: string,
+    private readonly properties: CommandProperties,
+    private readonly message: string
+  ) {
     if (!command) {
-      command = 'missing.command'
+      this.command = 'missing.command'
     }
-
-    this.command = command
-    this.properties = properties
-    this.message = message
   }
 
   toString(): string {


### PR DESCRIPTION
# Description

One day, on a cold Friday evening, I was grok'ing GitHub action code because I wanted to see how `core` functioned, and why https://deno.land/x?query=github was possibly missing a package for `@actions/core`.

I got side tracked ... and opened this PR instead...

This refactors `Command` to leverage TypeScript's parameter properties[^1]. This is purely a syntactical-sugar change. 🍡 🍬  

- [x] Tests in `core` are passing locally

[^1]: https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties