### PR TITLE
Add support for multi-line secrets in setSecret

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,7 +50,10 @@ function setSecret(secret: string): void {}
 
 Now, future logs containing BAR will be masked. E.g. running `echo "Hello FOO BAR World"` will now print `Hello FOO **** World`.
 
-**WARNING** The add-mask and setSecret  commands only support single line secrets. To register a multiline secrets you must register each line individually otherwise it will not be masked.
+**WARNING** The add-mask command only supports single line secrets. To register
+a multiline secret you must register each line individually otherwise it will
+not be masked, if you use `@actions/core >= 1.11.0` `setSecret` will do this
+for you.
 
 **WARNING** Do **not** mask short values if you can avoid it, it could render your output unreadable (and future steps' output as well).
 For example, if you mask the letter `l`, running `echo "Hello FOO BAR World"` will now print `He*********o FOO BAR Wor****d`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,10 +50,9 @@ function setSecret(secret: string): void {}
 
 Now, future logs containing BAR will be masked. E.g. running `echo "Hello FOO BAR World"` will now print `Hello FOO **** World`.
 
-**WARNING** The add-mask command only supports single line secrets. To register
-a multiline secret you must register each line individually otherwise it will
-not be masked, if you use `@actions/core >= 1.11.0` `setSecret` will do this
-for you.
+**WARNING** The add-mask command only supports single-line secrets. To register
+a multi-line secret, the recommended practice is to register each line individually. Otherwise, it will
+not be masked. `@actions/core >= 1.11.0` `setSecret` will perform this automatically.
 
 **WARNING** Do **not** mask short values if you can avoid it, it could render your output unreadable (and future steps' output as well).
 For example, if you mask the letter `l`, running `echo "Hello FOO BAR World"` will now print `He*********o FOO BAR Wor****d`

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -164,6 +164,15 @@ describe('@actions/core', () => {
     assertWriteCalls([`::add-mask::secret val${os.EOL}`])
   })
 
+  it('setSecret splits multi line secrets into multiple commands', () => {
+    core.setSecret('first\nsecond\r\nthird')
+    assertWriteCalls([
+      `::add-mask::first${os.EOL}`,
+      `::add-mask::second${os.EOL}`,
+      `::add-mask::third${os.EOL}`
+    ])
+  })
+
   it('prependPath produces the correct commands and sets the env', () => {
     const command = 'PATH'
     createFileCommandFile(command)

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -97,7 +97,7 @@ export function exportVariable(name: string, val: any): void {
  * @param secret value of the secret
  */
 export function setSecret(secret: string): void {
-  for (const part of secret.split(/[\r\n]/)) {
+  for (const part of secret.split(/[\r\n]+/)) {
     if (part) {
       issueCommand('add-mask', {}, part)
     }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -93,13 +93,13 @@ export function exportVariable(name: string, val: any): void {
 }
 
 /**
-  * Registers a secret which will get masked from logs
-* @param secret value of the secret
-*/
+ * Registers a secret which will get masked from logs
+ * @param secret value of the secret
+ */
 export function setSecret(secret: string): void {
   for (const part of secret.split(/[\r\n]/)) {
     if (part) {
-      issueCommand('add-mask', {}, part);
+      issueCommand('add-mask', {}, part)
     }
   }
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -97,7 +97,7 @@ export function exportVariable(name: string, val: any): void {
  * @param secret value of the secret
  */
 export function setSecret(secret: string): void {
-  secret.split(/\r?\n|\r/).forEach(part => {
+  secret.split(/[\r\n]/).forEach(part => {
     if (part) {
       issueCommand('add-mask', {}, part)
     }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -93,15 +93,15 @@ export function exportVariable(name: string, val: any): void {
 }
 
 /**
- * Registers a secret which will get masked from logs
- * @param secret value of the secret
- */
+  * Registers a secret which will get masked from logs
+* @param secret value of the secret
+*/
 export function setSecret(secret: string): void {
-  secret.split(/[\r\n]/).forEach(part => {
+  for (const part of secret.split(/[\r\n]/)) {
     if (part) {
-      issueCommand('add-mask', {}, part)
+      issueCommand('add-mask', {}, part);
     }
-  })
+  }
 }
 
 /**

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -97,7 +97,11 @@ export function exportVariable(name: string, val: any): void {
  * @param secret value of the secret
  */
 export function setSecret(secret: string): void {
-  issueCommand('add-mask', {}, secret)
+  secret.split(/\r?\n|\r/).forEach(part => {
+    if (part) {
+      issueCommand('add-mask', {}, part)
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
As reported in https://github.com/actions/toolkit/issues/1421, the current version of `setSecret` produces unexpected behaviour when provided with a multi-line secret in that the secret isn't masked throughout the workflow logs. This splits any multi-line secret and masks each line as a single secret (documented workaround for this kind of secret).