### PR TITLE
Update `lockfileVersion` in `package-lock.json` for `@actions/artifact`

### DIFF
--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@actions/artifact",
   "version": "0.6.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "dependencies": {
     "@actions/core": {


### PR DESCRIPTION
This change addresses [this](https://github.com/github/c2c-actions-checks/issues/270) issue.

Documentation for the semantics of `lockfileVersion` can be found [here](https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json#lockfileversion).

`lockfileVersion: 2` is corresponds to an npm `v7` (but is also backwards compatible with npm `v5` and `v6`).