### PR TITLE
@actions/artifact 1.1.0 release

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -86,3 +86,7 @@
 ### 1.0.2
 
 - Update to v2.0.1 of `@actions/http-client` [#1087](https://github.com/actions/toolkit/pull/1087)
+
+### 1.1.0
+
+- Add `x-actions-results-crc64` and `x-actions-results-md5` checksum headers on upload [#1063](https://github.com/actions/toolkit/pull/1063)

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [


### PR DESCRIPTION
Adds `x-actions-results-crc64` and `x-actions-results-md5` checksum headers on upload

- https://github.com/actions/toolkit/pull/1063