### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -753,7 +753,7 @@ describe('globber', () => {
     const searchPaths = await getSearchPaths(
       `#aaa/*${os.EOL}/foo/*${os.EOL}#bbb/*${os.EOL}/bar/*`
     )
-    const drive = IS_WINDOWS ? process.cwd().substr(0, 2) : ''
+    const drive = IS_WINDOWS ? process.cwd().slice(0, 2) : ''
     expect(searchPaths).toEqual([
       IS_WINDOWS ? `${drive}\\foo` : '/foo',
       IS_WINDOWS ? `${drive}\\bar` : '/bar'
@@ -764,7 +764,7 @@ describe('globber', () => {
     const searchPaths = await getSearchPaths(
       `${os.EOL}${os.EOL}/foo/*${os.EOL}${os.EOL}/bar/*${os.EOL}/baz/**${os.EOL}`
     )
-    const drive = IS_WINDOWS ? process.cwd().substr(0, 2) : ''
+    const drive = IS_WINDOWS ? process.cwd().slice(0, 2) : ''
     expect(searchPaths).toEqual([
       IS_WINDOWS ? `${drive}\\foo` : '/foo',
       IS_WINDOWS ? `${drive}\\bar` : '/bar',

--- a/packages/glob/__tests__/internal-path-helper.test.ts
+++ b/packages/glob/__tests__/internal-path-helper.test.ts
@@ -125,7 +125,7 @@ describe('path-helper', () => {
 
   it('ensureAbsoluteRoot roots paths', () => {
     if (IS_WINDOWS) {
-      const currentDrive = process.cwd().substr(0, 2)
+      const currentDrive = process.cwd().slice(0, 2)
       expect(currentDrive.match(/^[A-Z]:$/i)).toBeTruthy()
       const otherDrive = currentDrive.toUpperCase().startsWith('C')
         ? 'D:'

--- a/packages/glob/__tests__/internal-pattern.test.ts
+++ b/packages/glob/__tests__/internal-pattern.test.ts
@@ -47,7 +47,7 @@ describe('pattern', () => {
       expect(pattern.match(path.join(rootPath, 'not-match'))).toBeFalsy()
 
       if (IS_WINDOWS) {
-        const currentDrive = process.cwd().substr(0, 2)
+        const currentDrive = process.cwd().slice(0, 2)
         expect(currentDrive.match(/^[A-Z]:$/i)).toBeTruthy()
 
         // Relative current drive letter, e.g. C:m*
@@ -58,7 +58,7 @@ describe('pattern', () => {
 
         // Relative current drive, e.g. \path\to\cwd\m*
         pattern = new Pattern(
-          `${Pattern.globEscape(process.cwd().substr(2))}\\m*`
+          `${Pattern.globEscape(process.cwd().slice(2))}\\m*`
         )
         expect(pattern.searchPath).toBe(rootPath)
         expect(pattern.match(path.join(rootPath, 'match'))).toBeTruthy()
@@ -167,7 +167,7 @@ describe('pattern', () => {
 
   it('replaces leading relative root', () => {
     if (IS_WINDOWS) {
-      const currentDrive = process.cwd().substr(0, 2)
+      const currentDrive = process.cwd().slice(0, 2)
       expect(currentDrive.match(/^[A-Z]:$/i)).toBeTruthy()
       const otherDrive = currentDrive.toUpperCase().startsWith('C')
         ? 'D:'
@@ -196,7 +196,7 @@ describe('pattern', () => {
       expect(pattern.match(`${otherDrive}\\bar`)).toBeFalsy()
 
       // Pattern is '\\path\\to\\cwd'
-      pattern = new Pattern(`${process.cwd().substr(2)}\\foo`)
+      pattern = new Pattern(`${process.cwd().slice(2)}\\foo`)
       expect(pattern.match(path.join(process.cwd(), 'foo'))).toBeTruthy()
       expect(pattern.match(path.join(process.cwd(), 'bar'))).toBeFalsy()
     }
@@ -206,7 +206,7 @@ describe('pattern', () => {
     const patternStrings = ['!hello.txt', '!**/world.txt']
     const actual = patternStrings.map(x => new Pattern(x))
     const expected = patternStrings
-      .map(x => x.substr(1))
+      .map(x => x.slice(1))
       .map(x => path.join(Pattern.globEscape(process.cwd()), x))
       .map(x => `!${x}`)
       .map(x => new Pattern(x))

--- a/packages/glob/src/internal-path-helper.ts
+++ b/packages/glob/src/internal-path-helper.ts
@@ -68,7 +68,7 @@ export function ensureAbsoluteRoot(root: string, itemPath: string): string {
         // Drive only, e.g. C:
         if (itemPath.length === 2) {
           // Preserve specified drive letter case (upper or lower)
-          return `${itemPath[0]}:\\${cwd.substr(3)}`
+          return `${itemPath[0]}:\\${cwd.slice(3)}`
         }
         // Drive + path, e.g. C:foo
         else {
@@ -76,12 +76,12 @@ export function ensureAbsoluteRoot(root: string, itemPath: string): string {
             cwd += '\\'
           }
           // Preserve specified drive letter case (upper or lower)
-          return `${itemPath[0]}:\\${cwd.substr(3)}${itemPath.substr(2)}`
+          return `${itemPath[0]}:\\${cwd.slice(3)}${itemPath.slice(2)}`
         }
       }
       // Different drive
       else {
-        return `${itemPath[0]}:\\${itemPath.substr(2)}`
+        return `${itemPath[0]}:\\${itemPath.slice(2)}`
       }
     }
     // Check for itemPath like \ or \foo
@@ -92,7 +92,7 @@ export function ensureAbsoluteRoot(root: string, itemPath: string): string {
         `Expected current directory to start with an absolute drive root. Actual '${cwd}'`
       )
 
-      return `${cwd[0]}:\\${itemPath.substr(1)}`
+      return `${cwd[0]}:\\${itemPath.slice(1)}`
     }
   }
 
@@ -202,5 +202,5 @@ export function safeTrimTrailingSeparator(p: string): string {
   }
 
   // Otherwise trim trailing slash
-  return p.substr(0, p.length - 1)
+  return p.slice(0, -1)
 }

--- a/packages/glob/src/internal-pattern.ts
+++ b/packages/glob/src/internal-pattern.ts
@@ -91,7 +91,7 @@ export class Pattern {
     // Negate
     while (pattern.startsWith('!')) {
       this.negate = !this.negate
-      pattern = pattern.substr(1).trim()
+      pattern = pattern.slice(1).trim()
     }
 
     // Normalize slashes and ensures absolute root
@@ -221,7 +221,7 @@ export class Pattern {
 
     // Replace leading `.` segment
     if (pattern === '.' || pattern.startsWith(`.${path.sep}`)) {
-      pattern = Pattern.globEscape(process.cwd()) + pattern.substr(1)
+      pattern = Pattern.globEscape(process.cwd()) + pattern.slice(1)
     }
     // Replace leading `~` segment
     else if (pattern === '~' || pattern.startsWith(`~${path.sep}`)) {
@@ -231,7 +231,7 @@ export class Pattern {
         pathHelper.hasAbsoluteRoot(homedir),
         `Expected HOME directory to be a rooted path. Actual '${homedir}'`
       )
-      pattern = Pattern.globEscape(homedir) + pattern.substr(1)
+      pattern = Pattern.globEscape(homedir) + pattern.slice(1)
     }
     // Replace relative drive root, e.g. pattern is C: or C:foo
     else if (
@@ -240,12 +240,12 @@ export class Pattern {
     ) {
       let root = pathHelper.ensureAbsoluteRoot(
         'C:\\dummy-root',
-        pattern.substr(0, 2)
+        pattern.slice(0, 2)
       )
       if (pattern.length > 2 && !root.endsWith('\\')) {
         root += '\\'
       }
-      pattern = Pattern.globEscape(root) + pattern.substr(2)
+      pattern = Pattern.globEscape(root) + pattern.slice(2)
     }
     // Replace relative root, e.g. pattern is \ or \foo
     else if (IS_WINDOWS && (pattern === '\\' || pattern.match(/^\\[^\\]/))) {
@@ -253,7 +253,7 @@ export class Pattern {
       if (!root.endsWith('\\')) {
         root += '\\'
       }
-      pattern = Pattern.globEscape(root) + pattern.substr(1)
+      pattern = Pattern.globEscape(root) + pattern.slice(1)
     }
     // Otherwise ensure absolute root
     else {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.