### PR TITLE
Fix typo in AnnotationProperties doc

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -34,7 +34,7 @@ export enum ExitCode {
 }
 
 /**
- * Optional properties that can be sent with annotatation commands (notice, error, and warning)
+ * Optional properties that can be sent with annotation commands (notice, error, and warning)
  * See: https://docs.github.com/en/rest/reference/checks#create-a-check-run for more information about annotations.
  */
 export interface AnnotationProperties {


### PR DESCRIPTION
Just that, I was using `core` and checking the docs when I noticed the annotation typo