### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/update-github.yaml
+++ b/.github/workflows/update-github.yaml
@@ -20,7 +20,7 @@ jobs:
       working-directory: packages/github 
       run: | 
         if [[ "$(git status --porcelain)" != "" ]]; then 
-        echo "::set-output name=createPR::true"
+        echo "createPR=true" >> $GITHUB_OUTPUT
         git config --global user.email "github-actions@github.com"
         git config --global user.name "github-actions[bot]"
         git checkout -b bots/updateGitHubDependencies-${{github.run_number}}


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve  #1336 

Update `update-github.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=createPR::true"
```

**TO-BE**

```yml
echo "createPR=true" >> $GITHUB_OUTPUT
```
