### PR TITLE
[Artifacts] Prep for @actions/artifact 0.6.0 release

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -61,3 +61,12 @@
 ### 0.5.2
 
 - Add HTTP 500 as a retryable status code for artifact upload and download.
+
+### 0.6.0
+
+- Support upload from named pipes [748](https://github.com/actions/toolkit/pull/748)
+- Fixes to percentage values being greater than 100% when downloading all artifacts [889](https://github.com/actions/toolkit/pull/889)
+- Improved logging and output during artifact upload [949](https://github.com/actions/toolkit/pull/949)
+- Improvements to client-side validation for certain invalid characters not allowed during upload: [951](https://github.com/actions/toolkit/pull/951)
+- Faster upload speeds for certain types of large files by exempting gzip compression #956 [956](https://github.com/actions/toolkit/pull/956)
+- More detailed logging when dealing with chunked uploads [957](https://github.com/actions/toolkit/pull/957)

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -64,9 +64,9 @@
 
 ### 0.6.0
 
-- Support upload from named pipes [748](https://github.com/actions/toolkit/pull/748)
-- Fixes to percentage values being greater than 100% when downloading all artifacts [889](https://github.com/actions/toolkit/pull/889)
-- Improved logging and output during artifact upload [949](https://github.com/actions/toolkit/pull/949)
-- Improvements to client-side validation for certain invalid characters not allowed during upload: [951](https://github.com/actions/toolkit/pull/951)
-- Faster upload speeds for certain types of large files by exempting gzip compression #956 [956](https://github.com/actions/toolkit/pull/956)
-- More detailed logging when dealing with chunked uploads [957](https://github.com/actions/toolkit/pull/957)
+- Support upload from named pipes [#748](https://github.com/actions/toolkit/pull/748)
+- Fixes to percentage values being greater than 100% when downloading all artifacts [#889](https://github.com/actions/toolkit/pull/889)
+- Improved logging and output during artifact upload [#949](https://github.com/actions/toolkit/pull/949)
+- Improvements to client-side validation for certain invalid characters not allowed during upload: [#951](https://github.com/actions/toolkit/pull/951)
+- Faster upload speeds for certain types of large files by exempting gzip compression [#956](https://github.com/actions/toolkit/pull/956)
+- More detailed logging when dealing with chunked uploads [#957](https://github.com/actions/toolkit/pull/957)

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -240,7 +240,9 @@ Note: The size of downloaded zips can differ significantly from the reported siz
     while (downloadedArtifacts < artifacts.count) {
       const currentArtifactToDownload = artifacts.value[downloadedArtifacts]
       downloadedArtifacts += 1
-      core.info(`starting download of artifact ${currentArtifactToDownload.name} : ${downloadedArtifacts}/${artifacts.count}`)
+      core.info(
+        `starting download of artifact ${currentArtifactToDownload.name} : ${downloadedArtifacts}/${artifacts.count}`
+      )
 
       // Get container entries for the specific artifact
       const items = await downloadHttpClient.getContainerItems(

--- a/packages/artifact/src/internal/artifact-client.ts
+++ b/packages/artifact/src/internal/artifact-client.ts
@@ -240,6 +240,7 @@ Note: The size of downloaded zips can differ significantly from the reported siz
     while (downloadedArtifacts < artifacts.count) {
       const currentArtifactToDownload = artifacts.value[downloadedArtifacts]
       downloadedArtifacts += 1
+      core.info(`starting download of artifact ${currentArtifactToDownload.name} : ${downloadedArtifacts}/${artifacts.count}`)
 
       // Get container entries for the specific artifact
       const items = await downloadHttpClient.getContainerItems(

--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -228,9 +228,6 @@ export class DownloadHttpClient {
       let response: IHttpClientResponse
       try {
         response = await makeDownloadRequest()
-        if (core.isDebug()) {
-          displayHttpDiagnostics(response)
-        }
       } catch (error) {
         // if an error is caught, it is usually indicative of a timeout so retry the download
         core.info('An error occurred while attempting to download a file')

--- a/packages/artifact/src/internal/status-reporter.ts
+++ b/packages/artifact/src/internal/status-reporter.ts
@@ -57,7 +57,7 @@ export class StatusReporter {
       `Uploaded ${fileName} (${percentage.slice(
         0,
         percentage.indexOf('.') + 2
-      )}%) chunks ${chunkStartIndex}:${chunkEndIndex}`
+      )}%) bytes ${chunkStartIndex}:${chunkEndIndex}`
     )
   }
 


### PR DESCRIPTION
Bump package version from 0.5.2 to 0.6.0 in the following files
- `package.json`
- `package-lock.json`
Document all of the changes going in
Some small tweaks that I figured could squeeze into this PR
- Changes `chunk` to `bytes` for output when displaying chunked upload process. It makes more sense for `bytes` since that is the range that is being displayed

Looks like this: https://github.com/konradpabjan/artifact-test/runs/4437446512?check_suite_focus=true
![image](https://user-images.githubusercontent.com/16109154/144938724-39b4c472-5ffd-496d-ba0e-85950a3d2c56.png)

Remove some unnecessary diagnostic output when downloading all artifacts if debug mode is on. Before this would always show up. We only should call this method if there is an error but you can see in the screenshot we would display this even if a 200 response was received 

![image](https://user-images.githubusercontent.com/16109154/144938847-0c3f1465-7c03-42bc-a52e-14b083b6d2dc.png)

