### PR TITLE
Sanitize path components when constructing tool-cache path.

### DIFF
--- a/packages/tool-cache/__tests__/tool-cache.test.ts
+++ b/packages/tool-cache/__tests__/tool-cache.test.ts
@@ -878,6 +878,45 @@ describe('@actions/tool-cache', function() {
       }
     )
   })
+
+  it('checks for invalid tool name when creating the tool dir', async function() {
+    for (const invalidTool of [
+      path.join('foo', 'bar'),
+      path.join('..', 'baz'),
+      '..',
+      '.'
+    ]) {
+      await expect(
+        tc.cacheDir(__dirname, invalidTool, '1.1.0')
+      ).rejects.toThrow(/invalid tool/)
+    }
+  })
+
+  it('checks for invalid version when creating the tool dir', async function() {
+    for (const invalidVersion of [
+      path.join('1.1.0', '0'),
+      path.join('..', '1.1.0'),
+      '..',
+      '.'
+    ]) {
+      await expect(
+        tc.cacheDir(__dirname, 'foo', invalidVersion)
+      ).rejects.toThrow(/invalid version/)
+    }
+  })
+
+  it('checks for invalid architecture when creating the tool dir', async function() {
+    for (const invalidArch of [
+      path.join('amd', 'a64'),
+      path.join('..', 'x64'),
+      '..',
+      '.'
+    ]) {
+      await expect(
+        tc.cacheDir(__dirname, 'foo', '1.1.0', invalidArch)
+      ).rejects.toThrow(/invalid architecture/)
+    }
+  })
 })
 
 /**

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -657,6 +657,13 @@ async function _createExtractFolder(dest?: string): Promise<string> {
   return dest
 }
 
+function sanitizePathComponent(comp: string, name: string): string {
+  if (comp.includes(path.sep) || comp === '..' || comp === '.') {
+    throw new Error(`invalid ${name}: ${comp}`)
+  }
+  return comp
+}
+
 async function _createToolPath(
   tool: string,
   version: string,
@@ -664,9 +671,9 @@ async function _createToolPath(
 ): Promise<string> {
   const folderPath = path.join(
     _getCacheDirectory(),
-    tool,
-    semver.clean(version) || version,
-    arch || ''
+    sanitizePathComponent(tool, 'tool'),
+    sanitizePathComponent(semver.clean(version) || version, 'version'),
+    sanitizePathComponent(arch || '', 'architecture')
   )
   core.debug(`destination ${folderPath}`)
   const markerPath = `${folderPath}.complete`


### PR DESCRIPTION
This ensures that the tool name, version number, and architecture each only correspond to a single path component, avoiding (accidental or malicious) path traversal and data corruption.