### PR TITLE
Relative link to the interface

### DIFF
--- a/packages/exec/README.md
+++ b/packages/exec/README.md
@@ -24,7 +24,7 @@ await exec.exec('node', ['index.js', 'foo=bar']);
 
 #### Output/options
 
-Capture output or specify [other options](https://github.com/actions/toolkit/blob/d9347d4ab99fd507c0b9104b2cf79fb44fcc827d/packages/exec/src/interfaces.ts#L5):
+Capture output or specify [other options](./src/interfaces.ts#L5):
 
 ```js
 const exec = require('@actions/exec');


### PR DESCRIPTION
The interface link is outdated and doesn't tell the full list of options available today. For example `input` option was not available back then but it is the only way to have piping available to stdin with this library. 