### PR TITLE
Patch @actions/cache to use @action/core version 1.10.0

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -85,3 +85,6 @@
 ### 3.0.4
 - Fix zstd not working for windows on gnu tar in issues [#888](https://github.com/actions/cache/issues/888) and [#891](https://github.com/actions/cache/issues/891).
 - Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 60 minutes.
+
+### 3.0.5
+- Update `@actions/cache` to use `@actions/core@^1.10.0`

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -617,9 +617,9 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -9,7 +9,7 @@
       "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",
         "@actions/glob": "^0.1.0",
         "@actions/http-client": "^2.0.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [
@@ -37,7 +37,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.0.1",
     "@actions/glob": "^0.1.0",
     "@actions/http-client": "^2.0.1",


### PR DESCRIPTION
Update @action/cache package to use the version `1.10.0` of @actions/core. 