### PR TITLE
Keep order when hashFiles when globbing multiple files

### DIFF
--- a/packages/glob/src/internal-hash-files.ts
+++ b/packages/glob/src/internal-hash-files.ts
@@ -11,7 +11,7 @@ export async function hashFiles(globber: Globber): Promise<string> {
   const githubWorkspace = process.env['GITHUB_WORKSPACE'] ?? process.cwd()
   const result = crypto.createHash('sha256')
   let count = 0
-  for await (const file of globber.globGenerator()) {
+  for await (const file of await sortedFiles(globber)) {
     core.debug(file)
     if (!file.startsWith(`${githubWorkspace}${path.sep}`)) {
       core.debug(`Ignore '${file}' since it is not under GITHUB_WORKSPACE.`)
@@ -39,4 +39,13 @@ export async function hashFiles(globber: Globber): Promise<string> {
     core.debug(`No matches found for glob`)
     return ''
   }
+}
+
+async function sortedFiles(globber: Globber): Promise<string[]> {
+  const result: string[] = []
+  for await (const file of globber.globGenerator()) {
+    result.push(file)
+  }
+  result.sort()
+  return result
 }


### PR DESCRIPTION
Hello,
Currently `hashFiles` method does not respect the order of files, since internally it uses glob which does not guarantee order.
As a result, an `hash` may be calculated differently when run multiple times for the same files.
This PR fixes the behavior by keeping the same order, resulting in a deterministic hash.
When this PR gets approved I intend to update [action/runner/hashFiles.ts](https://github.com/actions/runner/blob/main/src/Misc/expressionFunc/hashFiles/src/hashFiles.ts) to use the method (`Glob.hashFiles`) from this module.

I am not very familiar with Typescript, so this PR may not be the prettiest code, I will be very happy to receive guidelines and feedbacks on how to make it better. :)
Thank you very much!