### PR TITLE
@actions/core 1.7.0 release

### DIFF
--- a/packages/core/RELEASES.md
+++ b/packages/core/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/core Releases
 
+### 1.7.0
+- [Added `markdownSummary` extension](https://github.com/actions/toolkit/pull/1014)
+
 ### 1.6.0
 - [Added OIDC Client function `getIDToken`](https://github.com/actions/toolkit/pull/919)
 - [Added `file` parameter to `AnnotationProperties`](https://github.com/actions/toolkit/pull/896) 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Actions core lib",
   "keywords": [
     "github",


### PR DESCRIPTION
Bumps actions core to `1.7.0`, adding [`core.markdownSummary`](https://github.com/actions/toolkit/pull/1014). We've darkshipped the job summary feature to a few users and it'd be great to get feedback on this library as well.