### PR TITLE
Add debug info for check os version id during manifest findMatch

### DIFF
--- a/packages/tool-cache/src/manifest.ts
+++ b/packages/tool-cache/src/manifest.ts
@@ -92,6 +92,11 @@ export async function _findMatch(
             chk = true
           } else {
             chk = semver.satisfies(osVersion, item.platform_version)
+            if (!chk) {
+              debug(
+                `os version: "${osVersion}" does not match version python is built for: "${item.platform_version}"`
+              )
+            }
           }
         }
 


### PR DESCRIPTION
Currently the setup-python action fails silently if run the linux distribution other than Ubuntu.
The PR adds more debug to detect the situation the client uses non-ubuntu self-hosted aggent