### PR TITLE
Export default octokit options

### DIFF
--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -10,7 +10,7 @@ import {paginateRest} from '@octokit/plugin-paginate-rest'
 export const context = new Context.Context()
 
 const baseUrl = Utils.getApiBaseUrl()
-const defaults = {
+export const defaults: OctokitOptions = {
   baseUrl,
   request: {
     agent: Utils.getProxyAgent(baseUrl)


### PR DESCRIPTION
Certain plugins override the various `OctokitOptions`. Exporting the defaults allows actions that use plugins to inspect the default options and keep them / merge them with their plugin's options if desired. 