### PR TITLE
Graceful handling of error (non-validation one) 

### DIFF
--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -83,7 +83,7 @@ test('restore with server error should fail', async () => {
   expect(cacheKey).toBe(undefined)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
   expect(logWarningMock).toHaveBeenCalledWith(
-    'Fail to restore: HTTP Error Occurred'
+    'Failed to restore: HTTP Error Occurred'
   )
 })
 

--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -73,14 +73,16 @@ test('restore with no cache found', async () => {
 test('restore with server error should fail', async () => {
   const paths = ['node_modules']
   const key = 'node-test'
+  const logWarningMock = jest.spyOn(core, "warning");
 
   jest.spyOn(cacheHttpClient, 'getCacheEntry').mockImplementation(() => {
     throw new Error('HTTP Error Occurred')
   })
 
-  await expect(restoreCache(paths, key)).rejects.toThrowError(
-    'HTTP Error Occurred'
-  )
+  const cacheKey = await restoreCache(paths, key)
+  expect(cacheKey).toBe(undefined)
+  expect(logWarningMock).toHaveBeenCalledTimes(1)
+  expect(logWarningMock).toHaveBeenCalledWith('Fail to restore: Error: HTTP Error Occurred')
 })
 
 test('restore with restore keys and no cache found', async () => {

--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -73,7 +73,7 @@ test('restore with no cache found', async () => {
 test('restore with server error should fail', async () => {
   const paths = ['node_modules']
   const key = 'node-test'
-  const logWarningMock = jest.spyOn(core, "warning");
+  const logWarningMock = jest.spyOn(core, 'warning')
 
   jest.spyOn(cacheHttpClient, 'getCacheEntry').mockImplementation(() => {
     throw new Error('HTTP Error Occurred')
@@ -82,7 +82,9 @@ test('restore with server error should fail', async () => {
   const cacheKey = await restoreCache(paths, key)
   expect(cacheKey).toBe(undefined)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to restore: Error: HTTP Error Occurred')
+  expect(logWarningMock).toHaveBeenCalledWith(
+    'Fail to restore: Error: HTTP Error Occurred'
+  )
 })
 
 test('restore with restore keys and no cache found', async () => {

--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -83,7 +83,7 @@ test('restore with server error should fail', async () => {
   expect(cacheKey).toBe(undefined)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
   expect(logWarningMock).toHaveBeenCalledWith(
-    'Fail to restore: Error: HTTP Error Occurred'
+    'Fail to restore: HTTP Error Occurred'
   )
 })
 

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -62,7 +62,7 @@ test('save with large cache outputs should fail', async () => {
   const cacheId = await saveCache([filePath], primaryKey)
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Error: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.')
+  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.')
 
   const archiveFolder = '/foo/bar'
 
@@ -112,7 +112,7 @@ test('save with large cache outputs should fail in GHES with error message', asy
   const cacheId = await saveCache([filePath], primaryKey)
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Error: The cache filesize must be between 0 and 1073741824 bytes')
+  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: The cache filesize must be between 0 and 1073741824 bytes')
 
   const archiveFolder = '/foo/bar'
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
@@ -158,7 +158,7 @@ test('save with large cache outputs should fail in GHES without error message', 
   const cacheId = await saveCache([filePath], primaryKey)
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Error: Cache size of ~11264 MB (11811160064 B) is over the data cap limit, not saving cache.')
+  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Cache size of ~11264 MB (11811160064 B) is over the data cap limit, not saving cache.')
 
   const archiveFolder = '/foo/bar'
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
@@ -174,7 +174,7 @@ test('save with large cache outputs should fail in GHES without error message', 
 test('save with reserve cache failure should fail', async () => {
   const paths = ['node_modules']
   const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
-  const logWarningMock = jest.spyOn(core, "warning");
+  const logInfoMock = jest.spyOn(core, "info");
 
   const reserveCacheMock = jest
     .spyOn(cacheHttpClient, 'reserveCache')
@@ -196,8 +196,8 @@ test('save with reserve cache failure should fail', async () => {
 
   const cacheId = await saveCache(paths, primaryKey)
   expect(cacheId).toBe(-1)
-  expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: ReserveCacheError: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache.')
+  expect(logInfoMock).toHaveBeenCalledTimes(1)
+  expect(logInfoMock).toHaveBeenCalledWith(`Fail to save: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache. More details: undefined`)
 
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
   expect(reserveCacheMock).toHaveBeenCalledWith(primaryKey, paths, {
@@ -239,7 +239,7 @@ test('save with server error should fail', async () => {
     
   await saveCache([filePath], primaryKey)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Error: HTTP Error Occurred')
+  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: HTTP Error Occurred')
 
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
   expect(reserveCacheMock).toHaveBeenCalledWith(primaryKey, [filePath], {

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -48,7 +48,7 @@ test('save with large cache outputs should fail', async () => {
   const cachePaths = [path.resolve(filePath)]
 
   const createTarMock = jest.spyOn(tar, 'createTar')
-  const logWarningMock = jest.spyOn(core, "warning");
+  const logWarningMock = jest.spyOn(core, 'warning')
 
   const cacheSize = 11 * 1024 * 1024 * 1024 //~11GB, over the 10GB limit
   jest
@@ -58,11 +58,13 @@ test('save with large cache outputs should fail', async () => {
   const getCompressionMock = jest
     .spyOn(cacheUtils, 'getCompressionMethod')
     .mockReturnValueOnce(Promise.resolve(compression))
-  
+
   const cacheId = await saveCache([filePath], primaryKey)
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.')
+  expect(logWarningMock).toHaveBeenCalledWith(
+    'Fail to save: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.'
+  )
 
   const archiveFolder = '/foo/bar'
 
@@ -81,7 +83,7 @@ test('save with large cache outputs should fail in GHES with error message', asy
   const cachePaths = [path.resolve(filePath)]
 
   const createTarMock = jest.spyOn(tar, 'createTar')
-  const logWarningMock = jest.spyOn(core, "warning");
+  const logWarningMock = jest.spyOn(core, 'warning')
 
   const cacheSize = 11 * 1024 * 1024 * 1024 //~11GB, over the 10GB limit
   jest
@@ -108,11 +110,13 @@ test('save with large cache outputs should fail in GHES with error message', asy
       }
       return response
     })
-  
+
   const cacheId = await saveCache([filePath], primaryKey)
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: The cache filesize must be between 0 and 1073741824 bytes')
+  expect(logWarningMock).toHaveBeenCalledWith(
+    'Fail to save: The cache filesize must be between 0 and 1073741824 bytes'
+  )
 
   const archiveFolder = '/foo/bar'
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
@@ -131,7 +135,7 @@ test('save with large cache outputs should fail in GHES without error message', 
   const cachePaths = [path.resolve(filePath)]
 
   const createTarMock = jest.spyOn(tar, 'createTar')
-  const logWarningMock = jest.spyOn(core, "warning");
+  const logWarningMock = jest.spyOn(core, 'warning')
 
   const cacheSize = 11 * 1024 * 1024 * 1024 //~11GB, over the 10GB limit
   jest
@@ -158,7 +162,9 @@ test('save with large cache outputs should fail in GHES without error message', 
   const cacheId = await saveCache([filePath], primaryKey)
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: Cache size of ~11264 MB (11811160064 B) is over the data cap limit, not saving cache.')
+  expect(logWarningMock).toHaveBeenCalledWith(
+    'Fail to save: Cache size of ~11264 MB (11811160064 B) is over the data cap limit, not saving cache.'
+  )
 
   const archiveFolder = '/foo/bar'
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
@@ -174,7 +180,7 @@ test('save with large cache outputs should fail in GHES without error message', 
 test('save with reserve cache failure should fail', async () => {
   const paths = ['node_modules']
   const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
-  const logInfoMock = jest.spyOn(core, "info");
+  const logInfoMock = jest.spyOn(core, 'info')
 
   const reserveCacheMock = jest
     .spyOn(cacheHttpClient, 'reserveCache')
@@ -197,7 +203,9 @@ test('save with reserve cache failure should fail', async () => {
   const cacheId = await saveCache(paths, primaryKey)
   expect(cacheId).toBe(-1)
   expect(logInfoMock).toHaveBeenCalledTimes(1)
-  expect(logInfoMock).toHaveBeenCalledWith(`Fail to save: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache. More details: undefined`)
+  expect(logInfoMock).toHaveBeenCalledWith(
+    `Fail to save: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache. More details: undefined`
+  )
 
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
   expect(reserveCacheMock).toHaveBeenCalledWith(primaryKey, paths, {
@@ -212,7 +220,7 @@ test('save with server error should fail', async () => {
   const filePath = 'node_modules'
   const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
   const cachePaths = [path.resolve(filePath)]
-  const logWarningMock = jest.spyOn(core, "warning");
+  const logWarningMock = jest.spyOn(core, 'warning')
   const cacheId = 4
   const reserveCacheMock = jest
     .spyOn(cacheHttpClient, 'reserveCache')
@@ -236,10 +244,12 @@ test('save with server error should fail', async () => {
   const getCompressionMock = jest
     .spyOn(cacheUtils, 'getCompressionMethod')
     .mockReturnValueOnce(Promise.resolve(compression))
-    
+
   await saveCache([filePath], primaryKey)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
-  expect(logWarningMock).toHaveBeenCalledWith('Fail to save: HTTP Error Occurred')
+  expect(logWarningMock).toHaveBeenCalledWith(
+    'Fail to save: HTTP Error Occurred'
+  )
 
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
   expect(reserveCacheMock).toHaveBeenCalledWith(primaryKey, [filePath], {

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -63,7 +63,7 @@ test('save with large cache outputs should fail', async () => {
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
   expect(logWarningMock).toHaveBeenCalledWith(
-    'Fail to save: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.'
+    'Failed to save: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.'
   )
 
   const archiveFolder = '/foo/bar'
@@ -115,7 +115,7 @@ test('save with large cache outputs should fail in GHES with error message', asy
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
   expect(logWarningMock).toHaveBeenCalledWith(
-    'Fail to save: The cache filesize must be between 0 and 1073741824 bytes'
+    'Failed to save: The cache filesize must be between 0 and 1073741824 bytes'
   )
 
   const archiveFolder = '/foo/bar'
@@ -163,7 +163,7 @@ test('save with large cache outputs should fail in GHES without error message', 
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
   expect(logWarningMock).toHaveBeenCalledWith(
-    'Fail to save: Cache size of ~11264 MB (11811160064 B) is over the data cap limit, not saving cache.'
+    'Failed to save: Cache size of ~11264 MB (11811160064 B) is over the data cap limit, not saving cache.'
   )
 
   const archiveFolder = '/foo/bar'
@@ -204,7 +204,7 @@ test('save with reserve cache failure should fail', async () => {
   expect(cacheId).toBe(-1)
   expect(logInfoMock).toHaveBeenCalledTimes(1)
   expect(logInfoMock).toHaveBeenCalledWith(
-    `Fail to save: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache. More details: undefined`
+    `Failed to save: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache. More details: undefined`
   )
 
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)
@@ -248,7 +248,7 @@ test('save with server error should fail', async () => {
   await saveCache([filePath], primaryKey)
   expect(logWarningMock).toHaveBeenCalledTimes(1)
   expect(logWarningMock).toHaveBeenCalledWith(
-    'Fail to save: HTTP Error Occurred'
+    'Failed to save: HTTP Error Occurred'
   )
 
   expect(reserveCacheMock).toHaveBeenCalledTimes(1)

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -5,7 +5,6 @@ import * as cacheHttpClient from './internal/cacheHttpClient'
 import {createTar, extractTar, listTar} from './internal/tar'
 import {DownloadOptions, UploadOptions} from './options'
 
-
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message)

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -5,6 +5,7 @@ import * as cacheHttpClient from './internal/cacheHttpClient'
 import {createTar, extractTar, listTar} from './internal/tar'
 import {DownloadOptions, UploadOptions} from './options'
 
+
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message)
@@ -128,7 +129,7 @@ export async function restoreCache(
     return cacheEntry.cacheKey
   } catch (error) {
     // Supress all cache related errors because caching should be optional
-    core.warning(`Fail to restore: ${error}`)
+    core.warning(`Fail to restore: ${(error as Error).message}`)
   } finally {
     // Try to delete the archive to save space
     try {

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -128,7 +128,7 @@ export async function restoreCache(
     return cacheEntry.cacheKey
   } catch (error) {
     // Supress all cache related errors because caching should be optional
-    core.warning(`Fail to restore: ${(error as Error).message}`)
+    core.warning(`Failed to restore: ${(error as Error).message}`)
   } finally {
     // Try to delete the archive to save space
     try {
@@ -226,9 +226,9 @@ export async function saveCache(
   } catch (error) {
     const typedError = error as Error
     if (typedError.name === ReserveCacheError.name) {
-      core.info(`Fail to save: ${typedError.message}`)
+      core.info(`Failed to save: ${typedError.message}`)
     } else {
-      core.warning(`Fail to save: ${typedError.message}`)
+      core.warning(`Failed to save: ${typedError.message}`)
     }
   } finally {
     // Try to delete the archive to save space

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -4,7 +4,7 @@ import * as utils from './internal/cacheUtils'
 import * as cacheHttpClient from './internal/cacheHttpClient'
 import {createTar, extractTar, listTar} from './internal/tar'
 import {DownloadOptions, UploadOptions} from './options'
-import { ArtifactCacheEntry } from './internal/contracts'
+import {ArtifactCacheEntry} from './internal/contracts'
 
 export class ValidationError extends Error {
   constructor(message: string) {
@@ -87,10 +87,10 @@ export async function restoreCache(
   }
 
   const compressionMethod = await utils.getCompressionMethod()
-  let archivePath = ""
+  let archivePath = ''
   try {
-      // path are needed to compute version
-      const cacheEntry = await cacheHttpClient.getCacheEntry(keys, paths, {
+    // path are needed to compute version
+    const cacheEntry = await cacheHttpClient.getCacheEntry(keys, paths, {
       compressionMethod
     })
 
@@ -98,13 +98,13 @@ export async function restoreCache(
       // Cache not found
       return undefined
     }
-  
-      archivePath = path.join(
+
+    archivePath = path.join(
       await utils.createTempDirectory(),
       utils.getCacheFileName(compressionMethod)
     )
     core.debug(`Archive Path: ${archivePath}`)
-  
+
     // Download the cache from the cache entry
     await cacheHttpClient.downloadCache(
       cacheEntry.archiveLocation,
@@ -125,12 +125,12 @@ export async function restoreCache(
 
     await extractTar(archivePath, compressionMethod)
     core.info('Cache restored successfully')
-    
+
     return cacheEntry.cacheKey
-  } catch(error) {
-      // Supress all cache related errors because caching should be optional
-      core.warning(`Fail to restore: ${error}`);
-  }finally {
+  } catch (error) {
+    // Supress all cache related errors because caching should be optional
+    core.warning(`Fail to restore: ${error}`)
+  } finally {
     // Try to delete the archive to save space
     try {
       await utils.unlinkFile(archivePath)
@@ -224,8 +224,8 @@ export async function saveCache(
 
     core.debug(`Saving Cache (ID: ${cacheId})`)
     await cacheHttpClient.saveCache(cacheId, archivePath, options)
-  } catch(error) {
-    const typedError = error as Error;
+  } catch (error) {
+    const typedError = error as Error
     if (typedError.name === ReserveCacheError.name) {
       core.info(`Fail to save: ${typedError.message}`)
     } else {

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -225,7 +225,12 @@ export async function saveCache(
     core.debug(`Saving Cache (ID: ${cacheId})`)
     await cacheHttpClient.saveCache(cacheId, archivePath, options)
   } catch(error) {
-    core.warning(`Fail to save: ${error}`)
+    const typedError = error as Error;
+    if (typedError.name === ReserveCacheError.name) {
+      core.info(`Fail to save: ${typedError.message}`)
+    } else {
+      core.warning(`Fail to save: ${typedError.message}`)
+    }
   } finally {
     // Try to delete the archive to save space
     try {

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -4,7 +4,6 @@ import * as utils from './internal/cacheUtils'
 import * as cacheHttpClient from './internal/cacheHttpClient'
 import {createTar, extractTar, listTar} from './internal/tar'
 import {DownloadOptions, UploadOptions} from './options'
-import {ArtifactCacheEntry} from './internal/contracts'
 
 export class ValidationError extends Error {
   constructor(message: string) {


### PR DESCRIPTION
We recently saw due to unavailability of Actions cache service, some of the setup-* start failing because of their caching feature. Ideally from actions-cache team it is recommended to handle cache service error (non-validation) gracefully and not to fail to workflow. This PR moves that dependency to caches packages, so that we will not throw error and throw the error as warning/info to stderr/stdout.