### PR TITLE
fix(core): getMultilineInput not trimming whitespace

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -30,8 +30,8 @@ const testEnvVars = {
   INPUT_BOOLEAN_INPUT_FALSE3: 'FALSE',
   INPUT_WRONG_BOOLEAN_INPUT: 'wrong',
   INPUT_WITH_TRAILING_WHITESPACE: '  some val  ',
-
   INPUT_MY_INPUT_LIST: 'val1\nval2\nval3',
+  INPUT_LIST_WITH_TRAILING_WHITESPACE: '  val1  \n  val2  \n  ',
 
   // Save inputs
   STATE_TEST_1: 'state_val',
@@ -170,14 +170,6 @@ describe('@actions/core', () => {
     )
   })
 
-  it('getMultilineInput works', () => {
-    expect(core.getMultilineInput('my input list')).toEqual([
-      'val1',
-      'val2',
-      'val3'
-    ])
-  })
-
   it('getInput trims whitespace by default', () => {
     expect(core.getInput('with trailing whitespace')).toBe('some val')
   })
@@ -216,6 +208,37 @@ describe('@actions/core', () => {
       'Input does not meet YAML 1.2 "Core Schema" specification: wrong boolean input\n' +
         `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``
     )
+  })
+
+  it('getMultilineInput works', () => {
+    expect(core.getMultilineInput('my input list')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+  })
+
+  it('getMultilineInput trims whitespace by default', () => {
+    expect(core.getMultilineInput('list with trailing whitespace')).toEqual([
+      'val1',
+      'val2'
+    ])
+  })
+
+  it('getMultilineInput trims whitespace when option is explicitly true', () => {
+    expect(
+      core.getMultilineInput('list with trailing whitespace', {
+        trimWhitespace: true
+      })
+    ).toEqual(['val1', 'val2'])
+  })
+
+  it('getMultilineInput does not trim whitespace when option is false', () => {
+    expect(
+      core.getMultilineInput('list with trailing whitespace', {
+        trimWhitespace: false
+      })
+    ).toEqual(['  val1  ', '  val2  ', '  '])
   })
 
   it('setOutput produces the correct command', () => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -155,7 +155,11 @@ export function getMultilineInput(
     .split('\n')
     .filter(x => x !== '')
 
-  return inputs
+  if (options && options.trimWhitespace === false) {
+    return inputs
+  }
+
+  return inputs.map(input => input.trim())
 }
 
 /**


### PR DESCRIPTION
`core.getInput` is [trimming whitespace](https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts#L17) by default, but `core.getMultilineInput` is not.
Also, `core.getMultilineInput` ignores `trimWhitespace` option.

This pull request has been fixed so that `core.getMultilineInput` will trim whitespace in the same way as `core.getInput`.

related: #802, #829