### PR TITLE
feat(exec): Added support for interrupting exec using signal

### DIFF
--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -380,6 +380,7 @@ export class ToolRunner extends events.EventEmitter {
     const result = <child.SpawnOptions>{}
     result.cwd = options.cwd
     result.env = options.env
+    result.signal = options.signal
     result['windowsVerbatimArguments'] =
       options.windowsVerbatimArguments || this._isCmdFile()
     if (options.windowsVerbatimArguments) {


### PR DESCRIPTION
GitHub actions document the use of [timeout_minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes) at a step level when writing composite action.

When creating js/ts actions, it's currently not possible to implement a timeout mechanism within only a portion of an action.

This PR adds support for "AbortSignal" as per the available option in [child.spawn](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options).

Our use case is fairly straightforward, we built a GitHub action:
* provisioning an environment, 
* executing integration tests,
* collecting run artifacts. 

We want to introduce the ability to interrupt the integration tests if they are taking longer than usual.  But even if the tests are interrupted, we still want to execute the rest of the action (and collect the artifacts).

The following code stops the execution of the exec call if it takes more than 5s:
```javascript
try {
  core.info(`Command starting at: ${JSON.stringify(new Date())}`)
  await exec.exec("sleep 10000", [], {signal: AbortSignal.timeout(5000)})
  core.info(`Command completed at: ${JSON.stringify(new Date())}`)
} catch (error: any) {
  if (error.name === "AbortError") {
    core.info(`Timeout reached at: ${JSON.stringify(new Date())}. The command was interrupted`)
  } else {
    core.info(`There was an issue processing the command (${error.name}). It failed at: ${JSON.stringify(new Date())}`)
  }
}
```