### PR TITLE
Updating blob storage client to 12.13.0 in actions/cache

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -5,116 +5,154 @@
 - Initial release
 
 ### 0.2.0
+
 - Fixes issues with the zstd compression algorithm on Windows and Ubuntu 16.04 [#469](https://github.com/actions/toolkit/pull/469)
 
 ### 0.2.1
+
 - Fix to await async function getCompressionMethod
 
 ### 1.0.0
+
 - Downloads Azure-hosted caches using the Azure SDK for speed and reliability
 - Displays download progress
 - Includes changes that break compatibility with earlier versions, including:
   - `retry`, `retryTypedResponse`, and `retryHttpClientResponse` moved from `cacheHttpClient` to `requestUtils`
 
 ### 1.0.1
+
 - Fix bug in downloading large files (> 2 GBs) with the Azure SDK
 
 ### 1.0.2
+
 - Use posix archive format to add support for some tools
 
 ### 1.0.3
+
 - Use http-client v1.0.9
 - Fixes error handling so retries are not attempted on non-retryable errors (409 Conflict, for example)
 - Adds 5 second delay between retry attempts
 
 ### 1.0.4
+
 - Use @actions/core v1.2.6
 - Fixes uploadChunk to throw an error if any unsuccessful response code is received
 
 ### 1.0.5
+
 - Fix to ensure Windows cache paths get resolved correctly
 
 ### 1.0.6
+
 - Make caching more verbose [#650](https://github.com/actions/toolkit/pull/650)
 - Use GNU tar on macOS if available [#701](https://github.com/actions/toolkit/pull/701)
 
 ### 1.0.7
+
 - Fixes permissions issue extracting archives with GNU tar on macOS ([issue](https://github.com/actions/cache/issues/527))
 
 ### 1.0.8
+
 - Increase the allowed artifact cache size from 5GB to 10GB ([issue](https://github.com/actions/cache/discussions/497))
 
 ### 1.0.9
-  - Use @azure/ms-rest-js v2.6.0
-  - Use @azure/storage-blob v12.8.0
+
+- Use @azure/ms-rest-js v2.6.0
+- Use @azure/storage-blob v12.8.0
 
 ### 1.0.10
+
 - Update `lockfileVersion` to `v2` in `package-lock.json [#1022](https://github.com/actions/toolkit/pull/1022)
 
 ### 1.0.11
+
 - Fix file downloads > 2GB([issue](https://github.com/actions/cache/issues/773))
 
 ### 2.0.0
+
 - Added support to check if Actions cache service feature is available or not [#1028](https://github.com/actions/toolkit/pull/1028)
 
 ### 2.0.3
+
 - Update to v2.0.0 of `@actions/http-client`
 
 ### 2.0.4
+
 - Update to v2.0.1 of `@actions/http-client` [#1087](https://github.com/actions/toolkit/pull/1087)
 
 ### 2.0.5
+
 - Fix to avoid saving empty cache when no files are available for caching. ([issue](https://github.com/actions/cache/issues/624))
 
 ### 2.0.6
+
 - Fix `Tar failed with error: The process '/usr/bin/tar' failed with exit code 1` issue when temp directory where tar is getting created is actually the subdirectory of the path mentioned by the user for caching. ([issue](https://github.com/actions/cache/issues/689))
 
 ### 3.0.0
+
 - Updated actions/cache to suppress Actions cache server error and log warning for those error  [#1122](https://github.com/actions/toolkit/pull/1122)
 
 ### 3.0.1
+
 - Fix [#833](https://github.com/actions/cache/issues/833) - cache doesn't work with github workspace directory.
 - Fix [#809](https://github.com/actions/cache/issues/809) `zstd -d: no such file or directory` error on AWS self-hosted runners.
 
 ### 3.0.2
+
 - Added 1 hour timeout for the download stuck issue [#810](https://github.com/actions/cache/issues/810).
 
 ### 3.0.3
+
 - Bug fixes for download stuck issue [#810](https://github.com/actions/cache/issues/810).
 
 ### 3.0.4
+
 - Fix zstd not working for windows on gnu tar in issues [#888](https://github.com/actions/cache/issues/888) and [#891](https://github.com/actions/cache/issues/891).
 - Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS`. Default is 60 minutes.
 
 ### 3.0.5
+
 - Update `@actions/cache` to use `@actions/core@^1.10.0`
 
 ### 3.0.6
+
 - Added `@azure/abort-controller` to dependencies to fix compatibility issue with ESM [#1208](https://github.com/actions/toolkit/issues/1208)
 
 ### 3.1.0-beta.1
+
 - Update actions/cache on windows to use gnu tar and zstd by default and fallback to bsdtar and zstd if gnu tar is not available. ([issue](https://github.com/actions/cache/issues/984))
 
 ### 3.1.0-beta.2
+
 - Added support for fallback to gzip to restore old caches on windows.
 
 ### 3.1.0-beta.3
+
 - Bug Fixes for fallback to gzip to restore old caches on windows and bsdtar if gnutar is not available.
 
 ### 3.1.0
+
 - Update actions/cache on windows to use gnu tar and zstd by default
 - Update actions/cache on windows to fallback to bsdtar and zstd if gnu tar is not available.
 - Added support for fallback to gzip to restore old caches on windows.
 
 ### 3.1.1
+
 - Reverted changes in 3.1.0 to fix issue with symlink restoration on windows.
 - Added support for verbose logging about cache version during cache miss.
 
 ### 3.1.2
+
 - Fix issue with symlink restoration on windows.
 
 ### 3.1.3
+
 - Fix to prevent from setting MYSYS environement variable globally [#1329](https://github.com/actions/toolkit/pull/1329).
 
 ### 3.1.4
+
 - Fix zstd not being used due to `zstd --version` output change in zstd 1.5.4 release. See [#1353](https://github.com/actions/toolkit/pull/1353).
+
+### 3.1.5
+
+- Updated @azure/storage-blob to `v12.13.0`

--- a/packages/cache/__tests__/options.test.ts
+++ b/packages/cache/__tests__/options.test.ts
@@ -8,7 +8,7 @@ import {
 const useAzureSdk = true
 const downloadConcurrency = 8
 const timeoutInMs = 30000
-const segmentTimeoutInMs = 3600000
+const segmentTimeoutInMs = 600000
 const uploadConcurrency = 4
 const uploadChunkSize = 32 * 1024 * 1024
 

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@types/semver": "^6.0.0",
         "@types/uuid": "^3.4.5",
-        "typescript": "^3.8.3"
+        "typescript": "~4.8.0"
       }
     },
     "node_modules/@actions/core": {
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1064,9 +1064,9 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uuid": {

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -16,7 +16,7 @@
         "@actions/io": "^1.0.1",
         "@azure/abort-controller": "^1.1.0",
         "@azure/ms-rest-js": "^2.6.0",
-        "@azure/storage-blob": "^12.8.0",
+        "@azure/storage-blob": "^12.13.0",
         "semver": "^6.1.0",
         "uuid": "^3.3.3"
       },
@@ -112,28 +112,27 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@azure/core-http": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.3.tgz",
-      "integrity": "sha512-xr8AeszxP418rI//W38NfJDDr0kbVAPZkURZnZ+Fle+lLWeURjDE5zNIuocA1wUPoKSP8iXc0ApW6nPtbLGswA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.0.tgz",
+      "integrity": "sha512-BxI2SlGFPPz6J1XyZNIVUf0QZLBKFX+ViFjKOkzqD18J1zOINIQ8JSBKKr+i+v8+MB6LacL6Nn/sP/TE13+s2Q==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-util": "^1.1.1",
         "@azure/logger": "^1.0.0",
         "@types/node-fetch": "^2.5.0",
         "@types/tunnel": "^0.0.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.6",
+        "node-fetch": "^2.6.7",
         "process": "^0.11.10",
-        "tough-cookie": "^4.0.0",
         "tslib": "^2.2.0",
         "tunnel": "^0.0.6",
         "uuid": "^8.3.0",
         "xml2js": "^0.4.19"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/core-http/node_modules/form-data": {
@@ -149,23 +148,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@azure/core-http/node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@azure/core-http/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@azure/core-http/node_modules/uuid": {
       "version": "8.3.2",
@@ -228,6 +214,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/@azure/core-util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
+      "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/@azure/logger": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
@@ -269,12 +272,12 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.8.0.tgz",
-      "integrity": "sha512-c8+Wz19xauW0bGkTCoqZH4dYfbtBniPiGiRQOn1ca6G5jsjr4azwaTk9gwjVY8r3vY2Taf95eivLzipfIfiS4A==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.13.0.tgz",
+      "integrity": "sha512-t3Q2lvBMJucgTjQcP5+hvEJMAsJSk0qmAnjDLie2td017IiduZbbC9BOcFfmwzR6y6cJdZOuewLCNFmEx9IrXA==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-http": "^2.0.0",
+        "@azure/core-http": "^3.0.0",
         "@azure/core-lro": "^2.2.0",
         "@azure/core-paging": "^1.1.1",
         "@azure/core-tracing": "1.0.0-preview.13",
@@ -283,7 +286,7 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/storage-blob/node_modules/tslib": {
@@ -300,14 +303,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-      "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -489,7 +492,7 @@
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -562,14 +565,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/uuid": {
@@ -700,21 +695,20 @@
       }
     },
     "@azure/core-http": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.3.tgz",
-      "integrity": "sha512-xr8AeszxP418rI//W38NfJDDr0kbVAPZkURZnZ+Fle+lLWeURjDE5zNIuocA1wUPoKSP8iXc0ApW6nPtbLGswA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.0.tgz",
+      "integrity": "sha512-BxI2SlGFPPz6J1XyZNIVUf0QZLBKFX+ViFjKOkzqD18J1zOINIQ8JSBKKr+i+v8+MB6LacL6Nn/sP/TE13+s2Q==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-util": "^1.1.1",
         "@azure/logger": "^1.0.0",
         "@types/node-fetch": "^2.5.0",
         "@types/tunnel": "^0.0.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.6",
+        "node-fetch": "^2.6.7",
         "process": "^0.11.10",
-        "tough-cookie": "^4.0.0",
         "tslib": "^2.2.0",
         "tunnel": "^0.0.6",
         "uuid": "^8.3.0",
@@ -731,20 +725,10 @@
             "mime-types": "^2.1.12"
           }
         },
-        "tough-cookie": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-          "requires": {
-            "psl": "^1.1.33",
-            "punycode": "^2.1.1",
-            "universalify": "^0.1.2"
-          }
-        },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -803,6 +787,22 @@
         }
       }
     },
+    "@azure/core-util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
+      "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "@azure/logger": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
@@ -842,12 +842,12 @@
       }
     },
     "@azure/storage-blob": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.8.0.tgz",
-      "integrity": "sha512-c8+Wz19xauW0bGkTCoqZH4dYfbtBniPiGiRQOn1ca6G5jsjr4azwaTk9gwjVY8r3vY2Taf95eivLzipfIfiS4A==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.13.0.tgz",
+      "integrity": "sha512-t3Q2lvBMJucgTjQcP5+hvEJMAsJSk0qmAnjDLie2td017IiduZbbC9BOcFfmwzR6y6cJdZOuewLCNFmEx9IrXA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-http": "^2.0.0",
+        "@azure/core-http": "^3.0.0",
         "@azure/core-lro": "^2.2.0",
         "@azure/core-paging": "^1.1.1",
         "@azure/core-tracing": "1.0.0-preview.13",
@@ -869,14 +869,14 @@
       "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
     },
     "@types/node": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-      "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -1016,7 +1016,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "psl": {
       "version": "1.8.0",
