### PR TITLE
github: Add ref type and name to context

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -12,6 +12,8 @@ export class Context {
   eventName: string
   sha: string
   ref: string
+  refType: string
+  refName: string
   workflow: string
   action: string
   actor: string
@@ -40,6 +42,8 @@ export class Context {
     this.eventName = process.env.GITHUB_EVENT_NAME as string
     this.sha = process.env.GITHUB_SHA as string
     this.ref = process.env.GITHUB_REF as string
+    this.refType = process.env.GITHUB_REF_TYPE as string
+    this.refName = process.env.GITHUB_REF_NAME as string
     this.workflow = process.env.GITHUB_WORKFLOW as string
     this.action = process.env.GITHUB_ACTION as string
     this.actor = process.env.GITHUB_ACTOR as string


### PR DESCRIPTION
This commit exposes the available GITHUB_REF_TYPE and GITHUB_REF_NAME variables in the context in order to avoid cutting the ref string and reasoning about it in actions.

Resolves https://github.com/actions/toolkit/issues/1315