### PR TITLE
chore(github): add triggeringActor  property with Context Class

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -15,6 +15,7 @@ export class Context {
   workflow: string
   action: string
   actor: string
+  triggeringActor: string
   job: string
   runNumber: number
   runId: number
@@ -43,6 +44,7 @@ export class Context {
     this.workflow = process.env.GITHUB_WORKFLOW as string
     this.action = process.env.GITHUB_ACTION as string
     this.actor = process.env.GITHUB_ACTOR as string
+    this.triggeringActor = process.env.GITHUB_TRIGGERING_ACTOR as string
     this.job = process.env.GITHUB_JOB as string
     this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER as string, 10)
     this.runId = parseInt(process.env.GITHUB_RUN_ID as string, 10)


### PR DESCRIPTION
A new property called **triggering_actor** has been added to the [context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context). It didn't exist in the Context class so I added it.


