### PR TITLE
Ensure `mkdirP` don't throw errors for root directories on Windows if they exists

### DIFF
--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -867,17 +867,16 @@ describe('mkdirP', () => {
 
   if (ioUtil.IS_WINDOWS) {
     it('show error only if Windows drive does not exist', async () => {
-      let errMsg: string
-      const driveRoot = path.parse(getTestTemp()).root
-      // Assuming 'A:\' is not a common Windows drive lets us test for a non-existing drive
-      for (const testPath of [driveRoot, 'A:\\']) {
+      const root = path.parse(getTestTemp()).root
+      // Assuming A:\ isn't a common Windows drive letter lets us test for a non-existing drive
+      const testPaths = [root, 'A:\\']
+      for (const testPath of testPaths) {
         if (await ioUtil.exists(testPath)) {
           await io.mkdirP(testPath)
         } else {
-          errMsg = `Drive '${testPath}' does not exist.`
           await expect(io.mkdirP(testPath)).rejects.toHaveProperty(
-            'message',
-            errMsg
+            'code',
+            'ENOENT'
           )
         }
       }

--- a/packages/io/__tests__/io.test.ts
+++ b/packages/io/__tests__/io.test.ts
@@ -864,6 +864,25 @@ describe('mkdirP', () => {
       (await fs.lstat(path.join(realDirPath, 'sub_dir'))).isDirectory()
     ).toBe(true)
   })
+
+  if (ioUtil.IS_WINDOWS) {
+    it('show error only if Windows drive does not exist', async () => {
+      let errMsg: string
+      const driveRoot = path.parse(getTestTemp()).root
+      // Assuming 'A:\' is not a common Windows drive lets us test for a non-existing drive
+      for (const testPath of [driveRoot, 'A:\\']) {
+        if (await ioUtil.exists(testPath)) {
+          await io.mkdirP(testPath)
+        } else {
+          errMsg = `Drive '${testPath}' does not exist.`
+          await expect(io.mkdirP(testPath)).rejects.toHaveProperty(
+            'message',
+            errMsg
+          )
+        }
+      }
+    })
+  }
 })
 
 describe('which', () => {


### PR DESCRIPTION
fixes: #1422 