### PR TITLE
Standardize behaviour of no_proxy environmental variable

### DIFF
--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -157,6 +157,12 @@ describe('proxy', () => {
     expect(bypass).toBeFalsy()
   })
 
+  it('checkBypass returns false if no_proxy is part of domain', () => {
+    process.env['no_proxy'] = 'myserver.com'
+    const bypass = pm.checkBypass(new URL('https://evilmyserver.com'))
+    expect(bypass).toBeFalsy()
+  })
+
   // Do not strip leading dots as per https://github.com/actions/runner/blob/97195bad5870e2ad0915ebfef1616083aacf5818/docs/adrs/0263-proxy-support.md
   it('checkBypass returns false if host with leading dot in no_proxy', () => {
     process.env['no_proxy'] = '.myserver.com'

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -164,6 +164,12 @@ describe('proxy', () => {
     expect(bypass).toBeFalsy()
   })
 
+  it('checkBypass returns true if host with subdomain in no_proxy defined with leading "."', () => {
+    process.env['no_proxy'] = '.myserver.com'
+    const bypass = pm.checkBypass(new URL('https://sub.myserver.com'))
+    expect(bypass).toBeTruthy()
+  })
+
   // Do not match wildcard ("*") as per https://github.com/actions/runner/blob/97195bad5870e2ad0915ebfef1616083aacf5818/docs/adrs/0263-proxy-support.md
   it('checkBypass returns true if no_proxy is "*"', () => {
     process.env['no_proxy'] = '*'

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -152,7 +152,7 @@ describe('proxy', () => {
   })
 
   it('checkBypass returns true if host with leading dot in no_proxy', () => {
-    process.env['no_proxy'] = '.myserver.com'
+    process.env['no_proxy'] = '.myserver.com' 
     const bypass = pm.checkBypass(new URL('https://myserver.com'))
     expect(bypass).toBeTruthy()
   })

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -151,10 +151,11 @@ describe('proxy', () => {
     expect(bypass).toBeTruthy()
   })
 
-  it('checkBypass returns true if host with leading dot in no_proxy', () => {
+  // Do not strip leading dots as per https://github.com/actions/runner/blob/97195bad5870e2ad0915ebfef1616083aacf5818/docs/adrs/0263-proxy-support.md
+  it('checkBypass returns false if host with leading dot in no_proxy', () => {
     process.env['no_proxy'] = '.myserver.com'
     const bypass = pm.checkBypass(new URL('https://myserver.com'))
-    expect(bypass).toBeTruthy()
+    expect(bypass).toBeFalsy()
   })
 
   it('checkBypass returns false if no_proxy is subdomain', () => {
@@ -163,10 +164,11 @@ describe('proxy', () => {
     expect(bypass).toBeFalsy()
   })
 
+  // Do not match wildcard ("*") as per https://github.com/actions/runner/blob/97195bad5870e2ad0915ebfef1616083aacf5818/docs/adrs/0263-proxy-support.md
   it('checkBypass returns true if no_proxy is "*"', () => {
     process.env['no_proxy'] = '*'
     const bypass = pm.checkBypass(new URL('https://anything.whatsoever.com'))
-    expect(bypass).toBeTruthy()
+    expect(bypass).toBeFalsy()
   })
 
   it('HttpClient does basic http get request through proxy', async () => {

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -151,16 +151,16 @@ describe('proxy', () => {
     expect(bypass).toBeTruthy()
   })
 
+  it('checkBypass returns false if no_proxy is subdomain', () => {
+    process.env['no_proxy'] = 'myserver.com'
+    const bypass = pm.checkBypass(new URL('https://myserver.com.evil.org'))
+    expect(bypass).toBeFalsy()
+  })
+
   // Do not strip leading dots as per https://github.com/actions/runner/blob/97195bad5870e2ad0915ebfef1616083aacf5818/docs/adrs/0263-proxy-support.md
   it('checkBypass returns false if host with leading dot in no_proxy', () => {
     process.env['no_proxy'] = '.myserver.com'
     const bypass = pm.checkBypass(new URL('https://myserver.com'))
-    expect(bypass).toBeFalsy()
-  })
-
-  it('checkBypass returns false if no_proxy is subdomain', () => {
-    process.env['no_proxy'] = 'myserver.com'
-    const bypass = pm.checkBypass(new URL('https://myserver.com.evil.org'))
     expect(bypass).toBeFalsy()
   })
 

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -145,6 +145,30 @@ describe('proxy', () => {
     expect(bypass).toBeFalsy()
   })
 
+  it('checkBypass returns true if host with subdomain in no_proxy', () => {
+    process.env['no_proxy'] = 'myserver.com'
+    const bypass = pm.checkBypass(new URL('https://sub.myserver.com'))
+    expect(bypass).toBeTruthy()
+  })
+
+  it('checkBypass returns true if host with leading dot in no_proxy', () => {
+    process.env['no_proxy'] = '.myserver.com'
+    const bypass = pm.checkBypass(new URL('https://myserver.com'))
+    expect(bypass).toBeTruthy()
+  })
+
+  it('checkBypass returns false if no_proxy is subdomain', () => {
+    process.env['no_proxy'] = 'myserver.com'
+    const bypass = pm.checkBypass(new URL('https://myserver.com.evil.org'))
+    expect(bypass).toBeFalsy()
+  })
+
+  it('checkBypass returns true if no_proxy is "*"', () => {
+    process.env['no_proxy'] = '*'
+    const bypass = pm.checkBypass(new URL('https://anything.whatsoever.com'))
+    expect(bypass).toBeTruthy()
+  })
+
   it('HttpClient does basic http get request through proxy', async () => {
     process.env['http_proxy'] = _proxyUrl
     const httpClient = new httpm.HttpClient()

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -152,7 +152,7 @@ describe('proxy', () => {
   })
 
   it('checkBypass returns true if host with leading dot in no_proxy', () => {
-    process.env['no_proxy'] = '.myserver.com' 
+    process.env['no_proxy'] = '.myserver.com'
     const bypass = pm.checkBypass(new URL('https://myserver.com'))
     expect(bypass).toBeTruthy()
   })

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -53,7 +53,7 @@ export function checkBypass(reqUrl: URL): boolean {
     .filter(x => x)) {
     if (
       upperReqHosts.some(
-        x => x === upperNoProxyItem || x.endsWith(`.${upperNoProxyItem}`)
+        x => x === upperNoProxyItem || x.endsWith(`${upperNoProxyItem}`)
       )
     ) {
       return true

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -30,11 +30,6 @@ export function checkBypass(reqUrl: URL): boolean {
     return false
   }
 
-  // '*' match all hosts (https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/#standardizing-no_proxy)
-  if (noProxy === '*') {
-    return true
-  }
-
   // Determine the request port
   let reqPort: number | undefined
   if (reqUrl.port) {
@@ -55,7 +50,6 @@ export function checkBypass(reqUrl: URL): boolean {
   for (const upperNoProxyItem of noProxy
     .split(',')
     .map(x => x.trim().toUpperCase())
-    .map(x => (x.startsWith('.') ? x.substring(1) : x)) // Strip leading dot (https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/#standardizing-no_proxy)
     .filter(x => x)) {
     if (
       upperReqHosts.some(

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -30,6 +30,11 @@ export function checkBypass(reqUrl: URL): boolean {
     return false
   }
 
+  // '*' match all hosts (https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/#standardizing-no_proxy)
+  if (noProxy === '*') {
+    return true
+  }
+
   // Determine the request port
   let reqPort: number | undefined
   if (reqUrl.port) {
@@ -50,8 +55,13 @@ export function checkBypass(reqUrl: URL): boolean {
   for (const upperNoProxyItem of noProxy
     .split(',')
     .map(x => x.trim().toUpperCase())
+    .map(x => (x.startsWith('.') ? x.substring(1) : x)) // Strip leading dot (https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/#standardizing-no_proxy)
     .filter(x => x)) {
-    if (upperReqHosts.some(x => x.includes(upperNoProxyItem))) {
+    if (
+      upperReqHosts.some(
+        x => x === upperNoProxyItem || x.endsWith(`.${upperNoProxyItem}`)
+      )
+    ) {
       return true
     }
   }

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -53,7 +53,11 @@ export function checkBypass(reqUrl: URL): boolean {
     .filter(x => x)) {
     if (
       upperReqHosts.some(
-        x => x === upperNoProxyItem || x.endsWith(`${upperNoProxyItem}`)
+        x =>
+          x === upperNoProxyItem ||
+          x.endsWith(`.${upperNoProxyItem}`) ||
+          (upperNoProxyItem.startsWith('.') &&
+            x.endsWith(`${upperNoProxyItem}`))
       )
     ) {
       return true

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -51,7 +51,7 @@ export function checkBypass(reqUrl: URL): boolean {
     .split(',')
     .map(x => x.trim().toUpperCase())
     .filter(x => x)) {
-    if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+    if (upperReqHosts.some(x => x.includes(upperNoProxyItem))) {
       return true
     }
   }


### PR DESCRIPTION
The behaviour of the `no_proxy` environmental variable is [famously inconsistent](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/), but this change should follow how it usually works (i.e., that `no_proxy=domain.com` matches its subdomains, such as `some.domain.com`). 

Resolves #1172 