### PR TITLE
Fix go matcher link

### DIFF
--- a/docs/problem-matchers.md
+++ b/docs/problem-matchers.md
@@ -133,7 +133,7 @@ Registering two problem-matchers with the same owner will result in only the pro
 Some of the starter actions are already using problem matchers, for example:
 - [setup-node](https://github.com/actions/setup-node/tree/main/.github)
 - [setup-python](https://github.com/actions/setup-python/tree/main/.github)
-- [setup-go](https://github.com/actions/setup-go/tree/main/.github)
+- [setup-go](https://github.com/actions/setup-go/blob/main/matchers.json)
 - [setup-dotnet](https://github.com/actions/setup-dotnet/tree/main/.github)
 
 ## Troubleshooting


### PR DESCRIPTION
Apparently https://github.com/actions/setup-go didn't know that https://github.com/actions/toolkit was linking to this file as they moved it in https://github.com/actions/setup-go/pull/40 (https://github.com/actions/setup-go/pull/40/commits/4282769cc08d1494516c04229c88d5c06dfc06dc)