### PR TITLE
Fix Empty Cache save when the path is github workspace directory

### DIFF
--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -1,6 +1,5 @@
 import {promises as fs} from 'fs'
 import * as path from 'path'
-import { coerce } from 'semver'
 import * as cacheUtils from '../src/internal/cacheUtils'
 
 test('getArchiveFileSizeInBytes returns file size', () => {

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -35,5 +35,5 @@ test('assertDefined returns value', () => {
 
 test('resolvePaths works on current directory', async () => {
   const resolvedPath = await cacheUtils.resolvePaths(['.'])
-  expect(resolvedPath).toBe(['.'])
+  expect(resolvedPath).toStrictEqual(['.'])
 })

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -1,5 +1,6 @@
 import {promises as fs} from 'fs'
 import * as path from 'path'
+import { coerce } from 'semver'
 import * as cacheUtils from '../src/internal/cacheUtils'
 
 test('getArchiveFileSizeInBytes returns file size', () => {
@@ -34,6 +35,6 @@ test('assertDefined returns value', () => {
 })
 
 test('resolvePaths works on current directory', async () => {
-  const resolvedPath = await cacheUtils.resolvePaths(['.'])
-  expect(resolvedPath).toStrictEqual(['.'])
+  const paths = await cacheUtils.resolvePaths(['.'])
+  expect(paths).toContain('.')
 })

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -33,7 +33,8 @@ test('assertDefined returns value', () => {
   expect(cacheUtils.assertDefined('test', 5)).toBe(5)
 })
 
-test('resolvePaths works on current directory', async () => {
-  const paths = await cacheUtils.resolvePaths(['.'])
-  expect(paths.length).toBe(1)
+test('resolvePaths works on github workspace directory', async () => {
+  const workspace = process.env['GITHUB_WORKSPACE'] ?? '.'
+  const paths = await cacheUtils.resolvePaths([workspace])
+  expect(paths.length).toBeGreaterThan(0)
 })

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -32,3 +32,8 @@ test('assertDefined throws if undefined', () => {
 test('assertDefined returns value', () => {
   expect(cacheUtils.assertDefined('test', 5)).toBe(5)
 })
+
+test('resolvePaths works on current directory', async () => {
+  const resolvedPath = await cacheUtils.resolvePaths(['.'])
+  expect(resolvedPath).toBe(['.'])
+})

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -52,7 +52,12 @@ export async function resolvePaths(patterns: string[]): Promise<string[]> {
       .replace(new RegExp(`\\${path.sep}`, 'g'), '/')
     core.debug(`Matched: ${relativeFile}`)
     // Paths are made relative so the tar entries are all relative to the root of the workspace.
-    paths.push(`${relativeFile}`)
+    if (relativeFile === "") {
+      // path.relative returns empty string if workspace and file are equal
+      paths.push(".")
+    } else {
+      paths.push(`${relativeFile}`)
+    }
   }
 
   return paths

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -52,9 +52,9 @@ export async function resolvePaths(patterns: string[]): Promise<string[]> {
       .replace(new RegExp(`\\${path.sep}`, 'g'), '/')
     core.debug(`Matched: ${relativeFile}`)
     // Paths are made relative so the tar entries are all relative to the root of the workspace.
-    if (relativeFile === "") {
+    if (relativeFile === '') {
       // path.relative returns empty string if workspace and file are equal
-      paths.push(".")
+      paths.push('.')
     } else {
       paths.push(`${relativeFile}`)
     }


### PR DESCRIPTION
This PR fixes the [#833](https://github.com/actions/cache/issues/833) issue in actions/cache.

**Issue Summary**: Cache being saved is empty in case of path being current directory or github.workspace. So github.workspace directory can never get cached.

**Root cause**:  The resolvePaths function returns empty since the relative path of the path provided in cache's path param is calculated against the workspace directory itself. 

**Resolution**: We manually add '.' to paths list since the list will be empty in the above scenario.

Feedback is welcome regarding the implementation and possible alternatives. 👀 