### PR TITLE
Release 3.1.0-beta.2 cache package

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -94,3 +94,6 @@
 
 ### 3.1.0-beta.1
 - Update actions/cache on windows to use gnu tar and zstd by default and fallback to bsdtar and zstd if gnu tar is not available. ([issue](https://github.com/actions/cache/issues/984))
+
+### 3.1.0-beta.2
+- Added support for fallback to gzip to restore old caches on windows.

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.1.0-beta.1",
+      "version": "3.1.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
This adds support for fallback to gzip if old cache is present on windows. 