### PR TITLE
Fix #809 and #833 in actions/cache. Bump version for NPM package actions/cache to v3.0.1

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -71,3 +71,7 @@
 
 ### 3.0.0
 - Updated actions/cache to suppress Actions cache server error and log warning for those error  [#1122](https://github.com/actions/toolkit/pull/1122)
+
+### 3.0.1
+- Fix [#833](https://github.com/actions/cache/issues/833) - cache doesn't work with github workspace directory.
+- Fix [#809](https://github.com/actions/cache/issues/809) `zstd -d: no such file or directory` error on AWS self-hosted runners.

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
This PR aims to release a new toolkit version `v3.0.1` with the following changes:

Bugfixes 🐞 : 
- Fix [#809](https://github.com/actions/cache/issues/809) in actions/cache repo
- Fix [#833](https://github.com/actions/cache/issues/833) in actions/cache repo

I need feedback regarding anything else that needs to be taken care of while releasing a new version. I have been following instructions from [here](https://github.com/github/c2c-actions/blob/main/docs/publishing-first-party-npm-packages.md) 🙇 
