### PR TITLE
Allow 300er HTTP status codes

### DIFF
--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -744,8 +744,7 @@ export class HttpClient {
         // Invalid resource (contents not json);  leaving result obj null
       }
 
-      // note that 3xx redirects are handled by the http layer.
-      if (statusCode > 299) {
+      if (statusCode > 399) {
         let msg: string
 
         // if exception/error in body, attempt to get better error


### PR DESCRIPTION
If httpClient is configured with `allowRedirects`

```
const req = new http.HttpClient('', null, {
  allowRedirects: false
})
```

`getJson` return a failure on 302, while this is fine/expected.