### PR TITLE
Add logs for cache version on miss

### DIFF
--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -143,7 +143,7 @@ async function printCachesListForDiagnostics(
       core.debug(
         `No matching cache found for cache key '${key}', version '${version} and scope ${process.env['GITHUB_REF']}. There exist one or more cache(s) with similar key but they have different version or scope. See more info on cache matching here: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key \nOther caches with similar key:`
       )
-      for (const cacheEntry of cacheListResult.artifactCaches || []) {
+      for (const cacheEntry of cacheListResult?.artifactCaches || []) {
         core.debug(
           `Cache Key: ${cacheEntry?.cacheKey}, Cache Version: ${cacheEntry?.cacheVersion}, Cache Scope: ${cacheEntry?.scope}, Cache Created: ${cacheEntry?.creationTime}`
         )

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -107,7 +107,7 @@ export async function getCacheEntry(
   if (response.statusCode === 204) {
     // List cache for primary key only if cache miss occurs
     if (core.isDebug()) {
-      await listCache(keys[0], httpClient, version)
+      await printCachesListForDiagnostics(keys[0], httpClient, version)
     }
     return null
   }
@@ -127,7 +127,7 @@ export async function getCacheEntry(
   return cacheResult
 }
 
-async function listCache(
+async function printCachesListForDiagnostics(
   key: string,
   httpClient: HttpClient,
   version: string
@@ -143,7 +143,7 @@ async function listCache(
       core.debug(
         `No matching cache found for cache key '${key}', version '${version} and scope ${process.env['GITHUB_REF']} but there are ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version \nOther versions are as follows:`
       )
-      for (const cacheEntry of cacheListResult?.artifactCaches || []) {
+      for (const cacheEntry of cacheListResult.artifactCaches || []) {
         core.debug(
           `Cache Key: ${cacheEntry?.cacheKey}, Cache Version: ${cacheEntry?.cacheVersion}, Cache Scope: ${cacheEntry?.scope}, Cache Created: ${cacheEntry?.creationTime}`
         )

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -115,7 +115,7 @@ export async function getCacheEntry(
   const cacheDownloadUrl = cacheResult?.archiveLocation
   if (!cacheDownloadUrl) {
     // List cache for primary key only if cache miss occurs
-    await listCache(keys[0], httpClient, version)
+    await listCache(keys[0], httpClient, version, cacheResult?.scope)
     throw new Error('Cache not found.')
   }
   core.setSecret(cacheDownloadUrl)
@@ -128,7 +128,8 @@ export async function getCacheEntry(
 async function listCache(
   key: string,
   httpClient: HttpClient,
-  version: string
+  version: string,
+  scope?: string
 ): Promise<void> {
   const resource = `caches?key=${encodeURIComponent(key)}`
   const response = await retryTypedResponse('listCache', async () =>
@@ -139,7 +140,7 @@ async function listCache(
     const totalCount = cacheListResult?.totalCount
     if (totalCount && totalCount > 0) {
       core.info(
-        `Cache miss occurred on the cache key '${key}' and version '${version} but there is ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version`
+        `No matching cache found for cache key '${key}', version '${version} and scope ${scope} but there is ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version`
       )
       core.debug(`Other versions are as follows:`)
       cacheListResult?.artifactCaches?.forEach(cacheEntry => {

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -17,7 +17,8 @@ import {
   CommitCacheRequest,
   ReserveCacheRequest,
   ReserveCacheResponse,
-  ITypedResponseWithError
+  ITypedResponseWithError,
+  ArtifactCacheList
 } from './contracts'
 import {downloadCacheHttpClient, downloadCacheStorageSDK} from './downloadUtils'
 import {
@@ -113,6 +114,21 @@ export async function getCacheEntry(
   const cacheResult = response.result
   const cacheDownloadUrl = cacheResult?.archiveLocation
   if (!cacheDownloadUrl) {
+    // List cache for primary key only if cache miss occurs
+    const resource = `caches?key=${encodeURIComponent(keys[0])}`
+    const response = await httpClient.getJson<ArtifactCacheList>(getCacheApiUrl(resource))
+    if(response.statusCode === 204) {
+      const cacheListResult = response.result
+      const totalCount = cacheListResult?.totalCount
+      if(totalCount && totalCount > 0) {
+        core.info(`Cache miss occurred on the cache key '${keys[0]}' and version '${version} but there is ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version`)
+        core.debug(`Other versions are as follows:`)
+        cacheListResult?.artifactCaches?.forEach(cacheEntry => {
+          core.debug(`Cache Key: ${cacheEntry?.cacheKey}, Cache Version: ${cacheEntry?.cacheVersion}, Cache Scope: ${cacheEntry?.scope}, Cache Created: ${cacheEntry?.creationTime}`)
+        })
+      }
+    }
+
     throw new Error('Cache not found.')
   }
   core.setSecret(cacheDownloadUrl)

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -136,8 +136,7 @@ async function listCache(
   const response = await retryTypedResponse('listCache', async () =>
     httpClient.getJson<ArtifactCacheList>(getCacheApiUrl(resource))
   )
-  core.debug(`List Cache Response Status Code: ${response.statusCode}`)
-  if (response.statusCode !== 200) {
+  if (response.statusCode === 200) {
     const cacheListResult = response.result
     const totalCount = cacheListResult?.totalCount
     if (totalCount && totalCount > 0) {

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -145,7 +145,7 @@ async function listCache(
       core.debug(
         `No matching cache found for cache key '${key}', version '${version} and scope ${scope} but there are ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version \nOther versions are as follows:`
       )
-      for (const cacheEntry of cacheListResult.artifactCaches || []) {
+      for (const cacheEntry of cacheListResult?.artifactCaches || []) {
         core.debug(
           `Cache Key: ${cacheEntry?.cacheKey}, Cache Version: ${cacheEntry?.cacheVersion}, Cache Scope: ${cacheEntry?.scope}, Cache Created: ${cacheEntry?.creationTime}`
         )

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -107,7 +107,7 @@ export async function getCacheEntry(
   if (response.statusCode === 204) {
     // List cache for primary key only if cache miss occurs
     if (core.isDebug()) {
-      await listCache(keys[0], httpClient, version, response)
+      await listCache(keys[0], httpClient, version)
     }
     return null
   }
@@ -130,20 +130,19 @@ export async function getCacheEntry(
 async function listCache(
   key: string,
   httpClient: HttpClient,
-  version: string,
-  getCacheEntryResponse: any
+  version: string
 ): Promise<void> {
-  const scope = getCacheEntryResponse.result?.scope
   const resource = `caches?key=${encodeURIComponent(key)}`
   const response = await retryTypedResponse('listCache', async () =>
     httpClient.getJson<ArtifactCacheList>(getCacheApiUrl(resource))
   )
-  if (response.statusCode === 200) {
+  core.debug(`List Cache Response Status Code: ${response.statusCode}`)
+  if (response.statusCode !== 200) {
     const cacheListResult = response.result
     const totalCount = cacheListResult?.totalCount
     if (totalCount && totalCount > 0) {
       core.debug(
-        `No matching cache found for cache key '${key}', version '${version} and scope ${scope} but there are ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version \nOther versions are as follows:`
+        `No matching cache found for cache key '${key}', version '${version} and scope ${process.env['GITHUB_REF']} but there are ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version \nOther versions are as follows:`
       )
       for (const cacheEntry of cacheListResult?.artifactCaches || []) {
         core.debug(

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -115,20 +115,7 @@ export async function getCacheEntry(
   const cacheDownloadUrl = cacheResult?.archiveLocation
   if (!cacheDownloadUrl) {
     // List cache for primary key only if cache miss occurs
-    const resource = `caches?key=${encodeURIComponent(keys[0])}`
-    const response = await httpClient.getJson<ArtifactCacheList>(getCacheApiUrl(resource))
-    if(response.statusCode === 204) {
-      const cacheListResult = response.result
-      const totalCount = cacheListResult?.totalCount
-      if(totalCount && totalCount > 0) {
-        core.info(`Cache miss occurred on the cache key '${keys[0]}' and version '${version} but there is ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version`)
-        core.debug(`Other versions are as follows:`)
-        cacheListResult?.artifactCaches?.forEach(cacheEntry => {
-          core.debug(`Cache Key: ${cacheEntry?.cacheKey}, Cache Version: ${cacheEntry?.cacheVersion}, Cache Scope: ${cacheEntry?.scope}, Cache Created: ${cacheEntry?.creationTime}`)
-        })
-      }
-    }
-
+    await listCache(keys[0], httpClient, version)
     throw new Error('Cache not found.')
   }
   core.setSecret(cacheDownloadUrl)
@@ -136,6 +123,32 @@ export async function getCacheEntry(
   core.debug(JSON.stringify(cacheResult))
 
   return cacheResult
+}
+
+async function listCache(
+  key: string,
+  httpClient: HttpClient,
+  version: string
+): Promise<void> {
+  const resource = `caches?key=${encodeURIComponent(key)}`
+  const response = await retryTypedResponse('listCache', async () =>
+    httpClient.getJson<ArtifactCacheList>(getCacheApiUrl(resource))
+  )
+  if (response.statusCode === 204) {
+    const cacheListResult = response.result
+    const totalCount = cacheListResult?.totalCount
+    if (totalCount && totalCount > 0) {
+      core.info(
+        `Cache miss occurred on the cache key '${key}' and version '${version} but there is ${totalCount} existing version of the cache for this key. More info on versioning can be found here: https://github.com/actions/cache#cache-version`
+      )
+      core.debug(`Other versions are as follows:`)
+      cacheListResult?.artifactCaches?.forEach(cacheEntry => {
+        core.debug(
+          `Cache Key: ${cacheEntry?.cacheKey}, Cache Version: ${cacheEntry?.cacheVersion}, Cache Scope: ${cacheEntry?.scope}, Cache Created: ${cacheEntry?.creationTime}`
+        )
+      })
+    }
+  }
 }
 
 export async function downloadCache(

--- a/packages/cache/src/internal/contracts.d.ts
+++ b/packages/cache/src/internal/contracts.d.ts
@@ -9,8 +9,14 @@ export interface ITypedResponseWithError<T> extends TypedResponse<T> {
 export interface ArtifactCacheEntry {
   cacheKey?: string
   scope?: string
+  cacheVersion?: string
   creationTime?: string
   archiveLocation?: string
+}
+
+export interface ArtifactCacheList {
+  totalCount: number
+  artifactCaches?: ArtifactCacheEntry[]
 }
 
 export interface CommitCacheRequest {


### PR DESCRIPTION
This PR should show cache version details on cache miss. Sample test workflow run: [here](https://github.com/bbq-beets/test-zstd/actions/runs/3710689378/jobs/6290420326#step:7:52)