### PR TITLE
Add a missing dependency "tunnel" to @actions/http-client

### DIFF
--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -38,9 +38,11 @@
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"
   },
+  "dependencies" {
+    "tunnel": "0.0.6"
+  },
   "devDependencies": {
     "@types/tunnel": "0.0.3",
-    "proxy": "^1.0.1",
-    "tunnel": "0.0.6"
+    "proxy": "^1.0.1"
   }
 }


### PR DESCRIPTION
`tunnel` is not a dev dependency, but a runtime dependency.

Fix https://github.com/actions/toolkit/issues/1083