### PR TITLE
Bump http-client to version 2.1.0

### DIFF
--- a/packages/http-client/RELEASES.md
+++ b/packages/http-client/RELEASES.md
@@ -1,5 +1,9 @@
 ## Releases
 
+## 2.1.0
+- Add support for `*` and subdomains in `no_proxy` [#1355](https://github.com/actions/toolkit/pull/1355) [#1223](https://github.com/actions/toolkit/pull/1223)
+- Bypass proxy for loopback IP adresses [#1360](https://github.com/actions/toolkit/pull/1360))
+
 ## 2.0.1
 - Fix an issue with missing `tunnel` dependency [#1085](https://github.com/actions/toolkit/pull/1085)
 

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Actions Http Client",
   "keywords": [
     "github",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Actions Http Client",
   "keywords": [
     "github",


### PR DESCRIPTION
Preparing release of proxy changes from

https://github.com/actions/toolkit/pull/1355
https://github.com/actions/toolkit/pull/1361
https://github.com/actions/toolkit/pull/1223