### PR TITLE
Pass in the current workspace as a parameter to hashFiles

### DIFF
--- a/packages/glob/__tests__/hash-files.test.ts
+++ b/packages/glob/__tests__/hash-files.test.ts
@@ -51,6 +51,7 @@ describe('globber', () => {
     )
   })
 
+  const emptyDirectory = ''
   it('followSymbolicLinks set to true', async () => {
     const root = path.join(getTestTemp(), 'set-to-true')
     await fs.mkdir(path.join(root, 'realdir'), {recursive: true})
@@ -60,7 +61,9 @@ describe('globber', () => {
       path.join(root, 'symDir')
     )
     const testPath = path.join(root, `symDir`)
-    const hash = await hashFiles(testPath, {followSymbolicLinks: true})
+    const hash = await hashFiles(testPath, emptyDirectory, {
+      followSymbolicLinks: true
+    })
     expect(hash).toEqual(
       'd8a411e8f8643821bed189e627ff57151918aa554c00c10b31c693ab2dded273'
     )
@@ -80,7 +83,9 @@ describe('globber', () => {
       path.join(root, 'symDir')
     )
     const testPath = path.join(root, 'symdir')
-    const hash = await hashFiles(testPath, {followSymbolicLinks: false})
+    const hash = await hashFiles(testPath, emptyDirectory, {
+      followSymbolicLinks: false
+    })
     expect(hash).toEqual('')
   })
 

--- a/packages/glob/src/glob.ts
+++ b/packages/glob/src/glob.ts
@@ -22,10 +22,13 @@ export async function create(
  * Computes the sha256 hash of a glob
  *
  * @param patterns  Patterns separated by newlines
+ * @param currentWorkspace  Workspace used when matching files
  * @param options   Glob options
+ * @param verbose   Enables verbose logging
  */
 export async function hashFiles(
   patterns: string,
+  currentWorkspace = '',
   options?: HashFileOptions,
   verbose: Boolean = false
 ): Promise<string> {
@@ -34,5 +37,5 @@ export async function hashFiles(
     followSymbolicLinks = options.followSymbolicLinks
   }
   const globber = await create(patterns, {followSymbolicLinks})
-  return _hashFiles(globber, verbose)
+  return _hashFiles(globber, currentWorkspace, verbose)
 }

--- a/packages/glob/src/internal-hash-files.ts
+++ b/packages/glob/src/internal-hash-files.ts
@@ -8,11 +8,14 @@ import {Globber} from './glob'
 
 export async function hashFiles(
   globber: Globber,
+  currentWorkspace: string,
   verbose: Boolean = false
 ): Promise<string> {
   const writeDelegate = verbose ? core.info : core.debug
   let hasMatch = false
-  const githubWorkspace = process.env['GITHUB_WORKSPACE'] ?? process.cwd()
+  const githubWorkspace = currentWorkspace
+    ? currentWorkspace
+    : process.env['GITHUB_WORKSPACE'] ?? process.cwd()
   const result = crypto.createHash('sha256')
   let count = 0
   for await (const file of globber.globGenerator()) {


### PR DESCRIPTION
Follow up work to allow the runner to use the hashFiles implementation in glob
