### PR TITLE
Release patch version update for cache

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -112,3 +112,6 @@
 
 ### 3.1.2
 - Fix issue with symlink restoration on windows.
+
+### 3.1.3
+- Fix to prevent from setting MYSYS environement variable globally [#1329](https://github.com/actions/toolkit/pull/1329).

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
This brings fix for not setting MSYS env variable globally: https://github.com/actions/toolkit/pull/1329