### PR TITLE
[Artifacts] More detailed information for chunked uploads

### DIFF
--- a/packages/artifact/src/internal/status-reporter.ts
+++ b/packages/artifact/src/internal/status-reporter.ts
@@ -53,10 +53,12 @@ export class StatusReporter {
   ): void {
     // display 1 decimal place without any rounding
     const percentage = this.formatPercentage(chunkEndIndex, totalUploadFileSize)
-    info(`Uploaded ${fileName} (${percentage.slice(
-      0,
-      percentage.indexOf('.') + 2
-    )}%) chunks ${chunkStartIndex}:${chunkEndIndex}`)
+    info(
+      `Uploaded ${fileName} (${percentage.slice(
+        0,
+        percentage.indexOf('.') + 2
+      )}%) chunks ${chunkStartIndex}:${chunkEndIndex}`
+    )
   }
 
   stop(): void {

--- a/packages/artifact/src/internal/status-reporter.ts
+++ b/packages/artifact/src/internal/status-reporter.ts
@@ -14,11 +14,9 @@ export class StatusReporter {
   private displayFrequencyInMilliseconds: number
   private largeFiles = new Map<string, string>()
   private totalFileStatus: NodeJS.Timeout | undefined
-  private largeFileStatus: NodeJS.Timeout | undefined
 
   constructor(displayFrequencyInMilliseconds: number) {
     this.totalFileStatus = undefined
-    this.largeFileStatus = undefined
     this.displayFrequencyInMilliseconds = displayFrequencyInMilliseconds
   }
 
@@ -44,41 +42,26 @@ export class StatusReporter {
         )}%)`
       )
     }, this.displayFrequencyInMilliseconds)
-
-    // displays extra information about any large files that take a significant amount of time to upload or download every 1 second
-    this.largeFileStatus = setInterval(() => {
-      for (const value of Array.from(this.largeFiles.values())) {
-        info(value)
-      }
-      // delete all entries in the map after displaying the information so it will not be displayed again unless explicitly added
-      this.largeFiles.clear()
-    }, 1000)
   }
 
   // if there is a large file that is being uploaded in chunks, this is used to display extra information about the status of the upload
   updateLargeFileStatus(
     fileName: string,
-    numerator: number,
-    denominator: number
+    chunkStartIndex: number,
+    chunkEndIndex: number,
+    totalUploadFileSize: number
   ): void {
     // display 1 decimal place without any rounding
-    const percentage = this.formatPercentage(numerator, denominator)
-    const displayInformation = `Uploading ${fileName} (${percentage.slice(
+    const percentage = this.formatPercentage(chunkEndIndex, totalUploadFileSize)
+    info(`Uploaded ${fileName} (${percentage.slice(
       0,
       percentage.indexOf('.') + 2
-    )}%)`
-
-    // any previously added display information should be overwritten for the specific large file because a map is being used
-    this.largeFiles.set(fileName, displayInformation)
+    )}%) chunks ${chunkStartIndex}:${chunkEndIndex}`)
   }
 
   stop(): void {
     if (this.totalFileStatus) {
       clearInterval(this.totalFileStatus)
-    }
-
-    if (this.largeFileStatus) {
-      clearInterval(this.largeFileStatus)
     }
   }
 


### PR DESCRIPTION
While investigating some 503s that can occur during artifact upload, the server reports that certain chunks were missing as part of the upload. The client thinks that all chunks were uploaded so it's unclear where something could be going wrong. This PR changes a few things
- Displays the chunks that were uploaded for all HTTP calls over 8MB (files that are smaller are not uploaded in chunks). Previously only files over 100MB would have any extra information displayed
- Displays the chunk information after each upload call. Previously there was this `largeFileStatus` that was used to display information about large files every 1 second. Within a 1 second period there can be more than 1 chunk uploaded for a file so I've gotten rid of that and every single HTTP call simply gets outputted. The downside of this is that there are more logs which makes things a bit more verbose but people generally don't care about that and it's much better to display all this information for diagnostic purposes

Old output: https://github.com/konradpabjan/artifact-test/runs/4434790411?check_suite_focus=true

![image](https://user-images.githubusercontent.com/16109154/144920500-ea22cd44-c196-42e1-ae10-17c2d685e566.png)


New output: https://github.com/konradpabjan/artifact-test/runs/4435915324?check_suite_focus=true

![image](https://user-images.githubusercontent.com/16109154/144920388-ad58ddf8-7174-4049-958e-e93512a1a637.png)


The new output is a bit more verbose, perhaps a bit too much but I this will help a lot in helping to diagnose weird issues where the client thinks it's uploaded everything but the server reports certain chunks are missing