### PR TITLE
Fix reject call in packages/artifact's upload-zip.ts

### DIFF
--- a/packages/artifact/src/internal/upload-gzip.ts
+++ b/packages/artifact/src/internal/upload-gzip.ts
@@ -47,7 +47,7 @@ export async function createGZipFileOnDisk(
     outputStream.on('error', error => {
       // eslint-disable-next-line no-console
       console.log(error)
-      reject
+      reject(error)
     })
   })
 }


### PR DESCRIPTION
The promise's `reject` function currently isn't actually being called in `packages/artifact/src/internal/upload-gzip.ts::createGZipFileOnDisk` in the event of an error. This fixes that by simply calling `reject` with the `error` from the context as argument.


---


Note: I found out about this mistake through [LGTM.com](https://lgtm.com/projects/g/actions/toolkit/snapshot/8ef45a3bfd72f2e0a37a2f819374d6342215d650/files/packages/artifact/src/internal/upload-gzip.ts?sort=name&dir=ASC&mode=heatmap). After patching the problem I noticed this repository also [uses the CodeQL Action](https://github.com/actions/toolkit/blob/c5278cdd088a8ed6a87dbd5c80d7c1ae03beb6e5/.github/workflows/codeql.yml) - and it even [looks like it's reporting this problem](https://github.com/actions/toolkit/runs/7039442930?check_suite_focus=true#step:5:1387) - so you might also already be aware of this. Though, the following warning may mean the CodeQL Action isn't set up correctly and hence the report never got through.

![CodeQL Action warning](https://user-images.githubusercontent.com/3742559/175699485-24354015-6060-4356-a632-ed5f4bd56d81.png)
