### PR TITLE
Remove non-printable space character from error message

### DIFF
--- a/packages/core/src/oidc-utils.ts
+++ b/packages/core/src/oidc-utils.ts
@@ -50,8 +50,8 @@ export class OidcClient {
       .getJson<TokenResponse>(id_token_url)
       .catch(error => {
         throw new Error(
-          `Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+          `Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.result.message}`
         )
       })


### PR DESCRIPTION
This character isn't encoded in utf-8 and doesn't seem to be intentional.