### PR TITLE
Added cacheSize in ReserveCache API request

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -44,6 +44,16 @@ function checkKey(key: string): void {
 }
 
 /**
+ * isFeatureAvailable to check the presence of Actions cache service
+ *
+ * @returns boolean return true if Actions cache service feature is available, otherwise false
+ */
+
+ export function isFeatureAvailable(): boolean {
+  return !!process.env['ACTIONS_CACHE_URL']
+}
+
+/**
  * Restores cache from keys
  *
  * @param paths a list of file paths to restore from the cache

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -49,7 +49,7 @@ function checkKey(key: string): void {
  * @returns boolean return true if Actions cache service feature is available, otherwise false
  */
 
- export function isFeatureAvailable(): boolean {
+export function isFeatureAvailable(): boolean {
   return !!process.env['ACTIONS_CACHE_URL']
 }
 

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -32,11 +32,7 @@ const versionSalt = '1.0'
 
 function getCacheApiUrl(resource: string): string {
   // Ideally we just use ACTIONS_CACHE_URL
-  const baseUrl: string = (
-    process.env['ACTIONS_CACHE_URL'] ||
-    process.env['ACTIONS_RUNTIME_URL'] ||
-    ''
-  ).replace('pipelines', 'artifactcache')
+  const baseUrl: string = process.env['ACTIONS_CACHE_URL'] || ''
   if (!baseUrl) {
     throw new Error('Cache Service Url not found, unable to restore cache.')
   }

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -31,7 +31,6 @@ import {
 const versionSalt = '1.0'
 
 function getCacheApiUrl(resource: string): string {
-  // Ideally we just use ACTIONS_CACHE_URL
   const baseUrl: string = process.env['ACTIONS_CACHE_URL'] || ''
   if (!baseUrl) {
     throw new Error('Cache Service Url not found, unable to restore cache.')

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -123,3 +123,10 @@ export function assertDefined<T>(name: string, value?: T): T {
 
   return value
 }
+
+export function isGhes(): boolean {
+  const ghUrl = new URL(
+      process.env["GITHUB_SERVER_URL"] || "https://github.com"
+  );
+  return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
+}

--- a/packages/cache/src/internal/contracts.d.ts
+++ b/packages/cache/src/internal/contracts.d.ts
@@ -14,6 +14,7 @@ export interface CommitCacheRequest {
 export interface ReserveCacheRequest {
   key: string
   version?: string
+  cacheSize?: number
 }
 
 export interface ReserveCacheResponse {
@@ -22,4 +23,5 @@ export interface ReserveCacheResponse {
 
 export interface InternalCacheOptions {
   compressionMethod?: CompressionMethod
+  cacheSize?: number
 }


### PR DESCRIPTION
Added an optional parameter ie `cacheSize` in Reserve Cache API which will be sent as part of body if the user is an GHES customer. In all the other cases, `cacheSize` will be missing. 