### PR TITLE
Update `@octokit/core` to 4.1.0.

### DIFF
--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@actions/http-client": "^2.0.1",
-    "@octokit/core": "^3.6.0",
+    "@octokit/core": "^4.1.0",
     "@octokit/plugin-paginate-rest": "^2.17.0",
     "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
   },


### PR DESCRIPTION
I have an action depending on `@octokit/openapi-types`. I cannot update to version 14 of `@octokit/openapi-types` since `@actions/github` still depends on `@octokit/core < 4.0.0`.