### PR TITLE
Add & deprecate old markdownSummary export

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -364,3 +364,8 @@ export async function getIDToken(aud?: string): Promise<string> {
  * Summary exports
  */
 export {summary} from './summary'
+
+/**
+ * @deprecated use core.summary
+ */
+export {markdownSummary} from './summary'

--- a/packages/core/src/summary.ts
+++ b/packages/core/src/summary.ts
@@ -354,5 +354,10 @@ class Summary {
   }
 }
 
-// singleton export
-export const summary = new Summary()
+const _summary = new Summary()
+
+/**
+ * @deprecated use `core.summary`
+ */
+export const markdownSummary = _summary
+export const summary = _summary


### PR DESCRIPTION
We originally dark shipped this feature to some users as `core.markdownSummary` but since then the feature name has been changed to be "Job Summary". To avoid conflict with our public documentation and to maintain consistency, this'll be `core.summary` going forward.

However, we'll keep `core.markdownSummary` in the API and marked as deprecated for the next release.

Original release:
- https://github.com/actions/toolkit/pull/1059

Rename:
- https://github.com/actions/toolkit/pull/1072
