### PR TITLE
Fixed environment variable in the docs.

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -84,7 +84,7 @@
 
 ### 3.0.4
 - Fix zstd not working for windows on gnu tar in issues [#888](https://github.com/actions/cache/issues/888) and [#891](https://github.com/actions/cache/issues/891).
-- Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 60 minutes.
+- Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS`. Default is 60 minutes.
 
 ### 3.0.5
 - Update `@actions/cache` to use `@actions/core@^1.10.0`


### PR DESCRIPTION
Fixed environment variable in release docs. `SEGMENT_DOWNLOAD_TIMEOUT_MIN` has been replaced with `SEGMENT_DOWNLOAD_TIMEOUT_MINS`