### PR TITLE
[artifact] exempt .tar.zst files from compression

### DIFF
--- a/packages/artifact/src/internal/upload-gzip.ts
+++ b/packages/artifact/src/internal/upload-gzip.ts
@@ -15,6 +15,8 @@ const gzipExemptFileExtensions = [
   '.tar.gz',
   '.tar.bz2',
   '.tar.zst',
+  '.tar.zstd',
+  '.tzst',
   '.7z'
 ]
 

--- a/packages/artifact/src/internal/upload-gzip.ts
+++ b/packages/artifact/src/internal/upload-gzip.ts
@@ -14,7 +14,7 @@ const gzipExemptFileExtensions = [
   '.tar.lz',
   '.tar.gz',
   '.tar.bz2',
-  '.tar.zst'
+  '.tar.zst',
   '.7z',
 ]
 

--- a/packages/artifact/src/internal/upload-gzip.ts
+++ b/packages/artifact/src/internal/upload-gzip.ts
@@ -14,7 +14,8 @@ const gzipExemptFileExtensions = [
   '.tar.lz',
   '.tar.gz',
   '.tar.bz2',
-  '.7z'
+  '.tar.zst'
+  '.7z',
 ]
 
 /**

--- a/packages/artifact/src/internal/upload-gzip.ts
+++ b/packages/artifact/src/internal/upload-gzip.ts
@@ -15,7 +15,7 @@ const gzipExemptFileExtensions = [
   '.tar.gz',
   '.tar.bz2',
   '.tar.zst',
-  '.7z',
+  '.7z'
 ]
 
 /**


### PR DESCRIPTION
These files are already compressed with zstd - no need to attempt re-compression.