### PR TITLE
Add repository preferences to the context

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -78,4 +78,14 @@ export class Context {
       "context.repo requires a GITHUB_REPOSITORY environment variable like 'owner/repo'"
     )
   }
+
+  get repositoryPreferences(): {isFork: boolean} {
+    if (this.payload.repository) {
+      return {
+        isFork: this.payload.repository.fork === 'true'
+      }
+    }
+
+    throw new Error('context.payload.repository must be populated')
+  }
 }


### PR DESCRIPTION
To solve this issue https://github.com/actions/stale/issues/881 it is necessary to detect is the current repository forked from the another. 

This PR introduces new getter to github's Context called "repositoryPreferences" with the only property "isFork".

Alternatives:

1. to do not introduce this property at all (cancel this PR), just access the payload directly from `actions/stale` repo. PROS: simplicity, consistency with [GitHub REST API](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28), CONS:  `actions/stale` never accesses payload  property of the context.
1. to add `isFork` to `repo` getter (not introduce `repositoryPreferences`). PROS: seems to be obvious, CONS: I assume semantic of the `repo` is not "repository" but rather "id of the repository". Particularly `repo` may exist before the `payload` [initialised](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L67).
1. to rename `repositoryPreferences` to `repository` and `isFork` to `fork`. PROS: to be in consistency with GitHub REST API, CONS: it is not clear what would be difference between `repo` and `repository`; from the `fork` name it is not obvious the property is boolean.
