### PR TITLE
Move zstd from flags to equivalent aliases

### DIFF
--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -50,7 +50,7 @@ test('zstd extract tar', async () => {
     `"${defaultTarPath}"`,
     [
       '--use-compress-program',
-      'zstd -d --long=30',
+      'unzstd --long=30',
       '-xf',
       IS_WINDOWS ? archivePath.replace(/\\/g, '/') : archivePath,
       '-P',
@@ -140,7 +140,7 @@ test('zstd create tar', async () => {
     [
       '--posix',
       '--use-compress-program',
-      'zstd -T0 --long=30',
+      'zstdmt --long=30',
       '-cf',
       IS_WINDOWS ? CacheFilename.Zstd.replace(/\\/g, '/') : CacheFilename.Zstd,
       '--exclude',
@@ -210,7 +210,7 @@ test('zstd list tar', async () => {
     `"${defaultTarPath}"`,
     [
       '--use-compress-program',
-      'zstd -d --long=30',
+      'unzstd --long=30',
       '-tf',
       IS_WINDOWS ? archivePath.replace(/\\/g, '/') : archivePath,
       '-P'
@@ -235,7 +235,7 @@ test('zstdWithoutLong list tar', async () => {
     `"${defaultTarPath}"`,
     [
       '--use-compress-program',
-      'zstd -d',
+      'unzstd',
       '-tf',
       IS_WINDOWS ? archivePath.replace(/\\/g, '/') : archivePath,
       '-P'

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -67,9 +67,9 @@ export async function extractTar(
   function getCompressionProgram(): string[] {
     switch (compressionMethod) {
       case CompressionMethod.Zstd:
-        return ['--use-compress-program', 'zstd -d --long=30']
+        return ['--use-compress-program', 'unzstd --long=30']
       case CompressionMethod.ZstdWithoutLong:
-        return ['--use-compress-program', 'zstd -d']
+        return ['--use-compress-program', 'unzstd']
       default:
         return ['-z']
     }
@@ -106,9 +106,9 @@ export async function createTar(
   function getCompressionProgram(): string[] {
     switch (compressionMethod) {
       case CompressionMethod.Zstd:
-        return ['--use-compress-program', 'zstd -T0 --long=30']
+        return ['--use-compress-program', 'zstdmt --long=30']
       case CompressionMethod.ZstdWithoutLong:
-        return ['--use-compress-program', 'zstd -T0']
+        return ['--use-compress-program', 'zstdmt']
       default:
         return ['-z']
     }
@@ -140,9 +140,9 @@ export async function listTar(
   function getCompressionProgram(): string[] {
     switch (compressionMethod) {
       case CompressionMethod.Zstd:
-        return ['--use-compress-program', 'zstd -d --long=30']
+        return ['--use-compress-program', 'unzstd --long=30']
       case CompressionMethod.ZstdWithoutLong:
-        return ['--use-compress-program', 'zstd -d']
+        return ['--use-compress-program', 'unzstd']
       default:
         return ['-z']
     }


### PR DESCRIPTION
This PR fixes the issue [809](https://github.com/actions/cache/issues/809).
Cache save/restore failing on self-hosted EC2 runners running Amazon Linux 2.

Root Cause:
- Tar is failing to recognise flags passed to zstd(eg. `-T0`)  causing no such file or directory error.
- The flags are conflicting with tar flags causing an incorrect command to be formed in case of tar version <= 1.26. This command fails with exit code 2 causing cache save/restore to fail.

Explanation:
Currently, the tar command that is executed is in the form:
`usr/bin/tar --use-compress-program zstd -d -xf`
Here the `-d` is a flag to zstd but gets read as a flag to tar. For zstd  `-d` is decompress. For tar `-d` is diff.
For tar version >= 1.27 this works. Two probable reasons(not tested):
1. The flag gets read as tar’s but gets overwritten/ignored by -xf coming later.
2. It correctly gets read as zstd’s flag.
 
However, for tar version 1.26 which is the version running on the aws self-hosted runner, tar command fails with error: `tar: You may not specify more than one `-Acdtrux' or `--test-label' option`

Resolution:
We can consider checking for tar version and then use gzip as the compression algorithm instead of zstd. There could be a performance penalty which is a drawback.

Alternatively, we can ensure the -d flag being passed to zstd is unambiguous so tar does not interfere or accepts it. There are two ways I test if it can be achieved without breaking existing functionality:
1. (Did Not Work) Use GNU style flags . Instead of using -d we use --decompress in the toolkit where applicable.
2. (Implemented in this PR) Use native aliases that come with zstd. From [man pages](https://manpages.ubuntu.com/manpages/focal/en/man1/zstd.1.html) of zstd, it comes with alias for the operations we are trying to do. For ex.
`zstdmt is equivalent to zstd -T0 // Compress using max threads`
`unzstd is equivalent to zstd -d  // Decompress`

Please feel free provide review comments and feedback. 🔍 

cc @bishal-pdMSFT 



