### PR TITLE
rename SummaryTableCell.header to SummaryTableCell.heading

### DIFF
--- a/packages/core/src/summary.ts
+++ b/packages/core/src/summary.ts
@@ -14,10 +14,17 @@ export interface SummaryTableCell {
    */
   data: string
   /**
-   * Render cell as header
+   * @deprecated use `core.summary`
+   * Render cell as heading
    * (optional) default: false
    */
   header?: boolean
+  /**
+   * @deprecated use `core.summary`
+   * Render cell as heading
+   * (optional) default: false
+   */
+  heading?: boolean
   /**
    * Number of columns the cell extends
    * (optional) default: '1'
@@ -235,8 +242,8 @@ class Summary {
               return this.wrap('td', cell)
             }
 
-            const {header, data, colspan, rowspan} = cell
-            const tag = header ? 'th' : 'td'
+            const {header, heading, data, colspan, rowspan} = cell
+            const tag = (header || heading) ? 'th' : 'td'
             const attrs = {
               ...(colspan && {colspan}),
               ...(rowspan && {rowspan})

--- a/packages/core/src/summary.ts
+++ b/packages/core/src/summary.ts
@@ -14,13 +14,12 @@ export interface SummaryTableCell {
    */
   data: string
   /**
-   * @deprecated use `core.summary`
+   * @deprecated use `heading`
    * Render cell as heading
    * (optional) default: false
    */
   header?: boolean
   /**
-   * @deprecated use `core.summary`
    * Render cell as heading
    * (optional) default: false
    */


### PR DESCRIPTION
small change to match the markdown/HTML terms