### PR TITLE
glob: skip error when subdirectory have not permission

### DIFF
--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -139,12 +139,19 @@ export class DefaultGlobber implements Globber {
           continue
         }
 
-        // Push the child items in reverse
-        const childLevel = item.level + 1
-        const childItems = (await fs.promises.readdir(item.path)).map(
-          x => new SearchState(path.join(item.path, x), childLevel)
-        )
-        stack.push(...childItems.reverse())
+        try {
+          // Push the child items in reverse
+          const childLevel = item.level + 1
+          const childItems = (await fs.promises.readdir(item.path)).map(
+            x => new SearchState(path.join(item.path, x), childLevel)
+          )
+          stack.push(...childItems.reverse())
+        } catch (err) {
+          if (err.code === 'EACCES') {
+            continue
+          }
+          throw err
+        }
       }
       // File
       else if (match & MatchKind.File) {


### PR DESCRIPTION
fix: https://github.com/actions/toolkit/issues/775


When globstar(`**`) is used in a directory with non-referenced subdirectories, the following differences exist between shell and @actions/glob. 

Sample directory structure
```
root
├ package-lock.json
├ deniedDir  <-    chmod 000
│ └ package-lock.json
└ visibleDir
　 └ package-lock.json
```
## shell(bash/zsh): skip no permission subdirectories

```
$ls **/package-lock.json
visibleDir/package-lock.json
```

```
%ls **/package-lock.json
package-lock.json
visibleDir/package-lock.json
```
## @actions/glob: error
```javascript
glob = require('@actions/glob')

const p = new Promise(async (resolve, reject) => {
    const matchPatterns = '**/package-lock.json'
    console.log(`@actions/glob ${matchPatterns}`)
    const globber = await glob.create(matchPatterns)
    for await (const file of globber.globGenerator()) {
        console.log(file)
    }
});
p.then()
```
output
```
@actions/glob **/package-lock.json
::debug::followSymbolicLinks 'true'
::debug::implicitDescendants 'true'
::debug::matchDirectories 'true'
::debug::omitBrokenSymbolicLinks 'true'
::debug::Search path '/Users/takuya.hayashi/Documents/dev/howyi/gha-hashfiles-parmission-check'
[Error: EACCES: permission denied, scandir '/Users/takuya.hayashi/Documents/dev/howyi/gha-hashfiles-parmission-check/deniedDir'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'scandir',
  path: '/Users/takuya.hayashi/Documents/dev/howyi/gha-hashfiles-parmission-check/deniedDir'
}
```

## Problems caused by this difference

When using hashFiles in @action/cache, etc., you may use the form `hashFiles('**/package-lock.json')`.  
ex: https://docs.github.com/ja/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
```
      - name: Cache node modules
        uses: actions/cache@v2
        env:
          cache-name: cache-node-modules
        with:
          path: ~/.npm
          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
          restore-keys: |
            ${{ runner.os }}-build-${{ env.cache-name }}-
            ${{ runner.os }}-build-
            ${{ runner.os }}-
```
If there is an unprivileged directory, this caching process will fail with an error.

Related issue: https://github.com/actions/cache/issues/753#issuecomment-1058951083


I have created a repository that reproduces this situation. Check here for details.   🐔 
https://github.com/howyi/gha-hashfiles-parmission-check