### PR TITLE
Add fallback to gzip compression if cache not found

### DIFF
--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -161,6 +161,81 @@ test('restore with gzip compressed cache found', async () => {
   expect(getCompressionMock).toHaveBeenCalledTimes(1)
 })
 
+test('restore with zstd as default but gzip compressed cache found on windows', async () => {
+  if (process.platform === 'win32') {
+    const paths = ['node_modules']
+    const key = 'node-test'
+
+    const cacheEntry: ArtifactCacheEntry = {
+      cacheKey: key,
+      scope: 'refs/heads/main',
+      archiveLocation: 'www.actionscache.test/download'
+    }
+    const getCacheMock = jest.spyOn(cacheHttpClient, 'getCacheEntry')
+    getCacheMock
+      .mockImplementationOnce(async () => {
+        return Promise.resolve(<ArtifactCacheEntry>{})
+      })
+      .mockImplementationOnce(async () => {
+        return Promise.resolve(cacheEntry)
+      })
+
+    const tempPath = '/foo/bar'
+
+    const createTempDirectoryMock = jest.spyOn(
+      cacheUtils,
+      'createTempDirectory'
+    )
+    createTempDirectoryMock.mockImplementation(async () => {
+      return Promise.resolve(tempPath)
+    })
+
+    const archivePath = path.join(tempPath, CacheFilename.Gzip)
+    const downloadCacheMock = jest.spyOn(cacheHttpClient, 'downloadCache')
+
+    const fileSize = 142
+    const getArchiveFileSizeInBytesMock = jest
+      .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
+      .mockReturnValue(fileSize)
+
+    const extractTarMock = jest.spyOn(tar, 'extractTar')
+    const unlinkFileMock = jest.spyOn(cacheUtils, 'unlinkFile')
+
+    const compression = CompressionMethod.Zstd
+    const getCompressionMock = jest
+      .spyOn(cacheUtils, 'getCompressionMethod')
+      .mockReturnValue(Promise.resolve(compression))
+
+    const cacheKey = await restoreCache(paths, key)
+
+    expect(cacheKey).toBe(key)
+    expect(getCacheMock).toHaveBeenNthCalledWith(1, [key], paths, {
+      compressionMethod: compression
+    })
+    expect(getCacheMock).toHaveBeenNthCalledWith(2, [key], paths, {
+      compressionMethod: CompressionMethod.Gzip
+    })
+    expect(createTempDirectoryMock).toHaveBeenCalledTimes(1)
+    expect(downloadCacheMock).toHaveBeenCalledWith(
+      cacheEntry.archiveLocation,
+      archivePath,
+      undefined
+    )
+    expect(getArchiveFileSizeInBytesMock).toHaveBeenCalledWith(archivePath)
+
+    expect(extractTarMock).toHaveBeenCalledTimes(1)
+    expect(extractTarMock).toHaveBeenCalledWith(
+      archivePath,
+      CompressionMethod.Gzip
+    )
+
+    expect(unlinkFileMock).toHaveBeenCalledTimes(1)
+    expect(unlinkFileMock).toHaveBeenCalledWith(archivePath)
+
+    expect(getCompressionMock).toHaveBeenCalledTimes(1)
+  }
+})
+
 test('restore with zstd compressed cache found', async () => {
   const paths = ['node_modules']
   const key = 'node-test'

--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -174,7 +174,7 @@ test('restore with zstd as default but gzip compressed cache found on windows', 
     const getCacheMock = jest.spyOn(cacheHttpClient, 'getCacheEntry')
     getCacheMock
       .mockImplementationOnce(async () => {
-        return Promise.resolve(<ArtifactCacheEntry>{})
+        throw new Error('Cache not found.')
       })
       .mockImplementationOnce(async () => {
         return Promise.resolve(cacheEntry)

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -106,9 +106,8 @@ export async function restoreCache(
         process.platform === 'win32' &&
         compressionMethod !== CompressionMethod.Gzip
       ) {
-        // On windows, we will try to download the cache entry with the same key
-        // but with different compression method. This is to support the old cache entry created
-        // by the old version of the cache action.
+        // This is to support the old cache entry created
+        // by the old version of the cache action on windows.
         compressionMethod = CompressionMethod.Gzip
         cacheEntry = await cacheHttpClient.getCacheEntry(keys, paths, {
           compressionMethod

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -103,8 +103,8 @@ export async function restoreCache(
       }
     } catch (error) {
       if (
-        process.platform == 'win32' &&
-        compressionMethod != CompressionMethod.Gzip
+        process.platform === 'win32' &&
+        compressionMethod !== CompressionMethod.Gzip
       ) {
         // On windows, we will try to download the cache entry with the same key
         // but with different compression method. This is to support the old cache entry created

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -122,6 +122,32 @@ export async function getCacheEntry(
   return cacheResult
 }
 
+// This is to support the old cache entry created
+// by the old version of the cache action on windows.
+export async function getCacheEntryForGzipFallbackOnWindows(
+  keys: string[],
+  paths: string[],
+  compressionMethod: CompressionMethod,
+  error: unknown
+): Promise<ArtifactCacheEntry> {
+  let cacheEntry: ArtifactCacheEntry | null
+  if (
+    process.platform === 'win32' &&
+    compressionMethod !== CompressionMethod.Gzip
+  ) {
+    compressionMethod = CompressionMethod.Gzip
+    cacheEntry = await getCacheEntry(keys, paths, {
+      compressionMethod
+    })
+    if (!cacheEntry?.archiveLocation) {
+      throw error
+    }
+  } else {
+    throw error
+  }
+  return cacheEntry
+}
+
 export async function downloadCache(
   archiveLocation: string,
   archivePath: string,

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -122,32 +122,6 @@ export async function getCacheEntry(
   return cacheResult
 }
 
-// This is to support the old cache entry created
-// by the old version of the cache action on windows.
-export async function getCacheEntryForGzipFallbackOnWindows(
-  keys: string[],
-  paths: string[],
-  compressionMethod: CompressionMethod,
-  error: unknown
-): Promise<ArtifactCacheEntry> {
-  let cacheEntry: ArtifactCacheEntry | null
-  if (
-    process.platform === 'win32' &&
-    compressionMethod !== CompressionMethod.Gzip
-  ) {
-    compressionMethod = CompressionMethod.Gzip
-    cacheEntry = await getCacheEntry(keys, paths, {
-      compressionMethod
-    })
-    if (!cacheEntry?.archiveLocation) {
-      throw error
-    }
-  } else {
-    throw error
-  }
-  return cacheEntry
-}
-
 export async function downloadCache(
   archiveLocation: string,
   archivePath: string,


### PR DESCRIPTION
This would make sure that caches done previously using `gzip` are restorable but any new caches or restore done using restore keys would be saved using `zstd` on windows if available.
### Changes made:
When cache not found on windows and compression method is not `gzip` then search again with `gzip`. If cache found with `gzip` compression cache version then continue as usual else throw error. 
