### PR TITLE
cache - getCacheVersion - dup paths array

### DIFF
--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -76,7 +76,8 @@ export function getCacheVersion(
   compressionMethod?: CompressionMethod,
   enableCrossOsArchive = false
 ): string {
-  const components = paths
+  // don't pass changes upstream
+  const components = paths.slice()
 
   // Add compression method to cache version to restore
   // compressed cache as per compression method


### PR DESCRIPTION
Previous to commit b2d865f18051, code used `components = paths.concat(...)`, which left `paths` unchanged.

The commit changed to using `components = paths`, then pushing onto `components` later.  This changes the `paths` array.

Closes #1377