### PR TITLE
Fix error type so that cache size limit violation is shown as warning( similar to previous error)

### DIFF
--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -197,7 +197,7 @@ export async function saveCache(
     if (reserveCacheResponse?.result?.cacheId) {
       cacheId = reserveCacheResponse?.result?.cacheId
     } else if (reserveCacheResponse?.statusCode === 400) {
-      throw new ReserveCacheError(
+      throw new Error(
         reserveCacheResponse?.error?.message ??
           `Cache size of ~${Math.round(
             archiveFileSize / (1024 * 1024)


### PR DESCRIPTION
With the dynamic cache size limit validation on GHES, the validation error should be shown as warning. In this PR we are  fixing error type to Error, so that cache size limit violation is shown as warning( similar to previous error) 
