### PR TITLE
Fix zstd version parsing [cache]

### DIFF
--- a/packages/cache/__tests__/tar.test.ts
+++ b/packages/cache/__tests__/tar.test.ts
@@ -73,7 +73,7 @@ test('zstd extract tar', async () => {
       .concat(IS_MAC ? ['--delay-directory-restore'] : [])
       .concat([
         '--use-compress-program',
-        IS_WINDOWS ? '"zstd -d --long=30"' : 'unzstd --long=30'
+        IS_WINDOWS ? '"zstd -d --long=30"' : '"unzstd --long=30"'
       ])
       .join(' '),
     undefined,
@@ -233,7 +233,7 @@ test('zstd create tar', async () => {
       .concat(IS_MAC ? ['--delay-directory-restore'] : [])
       .concat([
         '--use-compress-program',
-        IS_WINDOWS ? '"zstd -T0 --long=30"' : 'zstdmt --long=30'
+        IS_WINDOWS ? '"zstd -T0 --long=30"' : '"zstdmt --long=30"'
       ])
       .join(' '),
     undefined, // args
@@ -367,7 +367,7 @@ test('zstd list tar', async () => {
       .concat(IS_MAC ? ['--delay-directory-restore'] : [])
       .concat([
         '--use-compress-program',
-        IS_WINDOWS ? '"zstd -d --long=30"' : 'unzstd --long=30'
+        IS_WINDOWS ? '"zstd -d --long=30"' : '"unzstd --long=30"'
       ])
       .join(' '),
     undefined,

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -189,7 +189,7 @@ async function getDecompressionProgram(
           ]
         : [
             '--use-compress-program',
-            IS_WINDOWS ? '"zstd -d --long=30"' : 'unzstd --long=30'
+            IS_WINDOWS ? '"zstd -d --long=30"' : '"unzstd --long=30"'
           ]
     case CompressionMethod.ZstdWithoutLong:
       return BSD_TAR_ZSTD
@@ -229,7 +229,7 @@ async function getCompressionProgram(
           ]
         : [
             '--use-compress-program',
-            IS_WINDOWS ? '"zstd -T0 --long=30"' : 'zstdmt --long=30'
+            IS_WINDOWS ? '"zstd -T0 --long=30"' : '"zstdmt --long=30"'
           ]
     case CompressionMethod.ZstdWithoutLong:
       return BSD_TAR_ZSTD


### PR DESCRIPTION
zstd `1.5.4` changed the `--version` output which broke the version parsing and subsequent cache restores across different OS versions (e.g. `ubuntu-20.04` and `ubuntu-22.04` as those use different `zstd` versions). https://github.com/facebook/zstd/commit/9c93dd71cdb301595a8a9e364348967a173c010c

```diff
-*** zstd command line interface 64-bits v1.5.2, by Yann Collet ***
+*** Zstandard CLI (64-bit) v1.5.4, by Yann Collet ***
```

Use `--quiet` option to output machine readable version.
https://www.mankier.com/1/zstd#Options-Operation_Modifiers

Closes #1341
Closes https://github.com/actions/cache/issues/1110
Closes https://github.com/actions/cache/issues/1112