### PR TITLE
Document another likely reason for problem matcher patterns failing

### DIFF
--- a/docs/problem-matchers.md
+++ b/docs/problem-matchers.md
@@ -142,6 +142,8 @@ Some of the starter actions are already using problem matchers, for example:
 
 Use ECMAScript regular expression syntax when testing patterns.
 
+The patterns match the input lines as-is, without stripping ANSI escape codes or other extraneous characters.  If the subject strings can contain such characters, the regular expression must account for them.
+
 ### File property getting dropped
 
 [Enable debug logging](https://docs.github.com/en/actions/managing-workflow-runs/enabling-debug-logging) to determine why the file is getting dropped.

--- a/docs/problem-matchers.md
+++ b/docs/problem-matchers.md
@@ -142,7 +142,7 @@ Some of the starter actions are already using problem matchers, for example:
 
 Use ECMAScript regular expression syntax when testing patterns.
 
-The patterns match the input lines as-is, without stripping ANSI escape codes or other extraneous characters.  If the subject strings can contain such characters, the regular expression must account for them.
+The patterns match the input lines as-is, without stripping ANSI escape codes or other extraneous characters. If the subject strings can contain such characters, the regular expression must account for them.
 
 ### File property getting dropped
 


### PR DESCRIPTION
Input lines are passed as-is to the regular expressions used by problem matcher patterns. This can lead to unexpected failures when trying to, for example, match colored terminal output, which relies on [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code). The cause is not that obvious at a first glance because such characters are stripped from the GitHub log UI, and I think that it should be documented.