### PR TITLE
@actions/core 1.8.0 release

### DIFF
--- a/packages/core/RELEASES.md
+++ b/packages/core/RELEASES.md
@@ -1,5 +1,10 @@
 # @actions/core Releases
 
+### 1.8.0
+- Deprecate `markdownSummary` extension export in favor of `summary`
+  - https://github.com/actions/toolkit/pull/1072
+  - https://github.com/actions/toolkit/pull/1073
+
 ### 1.7.0
 - [Added `markdownSummary` extension](https://github.com/actions/toolkit/pull/1014)
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Actions core lib",
   "keywords": [
     "github",


### PR DESCRIPTION
We're deprecating `core.markdownSummary` and exposing `core.summary`.

Relevant issues:
- https://github.com/actions/toolkit/pull/1072
- https://github.com/actions/toolkit/pull/1073