### PR TITLE
Mention single quote limitation on documentation of exec.exec and exec.getExecOutput

### DIFF
--- a/packages/exec/src/exec.ts
+++ b/packages/exec/src/exec.ts
@@ -9,7 +9,7 @@ export {ExecOptions, ExecOutput, ExecListeners}
  * Output will be streamed to the live console.
  * Returns promise with return code
  *
- * @param     commandLine        command to execute (can include additional args). Must be correctly escaped.
+ * @param     commandLine        command to execute (can include additional args). Must be correctly escaped. Currently, only double quotes are supported for splitting args.
  * @param     args               optional arguments for tool. Escaping is handled by the lib.
  * @param     options            optional exec options.  See ExecOptions
  * @returns   Promise<number>    exit code
@@ -35,7 +35,7 @@ export async function exec(
  * Output will be streamed to the live console.
  * Returns promise with the exit code and collected stdout and stderr
  *
- * @param     commandLine           command to execute (can include additional args). Must be correctly escaped.
+ * @param     commandLine           command to execute (can include additional args). Must be correctly escaped. Currently, only double quotes are supported for splitting args.
  * @param     args                  optional arguments for tool. Escaping is handled by the lib.
  * @param     options               optional exec options.  See ExecOptions
  * @returns   Promise<ExecOutput>   exit code, stdout, and stderr


### PR DESCRIPTION
This resolves #1382.

By describing the limitation of single quote,
I would like to prevent confusion and save developers' time.

https://github.com/actions/toolkit/blob/457303960f03375db6f033e214b9f90d79c3fe5c/packages/exec/src/toolrunner.ts#L568