### PR TITLE
cache restore: suppress timestamp warnings

### DIFF
--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -72,6 +72,7 @@ test('zstd extract tar', async () => {
       .concat(IS_WINDOWS ? ['--force-local'] : [])
       .concat(IS_MAC ? ['--delay-directory-restore'] : [])
       .concat([
+        '--warning=no-timestamp',
         '--use-compress-program',
         IS_WINDOWS ? '"zstd -d --long=30"' : 'unzstd --long=30'
       ])
@@ -158,7 +159,7 @@ test('gzip extract tar', async () => {
     ]
       .concat(IS_WINDOWS ? ['--force-local'] : [])
       .concat(IS_MAC ? ['--delay-directory-restore'] : [])
-      .concat(['-z'])
+      .concat(['--warning=no-timestamp', '-z'])
       .join(' '),
     undefined,
     {

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -111,6 +111,7 @@ async function getTarArgs(
 
   // Platform specific args
   if (tarPath.type === ArchiveToolType.GNU) {
+    if (type === 'extract') args.push('--warning=no-timestamp')
     switch (process.platform) {
       case 'win32':
         args.push('--force-local')


### PR DESCRIPTION
Adds GNU tar `--warning=no-timestamp` flag when restoring a cache.

Some popular build tools like Bazel deliberately create files with timestmaps far into the future.

By default, GNU tar will warn about this.
This creates a lot of spam in the cache restore logs.

More information in the GNU tar manual:
https://www.gnu.org/software/tar/manual/html_section/warnings.html