### PR TITLE
Fix test for windows 2022

### DIFF
--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -332,23 +332,9 @@ describe('rmRF', () => {
     await assertExists(filePath)
 
     const fd = await fs.open(filePath, 'r')
+    await io.rmRF(testPath)
 
-    let worked: boolean
-
-    try {
-      await io.rmRF(testPath)
-      worked = true
-    } catch (err) {
-      worked = false
-    }
-
-    if (os.platform() === 'win32') {
-      expect(worked).toBe(false)
-      await assertExists(testPath)
-    } else {
-      expect(worked).toBe(true)
-      await assertNotExists(testPath)
-    }
+    await assertNotExists(testPath)
 
     await fd.close()
     await io.rmRF(testPath)


### PR DESCRIPTION
This test started failing when `windows-latest` updated to Windows Server 2022 [first failing run](https://github.com/actions/toolkit/runs/4854644455?check_suite_focus=true)

The last successful run was using Windows Server 2019 [last successful run](https://github.com/actions/toolkit/runs/4752740981?check_suite_focus=true)

This PR updates the test to be consistent with other platforms