### PR TITLE
feat: export Context from root

### DIFF
--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -6,6 +6,8 @@ import {OctokitOptions} from '@octokit/core/dist-types/types'
 
 export const context = new Context.Context()
 
+export {Context} from './context'
+
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
  *


### PR DESCRIPTION
Currently, `Context` is only exported via `lib/context` meaning if you want to use the type, you need an awkward import like `import {Context} from '@actions/github/lib/context'`. This looks like context was not meant for public use.

With this change, users can import Context like so: `import {Context} from '@actions/github'`.