### PR TITLE
Bump http-client to version 2.0.1

### DIFF
--- a/packages/http-client/RELEASES.md
+++ b/packages/http-client/RELEASES.md
@@ -1,5 +1,8 @@
 ## Releases
 
+## 2.0.1
+- Fix an issue with missing `tunnel` dependency [#1085](https://github.com/actions/toolkit/pull/1085)
+
 ## 2.0.0
 - The package is now compiled with TypeScript's [`strict` compiler setting](https://www.typescriptlang.org/tsconfig#strict). To comply with stricter rules:
   - Some exported types now include `| null` or `| undefined`, matching their actual behavior.

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Actions Http Client",
   "keywords": [
     "github",


### PR DESCRIPTION
Fix to help close out https://github.com/actions/toolkit/issues/1083

We'll need to update at least `@actions/core` and `@actions/github` afterwards as well with this new version