### PR TITLE
Glob 0.3.0 release

### DIFF
--- a/packages/exec/RELEASES.md
+++ b/packages/exec/RELEASES.md
@@ -1,8 +1,5 @@
 # @actions/exec Releases
 
-### 1.2.0
-- Added a `verbose` option to HashFiles [#1052](https://github.com/actions/toolkit/pull/1052/files)
-
 ### 1.1.1
 - Update `lockfileVersion` to `v2` in `package-lock.json [#1024](https://github.com/actions/toolkit/pull/1024) 
 

--- a/packages/exec/package-lock.json
+++ b/packages/exec/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/exec",
-  "version": "1.2.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/exec",
-  "version": "1.2.0",
+  "version": "1.1.1",
   "description": "Actions exec lib",
   "keywords": [
     "github",

--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/glob Releases
 
+### 0.3.0
+- Added a `verbose` option to HashFiles [#1052](https://github.com/actions/toolkit/pull/1052/files)
+
 ### 0.2.1
 - Update `lockfileVersion` to `v2` in `package-lock.json [#1023](https://github.com/actions/toolkit/pull/1023) 
 

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [


### PR DESCRIPTION
This [pr](https://github.com/actions/toolkit/pull/1055) bumped the exec version, but the pr in question was for glob. So this pr reverts that change, and bumps the correct package