### PR TITLE
Add additionalPlugins parameter to getOctokit method

### DIFF
--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -2,7 +2,7 @@ import * as Context from './context'
 import {GitHub, getOctokitOptions} from './utils'
 
 // octokit + plugins
-import {OctokitOptions} from '@octokit/core/dist-types/types'
+import {OctokitOptions, OctokitPlugin} from '@octokit/core/dist-types/types'
 
 export const context = new Context.Context()
 
@@ -14,7 +14,12 @@ export const context = new Context.Context()
  */
 export function getOctokit(
   token: string,
-  options?: OctokitOptions
+  options?: OctokitOptions,
+  ...additionalPlugins: OctokitPlugin[]
 ): InstanceType<typeof GitHub> {
+  if (additionalPlugins.length) {
+    const GitHubWithPlugins = GitHub.plugin(...additionalPlugins)
+    return new GitHubWithPlugins(getOctokitOptions(token, options))
+  }
   return new GitHub(getOctokitOptions(token, options))
 }


### PR DESCRIPTION
This allows clients to configure their Octokit/Github instance with OctoKit [plugins](https://github.com/octokit/core.js/#plugins). This is a variadic parameter, so it should not break existing calls to `getOctokit`