### PR TITLE
Bypass proxy on loopback IPs (localhost, 127.*, ::1 etc)

### DIFF
--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -255,11 +255,6 @@ describe('proxy', () => {
       // no support for ipv6 for now
       expect(httpClient.get('http://[::1]:8091')).rejects.toThrow()
 
-      // ipv6 not supported atm
-      // expect(async () => await httpClient.get(
-      //   'http://[::1]:8091'
-      // )).toThrow()
-
       // proxy at _proxyUrl was ignored
       expect(_proxyConnects).toEqual([])
     } finally {

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -28,7 +28,7 @@ describe('proxy', () => {
     _clearVars()
   })
 
-  afterEach(() => { })
+  afterEach(() => {})
 
   afterAll(async () => {
     _clearVars()
@@ -239,7 +239,7 @@ describe('proxy', () => {
 
   it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', async () => {
     // setup a server listening on localhost:8091
-    const server = http.createServer(function (request, response) {
+    const server = http.createServer((request, response) => {
       response.writeHead(200)
       request.pipe(response)
     })
@@ -247,18 +247,13 @@ describe('proxy', () => {
     try {
       process.env['http_proxy'] = _proxyUrl
       const httpClient = new httpm.HttpClient()
-      let res = await httpClient.get(
-        'http://localhost:8091'
-      )
+      let res = await httpClient.get('http://localhost:8091')
       expect(res.message.statusCode).toBe(200)
-      res = await httpClient.get(
-        'http://127.0.0.1:8091'
-      )
+      res = await httpClient.get('http://127.0.0.1:8091')
       expect(res.message.statusCode).toBe(200)
 
       // no support for ipv6 for now
-      expect(httpClient.get(
-        'http://[::1]:8091')).rejects.toThrow()
+      expect(httpClient.get('http://[::1]:8091')).rejects.toThrow()
 
       // ipv6 not supported atm
       // expect(async () => await httpClient.get(

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -223,43 +223,42 @@ describe('proxy', () => {
     expect(_proxyConnects).toEqual(['httpbin.org:443'])
   })
 
-it('HttpClient does basic https get request when bypass proxy', async () => {
-  process.env['https_proxy'] = _proxyUrl
-  process.env['no_proxy'] = 'httpbin.org'
-  const httpClient = new httpm.HttpClient()
-  const res: httpm.HttpClientResponse = await httpClient.get(
-    'https://httpbin.org/get'
-  )
-  expect(res.message.statusCode).toBe(200)
-  const body: string = await res.readBody()
-  const obj = JSON.parse(body)
-  expect(obj.url).toBe('https://httpbin.org/get')
-  expect(_proxyConnects).toHaveLength(0)
-})
-
-it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', async () => {
-  // setup a server listening on localhost:8091
-  var server = http.createServer(function (request, response) {
-    response.writeHead(200);
-    request.pipe(response);
-  });
-  await server.listen(8091)
-  try {
-    process.env['http_proxy'] = _proxyUrl 
+  it('HttpClient does basic https get request when bypass proxy', async () => {
+    process.env['https_proxy'] = _proxyUrl
+    process.env['no_proxy'] = 'httpbin.org'
     const httpClient = new httpm.HttpClient()
     const res: httpm.HttpClientResponse = await httpClient.get(
-      'http://localhost:8091'
+      'https://httpbin.org/get'
     )
     expect(res.message.statusCode).toBe(200)
     const body: string = await res.readBody()
-    expect(body).toEqual('');
-    // proxy at _proxyUrl was ignored
-    expect(_proxyConnects).toEqual([])
-  }
-  finally {
-    await server.close()
-  }
-})
+    const obj = JSON.parse(body)
+    expect(obj.url).toBe('https://httpbin.org/get')
+    expect(_proxyConnects).toHaveLength(0)
+  })
+
+  it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', async () => {
+    // setup a server listening on localhost:8091
+    const server = http.createServer(function(request, response) {
+      response.writeHead(200)
+      request.pipe(response)
+    })
+    server.listen(8091)
+    try {
+      process.env['http_proxy'] = _proxyUrl
+      const httpClient = new httpm.HttpClient()
+      const res: httpm.HttpClientResponse = await httpClient.get(
+        'http://localhost:8091'
+      )
+      expect(res.message.statusCode).toBe(200)
+      const body: string = await res.readBody()
+      expect(body).toEqual('')
+      // proxy at _proxyUrl was ignored
+      expect(_proxyConnects).toEqual([])
+    } finally {
+      server.close()
+    }
+  })
 
   it('proxyAuth not set in tunnel agent when authentication is not provided', async () => {
     process.env['https_proxy'] = 'http://127.0.0.1:8080'

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -240,7 +240,7 @@ it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', a
     const body: string = await res.readBody()
     expect(body).toEqual('');
     // proxy at _proxyUrl was ignored
-    expect(_proxyConnects).toEqual(undefined)
+    expect(_proxyConnects).toEqual([])
   }
   finally {
     await server.close()

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -28,7 +28,7 @@ describe('proxy', () => {
     _clearVars()
   })
 
-  afterEach(() => {})
+  afterEach(() => { })
 
   afterAll(async () => {
     _clearVars()
@@ -239,7 +239,7 @@ describe('proxy', () => {
 
   it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', async () => {
     // setup a server listening on localhost:8091
-    const server = http.createServer(function(request, response) {
+    const server = http.createServer(function (request, response) {
       response.writeHead(200)
       request.pipe(response)
     })
@@ -247,12 +247,24 @@ describe('proxy', () => {
     try {
       process.env['http_proxy'] = _proxyUrl
       const httpClient = new httpm.HttpClient()
-      const res: httpm.HttpClientResponse = await httpClient.get(
+      let res = await httpClient.get(
         'http://localhost:8091'
       )
       expect(res.message.statusCode).toBe(200)
-      const body: string = await res.readBody()
-      expect(body).toEqual('')
+      res = await httpClient.get(
+        'http://127.0.0.1:8091'
+      )
+      expect(res.message.statusCode).toBe(200)
+
+      // no support for ipv6 for now
+      expect(httpClient.get(
+        'http://[::1]:8091')).rejects.toThrow()
+
+      // ipv6 not supported atm
+      // expect(async () => await httpClient.get(
+      //   'http://[::1]:8091'
+      // )).toThrow()
+
       // proxy at _proxyUrl was ignored
       expect(_proxyConnects).toEqual([])
     } finally {

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -223,6 +223,20 @@ describe('proxy', () => {
     expect(_proxyConnects).toEqual(['httpbin.org:443'])
   })
 
+  it('HttpClient does basic https get request when bypass proxy', async () => {
+    process.env['https_proxy'] = _proxyUrl
+    process.env['no_proxy'] = 'httpbin.org'
+    const httpClient = new httpm.HttpClient()
+    const res: httpm.HttpClientResponse = await httpClient.get(
+      'https://httpbin.org/get'
+    )
+    expect(res.message.statusCode).toBe(200)
+    const body: string = await res.readBody()
+    const obj = JSON.parse(body)
+    expect(obj.url).toBe('https://httpbin.org/get')
+    expect(_proxyConnects).toHaveLength(0)
+  })
+
 it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', async () => {
   // setup a server listening on localhost:8091
   var server = http.createServer(function (request, response) {

--- a/packages/http-client/__tests__/proxy.test.ts
+++ b/packages/http-client/__tests__/proxy.test.ts
@@ -223,19 +223,19 @@ describe('proxy', () => {
     expect(_proxyConnects).toEqual(['httpbin.org:443'])
   })
 
-  it('HttpClient does basic https get request when bypass proxy', async () => {
-    process.env['https_proxy'] = _proxyUrl
-    process.env['no_proxy'] = 'httpbin.org'
-    const httpClient = new httpm.HttpClient()
-    const res: httpm.HttpClientResponse = await httpClient.get(
-      'https://httpbin.org/get'
-    )
-    expect(res.message.statusCode).toBe(200)
-    const body: string = await res.readBody()
-    const obj = JSON.parse(body)
-    expect(obj.url).toBe('https://httpbin.org/get')
-    expect(_proxyConnects).toHaveLength(0)
-  })
+it('HttpClient does basic https get request when bypass proxy', async () => {
+  process.env['https_proxy'] = _proxyUrl
+  process.env['no_proxy'] = 'httpbin.org'
+  const httpClient = new httpm.HttpClient()
+  const res: httpm.HttpClientResponse = await httpClient.get(
+    'https://httpbin.org/get'
+  )
+  expect(res.message.statusCode).toBe(200)
+  const body: string = await res.readBody()
+  const obj = JSON.parse(body)
+  expect(obj.url).toBe('https://httpbin.org/get')
+  expect(_proxyConnects).toHaveLength(0)
+})
 
 it('HttpClient bypasses proxy for loopback addresses (localhost, ::1, 127.*)', async () => {
   // setup a server listening on localhost:8091

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -74,5 +74,9 @@ export function checkBypass(reqUrl: URL): boolean {
 
 function isLoopbackAddress(host: string): boolean {
   const hostUpper = host.toUpperCase()
-  return hostUpper === 'LOCALHOST' || hostUpper.startsWith('127.') || hostUpper.startsWith('::1')
+  return (
+    hostUpper === 'LOCALHOST' ||
+    hostUpper.startsWith('127.') ||
+    hostUpper.startsWith('::1')
+  )
 }

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -77,6 +77,7 @@ function isLoopbackAddress(host: string): boolean {
   return (
     hostLower === 'localhost' ||
     hostLower.startsWith('127.') ||
-    hostLower.startsWith('::1')
+    hostLower.startsWith('[::1]') ||
+    hostLower.startsWith('[0:0:0:0:0:0:0:1]')
   )
 }

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -73,10 +73,10 @@ export function checkBypass(reqUrl: URL): boolean {
 }
 
 function isLoopbackAddress(host: string): boolean {
-  const hostUpper = host.toUpperCase()
+  const hostLower = host.toLowerCase()
   return (
-    hostUpper === 'LOCALHOST' ||
-    hostUpper.startsWith('127.') ||
-    hostUpper.startsWith('::1')
+    hostLower === 'localhost' ||
+    hostLower.startsWith('127.') ||
+    hostLower.startsWith('::1')
   )
 }

--- a/packages/http-client/src/proxy.ts
+++ b/packages/http-client/src/proxy.ts
@@ -25,6 +25,11 @@ export function checkBypass(reqUrl: URL): boolean {
     return false
   }
 
+  const reqHost = reqUrl.hostname
+  if (isLoopbackAddress(reqHost)) {
+    return true
+  }
+
   const noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || ''
   if (!noProxy) {
     return false
@@ -65,4 +70,9 @@ export function checkBypass(reqUrl: URL): boolean {
   }
 
   return false
+}
+
+function isLoopbackAddress(host: string): boolean {
+  const hostUpper = host.toUpperCase()
+  return hostUpper === 'LOCALHOST' || hostUpper.startsWith('127.') || hostUpper.startsWith('::1')
 }


### PR DESCRIPTION
Requests to localhost should not be proxied (if the proxy is on another device / network, the proxied request targeting 'localhost' will likely be lost)

The [runner](https://github.com/actions/runner/blob/5421fe3f7107f770c904ed4c7e506ae7a5cde2c2/src/Runner.Sdk/RunnerWebProxy.cs#L203) also ignores loopback IPs
[Golang as well](https://go.dev/src/vendor/golang.org/x/net/http/httpproxy/proxy.go?s=4195:4265#:~:text=if%20ip.IsLoopback,%7D)