### PR TITLE
Rename core's `markdownSummary` extension to `summary`

### DIFF
--- a/packages/core/__tests__/summary.test.ts
+++ b/packages/core/__tests__/summary.test.ts
@@ -1,9 +1,10 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import path from 'path'
-import {markdownSummary, SUMMARY_ENV_VAR} from '../src/markdown-summary'
+import {summary, SUMMARY_ENV_VAR} from '../src/summary'
 
-const testFilePath = path.join(__dirname, 'test', 'test-summary.md')
+const testDirectoryPath = path.join(__dirname, 'test')
+const testFilePath = path.join(testDirectoryPath, 'test-summary.md')
 
 async function assertSummary(expected: string): Promise<void> {
   const file = await fs.promises.readFile(testFilePath, {encoding: 'utf8'})
@@ -67,11 +68,12 @@ const fixtures = {
   }
 }
 
-describe('@actions/core/src/markdown-summary', () => {
+describe('@actions/core/src/summary', () => {
   beforeEach(async () => {
     process.env[SUMMARY_ENV_VAR] = testFilePath
+    await fs.promises.mkdir(testDirectoryPath, {recursive: true})
     await fs.promises.writeFile(testFilePath, '', {encoding: 'utf8'})
-    markdownSummary.emptyBuffer()
+    summary.emptyBuffer()
   })
 
   afterAll(async () => {
@@ -80,39 +82,39 @@ describe('@actions/core/src/markdown-summary', () => {
 
   it('throws if summary env var is undefined', async () => {
     process.env[SUMMARY_ENV_VAR] = undefined
-    const write = markdownSummary.addRaw(fixtures.text).write()
+    const write = summary.addRaw(fixtures.text).write()
 
     await expect(write).rejects.toThrow()
   })
 
   it('throws if summary file does not exist', async () => {
     await fs.promises.unlink(testFilePath)
-    const write = markdownSummary.addRaw(fixtures.text).write()
+    const write = summary.addRaw(fixtures.text).write()
 
     await expect(write).rejects.toThrow()
   })
 
   it('appends text to summary file', async () => {
     await fs.promises.writeFile(testFilePath, '# ', {encoding: 'utf8'})
-    await markdownSummary.addRaw(fixtures.text).write()
+    await summary.addRaw(fixtures.text).write()
     await assertSummary(`# ${fixtures.text}`)
   })
 
   it('overwrites text to summary file', async () => {
     await fs.promises.writeFile(testFilePath, 'overwrite', {encoding: 'utf8'})
-    await markdownSummary.addRaw(fixtures.text).write({overwrite: true})
+    await summary.addRaw(fixtures.text).write({overwrite: true})
     await assertSummary(fixtures.text)
   })
 
   it('appends text with EOL to summary file', async () => {
     await fs.promises.writeFile(testFilePath, '# ', {encoding: 'utf8'})
-    await markdownSummary.addRaw(fixtures.text, true).write()
+    await summary.addRaw(fixtures.text, true).write()
     await assertSummary(`# ${fixtures.text}${os.EOL}`)
   })
 
   it('chains appends text to summary file', async () => {
     await fs.promises.writeFile(testFilePath, '', {encoding: 'utf8'})
-    await markdownSummary
+    await summary
       .addRaw(fixtures.text)
       .addRaw(fixtures.text)
       .addRaw(fixtures.text)
@@ -122,33 +124,33 @@ describe('@actions/core/src/markdown-summary', () => {
 
   it('empties buffer after write', async () => {
     await fs.promises.writeFile(testFilePath, '', {encoding: 'utf8'})
-    await markdownSummary.addRaw(fixtures.text).write()
+    await summary.addRaw(fixtures.text).write()
     await assertSummary(fixtures.text)
-    expect(markdownSummary.isEmptyBuffer()).toBe(true)
+    expect(summary.isEmptyBuffer()).toBe(true)
   })
 
   it('returns summary buffer as string', () => {
-    markdownSummary.addRaw(fixtures.text)
-    expect(markdownSummary.stringify()).toEqual(fixtures.text)
+    summary.addRaw(fixtures.text)
+    expect(summary.stringify()).toEqual(fixtures.text)
   })
 
   it('return correct values for isEmptyBuffer', () => {
-    markdownSummary.addRaw(fixtures.text)
-    expect(markdownSummary.isEmptyBuffer()).toBe(false)
+    summary.addRaw(fixtures.text)
+    expect(summary.isEmptyBuffer()).toBe(false)
 
-    markdownSummary.emptyBuffer()
-    expect(markdownSummary.isEmptyBuffer()).toBe(true)
+    summary.emptyBuffer()
+    expect(summary.isEmptyBuffer()).toBe(true)
   })
 
   it('clears a buffer and summary file', async () => {
     await fs.promises.writeFile(testFilePath, 'content', {encoding: 'utf8'})
-    await markdownSummary.clear()
+    await summary.clear()
     await assertSummary('')
-    expect(markdownSummary.isEmptyBuffer()).toBe(true)
+    expect(summary.isEmptyBuffer()).toBe(true)
   })
 
   it('adds EOL', async () => {
-    await markdownSummary
+    await summary
       .addRaw(fixtures.text)
       .addEOL()
       .write()
@@ -156,37 +158,37 @@ describe('@actions/core/src/markdown-summary', () => {
   })
 
   it('adds a code block without language', async () => {
-    await markdownSummary.addCodeBlock(fixtures.code).write()
+    await summary.addCodeBlock(fixtures.code).write()
     const expected = `<pre><code>func fork() {\n  for {\n    go fork()\n  }\n}</code></pre>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a code block with a language', async () => {
-    await markdownSummary.addCodeBlock(fixtures.code, 'go').write()
+    await summary.addCodeBlock(fixtures.code, 'go').write()
     const expected = `<pre lang="go"><code>func fork() {\n  for {\n    go fork()\n  }\n}</code></pre>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds an unordered list', async () => {
-    await markdownSummary.addList(fixtures.list).write()
+    await summary.addList(fixtures.list).write()
     const expected = `<ul><li>foo</li><li>bar</li><li>baz</li><li>💣</li></ul>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds an ordered list', async () => {
-    await markdownSummary.addList(fixtures.list, true).write()
+    await summary.addList(fixtures.list, true).write()
     const expected = `<ol><li>foo</li><li>bar</li><li>baz</li><li>💣</li></ol>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a table', async () => {
-    await markdownSummary.addTable(fixtures.table).write()
+    await summary.addTable(fixtures.table).write()
     const expected = `<table><tr><th>foo</th><th>bar</th><th>baz</th><td rowspan="3">tall</td></tr><tr><td>one</td><td>two</td><td>three</td></tr><tr><td colspan="3">wide</td></tr></table>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a details element', async () => {
-    await markdownSummary
+    await summary
       .addDetails(fixtures.details.label, fixtures.details.content)
       .write()
     const expected = `<details><summary>open me</summary>🎉 surprise</details>${os.EOL}`
@@ -194,13 +196,13 @@ describe('@actions/core/src/markdown-summary', () => {
   })
 
   it('adds an image with alt text', async () => {
-    await markdownSummary.addImage(fixtures.img.src, fixtures.img.alt).write()
+    await summary.addImage(fixtures.img.src, fixtures.img.alt).write()
     const expected = `<img src="https://github.com/actions.png" alt="actions logo">${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds an image with custom dimensions', async () => {
-    await markdownSummary
+    await summary
       .addImage(fixtures.img.src, fixtures.img.alt, fixtures.img.options)
       .write()
     const expected = `<img src="https://github.com/actions.png" alt="actions logo" width="32" height="32">${os.EOL}`
@@ -208,7 +210,7 @@ describe('@actions/core/src/markdown-summary', () => {
   })
 
   it('adds an image with custom dimensions', async () => {
-    await markdownSummary
+    await summary
       .addImage(fixtures.img.src, fixtures.img.alt, fixtures.img.options)
       .write()
     const expected = `<img src="https://github.com/actions.png" alt="actions logo" width="32" height="32">${os.EOL}`
@@ -217,21 +219,21 @@ describe('@actions/core/src/markdown-summary', () => {
 
   it('adds headings h1...h6', async () => {
     for (const i of [1, 2, 3, 4, 5, 6]) {
-      markdownSummary.addHeading('heading', i)
+      summary.addHeading('heading', i)
     }
-    await markdownSummary.write()
+    await summary.write()
     const expected = `<h1>heading</h1>${os.EOL}<h2>heading</h2>${os.EOL}<h3>heading</h3>${os.EOL}<h4>heading</h4>${os.EOL}<h5>heading</h5>${os.EOL}<h6>heading</h6>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds h1 if heading level not specified', async () => {
-    await markdownSummary.addHeading('heading').write()
+    await summary.addHeading('heading').write()
     const expected = `<h1>heading</h1>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('uses h1 if heading level is garbage or out of range', async () => {
-    await markdownSummary
+    await summary
       .addHeading('heading', 'foobar')
       .addHeading('heading', 1337)
       .addHeading('heading', -1)
@@ -242,35 +244,31 @@ describe('@actions/core/src/markdown-summary', () => {
   })
 
   it('adds a separator', async () => {
-    await markdownSummary.addSeparator().write()
+    await summary.addSeparator().write()
     const expected = `<hr>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a break', async () => {
-    await markdownSummary.addBreak().write()
+    await summary.addBreak().write()
     const expected = `<br>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a quote', async () => {
-    await markdownSummary.addQuote(fixtures.quote.text).write()
+    await summary.addQuote(fixtures.quote.text).write()
     const expected = `<blockquote>Where the world builds software</blockquote>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a quote with citation', async () => {
-    await markdownSummary
-      .addQuote(fixtures.quote.text, fixtures.quote.cite)
-      .write()
+    await summary.addQuote(fixtures.quote.text, fixtures.quote.cite).write()
     const expected = `<blockquote cite="https://github.com/about">Where the world builds software</blockquote>${os.EOL}`
     await assertSummary(expected)
   })
 
   it('adds a link with href', async () => {
-    await markdownSummary
-      .addLink(fixtures.link.text, fixtures.link.href)
-      .write()
+    await summary.addLink(fixtures.link.text, fixtures.link.href).write()
     const expected = `<a href="https://github.com/">GitHub</a>${os.EOL}`
     await assertSummary(expected)
   })

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -361,6 +361,6 @@ export async function getIDToken(aud?: string): Promise<string> {
 }
 
 /**
- * Markdown summary exports
+ * Summary exports
  */
-export {markdownSummary} from './markdown-summary'
+export {summary} from './summary'


### PR DESCRIPTION
For consistency, the feature will be called "Job Summary" not "Markdown Summary" so we'll need to rename the core extensions.