### PR TITLE
Address bugbash issues

### DIFF
--- a/.github/workflows/cache-windows-test.yml
+++ b/.github/workflows/cache-windows-test.yml
@@ -78,7 +78,6 @@ jobs:
       run: |
         rm -rf test-cache
         rm -rf ~/test-cache
-        rm -f cache.tar
 
     - name: Restore cache using restoreCache() with Azure SDK
       run: |

--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -99,7 +99,7 @@ test('zstd extract tar with windows BSDtar', async () => {
     expect(execMock).toHaveBeenNthCalledWith(
       1,
       [
-        'zstd -d --long=30 -o',
+        'zstd -d --long=30 --force -o',
         TarFilename.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
         archivePath.replace(new RegExp(`\\${path.sep}`, 'g'), '/')
       ].join(' '),
@@ -273,7 +273,7 @@ test('zstd create tar with windows BSDtar', async () => {
     expect(execMock).toHaveBeenNthCalledWith(
       2,
       [
-        'zstd -T0 --long=30 -o',
+        'zstd -T0 --long=30 --force -o',
         CacheFilename.Zstd.replace(/\\/g, '/'),
         TarFilename.replace(/\\/g, '/')
       ].join(' '),
@@ -370,7 +370,7 @@ test('zstd list tar with windows BSDtar', async () => {
     expect(execMock).toHaveBeenNthCalledWith(
       1,
       [
-        'zstd -d --long=30 -o',
+        'zstd -d --long=30 --force -o',
         TarFilename.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
         archivePath.replace(new RegExp(`\\${path.sep}`, 'g'), '/')
       ].join(' '),

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -109,7 +109,7 @@ export async function restoreCache(
           return undefined
         }
 
-        core.debug(
+        core.info(
           "Couldn't find cache entry with zstd compression, falling back to gzip compression."
         )
       } else {

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -183,7 +183,7 @@ async function getDecompressionProgram(
     case CompressionMethod.Zstd:
       return BSD_TAR_ZSTD
         ? [
-            'zstd -d --long=30 -o',
+            'zstd -d --long=30 --force -o',
             TarFilename,
             archivePath.replace(new RegExp(`\\${path.sep}`, 'g'), '/')
           ]
@@ -194,7 +194,7 @@ async function getDecompressionProgram(
     case CompressionMethod.ZstdWithoutLong:
       return BSD_TAR_ZSTD
         ? [
-            'zstd -d -o',
+            'zstd -d --force -o',
             TarFilename,
             archivePath.replace(new RegExp(`\\${path.sep}`, 'g'), '/')
           ]
@@ -223,7 +223,7 @@ async function getCompressionProgram(
     case CompressionMethod.Zstd:
       return BSD_TAR_ZSTD
         ? [
-            'zstd -T0 --long=30 -o',
+            'zstd -T0 --long=30 --force -o',
             cacheFileName.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
             TarFilename
           ]
@@ -234,7 +234,7 @@ async function getCompressionProgram(
     case CompressionMethod.ZstdWithoutLong:
       return BSD_TAR_ZSTD
         ? [
-            'zstd -T0 -o',
+            'zstd -T0 --force -o',
             cacheFileName.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
             TarFilename
           ]


### PR DESCRIPTION
There were few issues which came up during internal bugbash:
1. With debug logs on restore was failing saying `zstd: cache.tar already exists; not overwritten:`. 
Possible solutions:
- Add `--force` to zstd command. Docs say that they overwrite the file with this.
- Delete `cache.tar` file after every list, create and extract operation
**Final solution:** Add --force to zstd command as problem is seen when `list` runs which happen in debug mode thus justifying extra time taken in deleting and creating `cache.tar` file using --force.
3. Change debug log to info log when falling back to gzip for restoration of cache on windows.