### PR TITLE
chore: add debug logging of os version check in find manifest

### DIFF
--- a/packages/tool-cache/src/manifest.ts
+++ b/packages/tool-cache/src/manifest.ts
@@ -88,6 +88,9 @@ export async function _findMatch(
         if (chk && item.platform_version) {
           const osVersion = module.exports._getOsVersion()
 
+          debug(
+            `${osVersion}===${item.platform_version}`
+          )
           if (osVersion === item.platform_version) {
             chk = true
           } else {


### PR DESCRIPTION
Currently when enabling debug logging for workflows using for example `setup-python` it will not be clear in case no match is found due to platform version mismatching. Therefore adding debug print with this particular information. 