### PR TITLE
feat: add runAttempt to Context

### DIFF
--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -17,6 +17,7 @@ export class Context {
   actor: string
   job: string
   runNumber: number
+  runAttempt: number
   runId: number
   apiUrl: string
   serverUrl: string
@@ -45,6 +46,7 @@ export class Context {
     this.actor = process.env.GITHUB_ACTOR as string
     this.job = process.env.GITHUB_JOB as string
     this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER as string, 10)
+    this.runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT as string, 10)
     this.runId = parseInt(process.env.GITHUB_RUN_ID as string, 10)
     this.apiUrl = process.env.GITHUB_API_URL ?? `https://api.github.com`
     this.serverUrl = process.env.GITHUB_SERVER_URL ?? `https://github.com`


### PR DESCRIPTION
### Summary
Currently, `github.context` doesn't include the run attempt. This PR pulls the attempt number from `process.env.GITHUB_RUN_ATTEMPT` and adds it as an instance property of the `Context` class.