### PR TITLE
Handle relative paths starting with hyphens in io's rmRF

### DIFF
--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -748,6 +748,16 @@ describe('rmRF', () => {
     await io.rmRF(file)
     await assertNotExists(file)
   })
+
+  it('removes directories starting with a hyphen with rmRF', async () => {
+    const root = path.join(getTestTemp(), '.rmRF_hyphen_directory')
+    const hyphenDirectory = path.join(root, '-hyphen')
+    await io.mkdirP(hyphenDirectory)
+    await assertExists(hyphenDirectory)
+    process.chdir(root)
+    await io.rmRF('-hyphen')
+    await assertNotExists(hyphenDirectory)
+  })
 })
 
 describe('mkdirP', () => {

--- a/packages/io/src/io.ts
+++ b/packages/io/src/io.ts
@@ -163,7 +163,7 @@ export async function rmRF(inputPath: string): Promise<void> {
     }
 
     if (isDir) {
-      await execFile(`rm`, [`-rf`, `${inputPath}`])
+      await execFile(`rm`, [`-rf`, `--`, `${inputPath}`])
     } else {
       await ioUtil.unlink(inputPath)
     }


### PR DESCRIPTION
When using `io.rmRF` with a relative path to a directory that starts with a hyphen on non-Windows systems, the directory name was interpreted as an option to `rm`. Fix that by separating options and arguments via a double-hyphen `--`.

Without this change, the provided test fails with:

```
    Command failed: rm -rf -hyphen
    rm: invalid option -- 'h'
    Try 'rm ./-hyphen' to remove the file '-hyphen'.
    Try 'rm --help' for more information.
```