### PR TITLE
tool-cache now logs when it skips a version

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -555,6 +555,8 @@ export function findAllVersions(toolName: string, arch?: string): string[] {
         if (fs.existsSync(fullPath) && fs.existsSync(`${fullPath}.complete`)) {
           versions.push(child)
         }
+      } else {
+        core.debug(`Skipping ${child} as it is not an explicit version.`)
       }
     }
   }


### PR DESCRIPTION
Really helps debugging if, for some reason, a tool doesn't follow semver. Otherwise said tool is silently ignored and it's really hard to understand why tool-cache always yields cache misses