### PR TITLE
Update releases.yml

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,6 +18,11 @@ jobs:
       - name: verify package exists
         run: ls packages/${{ github.event.inputs.package }}
         
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+        
       - name: npm install
         run: npm install
         


### PR DESCRIPTION
I was getting ready to release a new version of `@actions/artifact` but `npm run test` failed in the publish workflow while on other CI it works 🤔 

Successful run on `mac-os`: https://github.com/actions/toolkit/runs/4437602856?check_suite_focus=true
Failed run on `mac-os` when trying to publish: https://github.com/actions/toolkit/runs/4445579026?check_suite_focus=true

The only difference I could find between the two workflows is that one explicitly sets node 12 while the other one doesn't.

I also found this recent change so this is expected: https://github.com/actions/virtual-environments/issues/4446