### PR TITLE
Avoid saving empty cache when there are no files to cache.

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -62,3 +62,6 @@
 
 ### 2.0.4
 - Update to v2.0.1 of `@actions/http-client` [#1087](https://github.com/actions/toolkit/pull/1087)
+
+### 2.0.5
+- Fix to avoid saving empty cache when no files are available for caching. ([issue](https://github.com/actions/cache/issues/624))

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -298,6 +298,6 @@ test('save with non existing path should not save cache', async () => {
     return []
   })
   await expect(saveCache([path], primaryKey)).rejects.toThrowError(
-    `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`
+    `Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`
   )
 })

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -290,3 +290,14 @@ test('save with valid inputs uploads a cache', async () => {
   expect(saveCacheMock).toHaveBeenCalledWith(cacheId, archiveFile, undefined)
   expect(getCompressionMock).toHaveBeenCalledTimes(1)
 })
+
+test('save with non existing path should not save cache', async () => {
+  const paths: string[] = ['aPathThatDoesnotExist']
+  const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  jest.spyOn(cacheUtils, 'resolvePaths').mockImplementation(async filePaths => {
+    return []
+  })
+  await expect(saveCache(paths, primaryKey)).rejects.toThrowError(
+    `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`
+  )
+})

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -292,7 +292,7 @@ test('save with valid inputs uploads a cache', async () => {
 })
 
 test('save with non existing path should not save cache', async () => {
-  const paths: string[] = ['aPathThatDoesnotExist']
+  const paths: string[] = ['node_modules']
   const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
   jest.spyOn(cacheUtils, 'resolvePaths').mockImplementation(async filePaths => {
     return []

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -292,12 +292,12 @@ test('save with valid inputs uploads a cache', async () => {
 })
 
 test('save with non existing path should not save cache', async () => {
-  const paths: string[] = ['node_modules']
+  const path = 'node_modules'
   const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
-  jest.spyOn(cacheUtils, 'resolvePaths').mockImplementation(async filePaths => {
+  jest.spyOn(cacheUtils, 'resolvePaths').mockImplementation(async () => {
     return []
   })
-  await expect(saveCache(paths, primaryKey)).rejects.toThrowError(
+  await expect(saveCache([path], primaryKey)).rejects.toThrowError(
     `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`
   )
 })

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -160,7 +160,7 @@ export async function saveCache(
 
   if (cachePaths.length === 0) {
     throw new Error(
-      `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`
+      `Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`
     )
   }
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -160,8 +160,9 @@ export async function saveCache(
 
   
   if(cachePaths.length === 0){
-    throw new ValidationError(
-      `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`)
+    throw new Error(
+      `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`
+      )
   }
 
   const archiveFolder = await utils.createTempDirectory()

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -158,6 +158,12 @@ export async function saveCache(
   core.debug('Cache Paths:')
   core.debug(`${JSON.stringify(cachePaths)}`)
 
+  
+  if(cachePaths.length === 0){
+    throw new ValidationError(
+      `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`)
+  }
+
   const archiveFolder = await utils.createTempDirectory()
   const archivePath = path.join(
     archiveFolder,

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -158,11 +158,10 @@ export async function saveCache(
   core.debug('Cache Paths:')
   core.debug(`${JSON.stringify(cachePaths)}`)
 
-  
-  if(cachePaths.length === 0){
+  if (cachePaths.length === 0) {
     throw new Error(
       `Path Validation Error: Path(s) specified in the action do not exist, hence no cache is being saved.`
-      )
+    )
   }
 
   const archiveFolder = await utils.createTempDirectory()


### PR DESCRIPTION
Fix for [#624](https://github.com/actions/cache/issues/624), below are the changes in the PR- 

- Checking if the cachePaths generated consist of at least one file/directory to cache. Throwing a warning if there are no paths.
- Unit Test cases.