@@ -1068,11 +1068,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@types/semver": "^6.0.0",
         "@types/uuid": "^3.4.5",
-        "typescript": "~4.8.0"
+        "typescript": "^4.8.0"
       }
     },
     "node_modules/@actions/core": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -51,6 +51,6 @@
   "devDependencies": {
     "@types/semver": "^6.0.0",
     "@types/uuid": "^3.4.5",
-    "typescript": "^3.8.3"
+    "typescript": "~4.8.0"
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -44,7 +44,7 @@
     "@actions/io": "^1.0.1",
     "@azure/abort-controller": "^1.1.0",
     "@azure/ms-rest-js": "^2.6.0",
-    "@azure/storage-blob": "^12.8.0",
+    "@azure/storage-blob": "^12.13.0",
     "semver": "^6.1.0",
     "uuid": "^3.3.3"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -51,6 +51,6 @@
   "devDependencies": {
     "@types/semver": "^6.0.0",
     "@types/uuid": "^3.4.5",
-    "typescript": "~4.8.0"
+    "typescript": "^4.8.0"
   }
 }

--- a/packages/cache/src/internal/downloadUtils.ts
+++ b/packages/cache/src/internal/downloadUtils.ts
@@ -242,7 +242,9 @@ export async function downloadCacheStorageSDK(
     // If the file exceeds the buffer maximum length (~1 GB on 32-bit systems and ~2 GB
     // on 64-bit systems), split the download into multiple segments
     // ~2 GB = 2147483647, beyond this, we start getting out of range error. So, capping it accordingly.
-    const maxSegmentSize = Math.min(2147483647, buffer.constants.MAX_LENGTH)
+
+    // Updated segment size to 128MB to complete a segment faster and fail fast
+    const maxSegmentSize = Math.min(134217728, buffer.constants.MAX_LENGTH)
     const downloadProgress = new DownloadProgress(contentLength)
 
     const fd = fs.openSync(archivePath, 'w')

--- a/packages/cache/src/internal/downloadUtils.ts
+++ b/packages/cache/src/internal/downloadUtils.ts
@@ -243,7 +243,7 @@ export async function downloadCacheStorageSDK(
     // on 64-bit systems), split the download into multiple segments
     // ~2 GB = 2147483647, beyond this, we start getting out of range error. So, capping it accordingly.
 
-    // Updated segment size to 128MB to complete a segment faster and fail fast
+    // Updated segment size to 128MB = 134217728 bytes, to complete a segment faster and fail fast
     const maxSegmentSize = Math.min(134217728, buffer.constants.MAX_LENGTH)
     const downloadProgress = new DownloadProgress(contentLength)
 

--- a/packages/cache/src/options.ts
+++ b/packages/cache/src/options.ts
@@ -101,7 +101,7 @@ export function getDownloadOptions(copy?: DownloadOptions): DownloadOptions {
     useAzureSdk: true,
     downloadConcurrency: 8,
     timeoutInMs: 30000,
-    segmentTimeoutInMs: 600000
+    segmentTimeoutInMs: 600000,
     lookupOnly: false
   }
 

--- a/packages/cache/src/options.ts
+++ b/packages/cache/src/options.ts
@@ -92,7 +92,7 @@ export function getDownloadOptions(copy?: DownloadOptions): DownloadOptions {
     useAzureSdk: true,
     downloadConcurrency: 8,
     timeoutInMs: 30000,
-    segmentTimeoutInMs: 3600000
+    segmentTimeoutInMs: 600000
   }
 
   if (copy) {

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": "./",
     "outDir": "./lib",
     "rootDir": "./src",
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    "useUnknownInCatchVariables": false
   },
   "include": [
     "./src"


### PR DESCRIPTION
This PR updates the blob storage client to v12.13.0 which is the latest to accommodate the latest SDK changes in cache library.

Also updated the typescript version because the [builds](https://github.com/actions/toolkit/actions/runs/4343131738/jobs/7584792497) were failing and azure sdk [uses](https://github.com/Azure/azure-sdk-for-js/commit/526926acc6b089b0e199c54a48bab4afc7e052e1) typescript 4.8.0