### PR TITLE
Added custom user inputted timeout

### DIFF
--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -44,6 +44,6 @@ const cacheKey = await cache.restoreCache(paths, key, restoreKeys)
 
 ##### Cache segment restore timeout
 
-Version `v3.0.4` of cache package introduces a segment download timeout. A cache gets downloaded in multiple segments of fixed sizes (`1GB` for a `32-bit` runner and `2GB` for a `64-bit` runner). Sometimes, a segment download gets stuck which causes the workflow job to be stuck forever and fail. The segment download timeout will allow the segment download to get aborted and hence allow the job to proceed with a cache miss.
+A cache gets downloaded in multiple segments of fixed sizes (`1GB` for a `32-bit` runner and `2GB` for a `64-bit` runner). Sometimes, a segment download gets stuck which causes the workflow job to be stuck forever and fail. Version `v3.0.4` of cache package introduces a segment download timeout. The segment download timeout will allow the segment download to get aborted and hence allow the job to proceed with a cache miss.
 
-Default value of this timeout is 1 hour and can be customized by specifying an [environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables) named `SEGMENT_DOWNLOAD_TIMEOUT_MINS`.
+Default value of this timeout is 60 minutes and can be customized by specifying an [environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables) named `SEGMENT_DOWNLOAD_TIMEOUT_MINS` with timeout value in minutes.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -42,3 +42,8 @@ const restoreKeys = [
 const cacheKey = await cache.restoreCache(paths, key, restoreKeys)
 ```
 
+##### Cache segment restore timeout
+
+Starting `v3.0.5` of `actions/toolkit`, in case any issue occurs while downloading the cache, the download will be aborted by default within 1 hour if any `segment` doesn't download completely. A `segment` is limited to size of `1GB` for a `32-bit` runner and `2GB` for a `64-bit` runner. So for any cache that exceeds the size of one segment, multiple segments will be downloaded in sequence to complete the download.
+
+To customise the `segment` download timeout, an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS` needs to be set with the timeout minutes. This way the download wouldn't get stuck forever and proceed to next step in the workflow without any problem.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -44,6 +44,6 @@ const cacheKey = await cache.restoreCache(paths, key, restoreKeys)
 
 ##### Cache segment restore timeout
 
-Starting `v3.0.5` of `actions/toolkit`, in case any issue occurs while downloading the cache, the download will be aborted by default within 1 hour if any `segment` doesn't download completely. A `segment` is limited to size of `1GB` for a `32-bit` runner and `2GB` for a `64-bit` runner. So for any cache that exceeds the size of one segment, multiple segments will be downloaded in sequence to complete the download.
+Version `v3.0.4` of cache package introduces a segment download timeout. A cache gets downloaded in multiple segments of fixed sizes (`1GB` for a `32-bit` runner and `2GB` for a `64-bit` runner). Sometimes, a segment download gets stuck which causes the workflow job to be stuck forever and fail. The segment download timeout will allow the segment download to get aborted and hence allow the job to proceed with a cache miss.
 
-To customise the `segment` download timeout, an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS` needs to be set with the timeout minutes. This way the download wouldn't get stuck forever and proceed to next step in the workflow without any problem.
+Default value of this timeout is 1 hour and can be customized by specifying an [environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables) named `SEGMENT_DOWNLOAD_TIMEOUT_MINS`.

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -82,5 +82,5 @@
 ### 3.0.3
 - Bug fixes for download stuck issue [#810](https://github.com/actions/cache/issues/810).
 
-### 3.0.4
--  Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `CACHE_DOWNLOAD_TIMEOUT_MINS`. Default is 1 hour.
+### 3.0.5
+-  Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 1 hour.

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -83,4 +83,4 @@
 - Bug fixes for download stuck issue [#810](https://github.com/actions/cache/issues/810).
 
 ### 3.0.4
-- Allowing users to provide a custom timeout as input for aborting cache download using an environment variable `CACHE_DOWNLOAD_TIMEOUT_MINS`. Default is 1 hour.
+-  Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `CACHE_DOWNLOAD_TIMEOUT_MINS`. Default is 1 hour.

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -81,3 +81,6 @@
 
 ### 3.0.3
 - Bug fixes for download stuck issue [#810](https://github.com/actions/cache/issues/810).
+
+### 3.0.4
+- Allowing users to provide a custom timeout as input for aborting cache download using an environment variable `CACHE_DOWNLOAD_TIMEOUT_MINS`. Default is 1 hour.

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -82,5 +82,5 @@
 ### 3.0.3
 - Bug fixes for download stuck issue [#810](https://github.com/actions/cache/issues/810).
 
-### 3.0.5
+### 3.0.4
 -  Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 1 hour.

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -83,4 +83,4 @@
 - Bug fixes for download stuck issue [#810](https://github.com/actions/cache/issues/810).
 
 ### 3.0.4
--  Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 1 hour.
+-  Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 60 minutes.

--- a/packages/cache/__tests__/options.test.ts
+++ b/packages/cache/__tests__/options.test.ts
@@ -63,7 +63,7 @@ test('getDownloadOptions overrides download timeout minutes', async () => {
     timeoutInMs: 20000,
     segmentTimeoutInMs: 3600000
   }
-  process.env.CACHE_DOWNLOAD_TIMEOUT_MINS = '10'
+  process.env.SEGMENT_DOWNLOAD_TIMEOUT_MINS = '10'
   const actualOptions = getDownloadOptions(expectedOptions)
 
   expect(actualOptions.useAzureSdk).toEqual(expectedOptions.useAzureSdk)

--- a/packages/cache/__tests__/options.test.ts
+++ b/packages/cache/__tests__/options.test.ts
@@ -55,3 +55,21 @@ test('getUploadOptions overrides all settings', async () => {
 
   expect(actualOptions).toEqual(expectedOptions)
 })
+
+test('getDownloadOptions overrides download timeout minutes', async () => {
+  const expectedOptions: DownloadOptions = {
+    useAzureSdk: false,
+    downloadConcurrency: 14,
+    timeoutInMs: 20000,
+    segmentTimeoutInMs: 3600000
+  }
+  process.env.CACHE_DOWNLOAD_TIMEOUT_MINS = '10'
+  const actualOptions = getDownloadOptions(expectedOptions)
+
+  expect(actualOptions.useAzureSdk).toEqual(expectedOptions.useAzureSdk)
+  expect(actualOptions.downloadConcurrency).toEqual(
+    expectedOptions.downloadConcurrency
+  )
+  expect(actualOptions.timeoutInMs).toEqual(expectedOptions.timeoutInMs)
+  expect(actualOptions.segmentTimeoutInMs).toEqual(600000)
+})

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/src/options.ts
+++ b/packages/cache/src/options.ts
@@ -112,20 +112,21 @@ export function getDownloadOptions(copy?: DownloadOptions): DownloadOptions {
       result.segmentTimeoutInMs = copy.segmentTimeoutInMs
     }
   }
-  const customDownloadTimeoutMins = process.env['CACHE_DOWNLOAD_TIMEOUT_MINS']
+  const segmentDownloadTimeoutMins =
+    process.env['SEGMENT_DOWNLOAD_TIMEOUT_MINS']
 
   if (
-    customDownloadTimeoutMins &&
-    !isNaN(Number(customDownloadTimeoutMins)) &&
-    isFinite(Number(customDownloadTimeoutMins))
+    segmentDownloadTimeoutMins &&
+    !isNaN(Number(segmentDownloadTimeoutMins)) &&
+    isFinite(Number(segmentDownloadTimeoutMins))
   ) {
-    result.segmentTimeoutInMs = Number(customDownloadTimeoutMins) * 60 * 1000
+    result.segmentTimeoutInMs = Number(segmentDownloadTimeoutMins) * 60 * 1000
   }
   core.debug(`Use Azure SDK: ${result.useAzureSdk}`)
   core.debug(`Download concurrency: ${result.downloadConcurrency}`)
   core.debug(`Request timeout (ms): ${result.timeoutInMs}`)
   core.debug(
-    `Cache download timeout mins env var: ${process.env['CACHE_DOWNLOAD_TIMEOUT_MINS']}`
+    `Cache segment download timeout mins env var: ${process.env['SEGMENT_DOWNLOAD_TIMEOUT_MINS']}`
   )
   core.debug(`Segment download timeout (ms): ${result.segmentTimeoutInMs}`)
 

--- a/packages/cache/src/options.ts
+++ b/packages/cache/src/options.ts
@@ -112,10 +112,21 @@ export function getDownloadOptions(copy?: DownloadOptions): DownloadOptions {
       result.segmentTimeoutInMs = copy.segmentTimeoutInMs
     }
   }
+  const customDownloadTimeoutMins = process.env['CACHE_DOWNLOAD_TIMEOUT_MINS']
 
+  if (
+    customDownloadTimeoutMins &&
+    !isNaN(Number(customDownloadTimeoutMins)) &&
+    isFinite(Number(customDownloadTimeoutMins))
+  ) {
+    result.segmentTimeoutInMs = Number(customDownloadTimeoutMins) * 60 * 1000
+  }
   core.debug(`Use Azure SDK: ${result.useAzureSdk}`)
   core.debug(`Download concurrency: ${result.downloadConcurrency}`)
   core.debug(`Request timeout (ms): ${result.timeoutInMs}`)
+  core.debug(
+    `Cache download timeout mins env var: ${process.env['CACHE_DOWNLOAD_TIMEOUT_MINS']}`
+  )
   core.debug(`Segment download timeout (ms): ${result.segmentTimeoutInMs}`)
 
   return result


### PR DESCRIPTION
Added an env var `SEGMENT_DOWNLOAD_TIMEOUT_MINS` that overrides the 1 hour default timeout for decreasing the cache download timeout.

[A successful run ](https://github.com/bbq-beets/test-cache-load/actions/runs/2865816461) 