### PR TITLE
Upgraded actions/cache version to 3.0.6

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -88,3 +88,6 @@
 
 ### 3.0.5
 - Update `@actions/cache` to use `@actions/core@^1.10.0`
+
+### 3.0.6
+- Added `@azure/abort-controller` to dependencies to fix compatibility issue with ESM [#1208](https://github.com/actions/toolkit/issues/1208)

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
Upgraded actions/cache version to 3.0.6 to fix compatibility issue with ESM [#1208](https://github.com/actions/toolkit/issues/1208)