### PR TITLE
[Artifacts] Remove error annotations why retrying artifact download

### DIFF
--- a/packages/artifact/src/internal/download-http-client.ts
+++ b/packages/artifact/src/internal/download-http-client.ts
@@ -311,7 +311,7 @@ export class DownloadHttpClient {
         const gunzip = zlib.createGunzip()
         response.message
           .on('error', error => {
-            core.error(
+            core.info(
               `An error occurred while attempting to read the response stream`
             )
             gunzip.close()
@@ -320,7 +320,7 @@ export class DownloadHttpClient {
           })
           .pipe(gunzip)
           .on('error', error => {
-            core.error(
+            core.info(
               `An error occurred while attempting to decompress the response stream`
             )
             destinationStream.close()
@@ -331,7 +331,7 @@ export class DownloadHttpClient {
             resolve()
           })
           .on('error', error => {
-            core.error(
+            core.info(
               `An error occurred while writing a downloaded file to ${destinationStream.path}`
             )
             reject(error)
@@ -339,7 +339,7 @@ export class DownloadHttpClient {
       } else {
         response.message
           .on('error', error => {
-            core.error(
+            core.info(
               `An error occurred while attempting to read the response stream`
             )
             destinationStream.close()
@@ -350,7 +350,7 @@ export class DownloadHttpClient {
             resolve()
           })
           .on('error', error => {
-            core.error(
+            core.info(
               `An error occurred while writing a downloaded file to ${destinationStream.path}`
             )
             reject(error)


### PR DESCRIPTION
Fix for https://github.com/actions/download-artifact/issues/157

`core.error` creates an annotation when the download can succeed so we should just use `core.info` which is like `console.log` for these messages.

If the artifact download fails and the retry limit has been exceeded we throw and error anyway which is caught at the very end and then we set a failed status with an annotation:

https://github.com/actions/toolkit/blob/06c3c38ef2b06460057795826f7977cec630099f/packages/artifact/src/internal/download-http-client.ts#L175-L177

https://github.com/actions/download-artifact/blob/e9ef242655d12993efdcda9058dee2db83a2cb9b/src/download-artifact.ts#LL57C10-L57C19