### PR TITLE
[Artifacts] Save md5 hash for each artifact upload

### DIFF
--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -14,6 +14,7 @@
         "@azure/storage-blob": "^12.15.0",
         "@protobuf-ts/plugin": "^2.2.3-alpha.1",
         "archiver": "^5.3.1",
+        "crypto": "^1.0.1",
         "jwt-decode": "^3.1.2",
         "twirp-ts": "^2.5.0"
       },
@@ -518,6 +519,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -44,6 +44,7 @@
     "@azure/storage-blob": "^12.15.0",
     "@protobuf-ts/plugin": "^2.2.3-alpha.1",
     "archiver": "^5.3.1",
+    "crypto": "^1.0.1",
     "jwt-decode": "^3.1.2",
     "twirp-ts": "^2.5.0"
   },

--- a/packages/artifact/src/internal/upload/blob-upload.ts
+++ b/packages/artifact/src/internal/upload/blob-upload.ts
@@ -72,7 +72,7 @@ export async function uploadZipToBlobStorage(
     core.info(`MD5 hash of uploaded artifact zip is ${md5Hash}`)
 
   } catch (error) {
-    core.info(`Failed to upload artifact zip to blob storage, error: ${error}`)
+    core.warning(`Failed to upload artifact zip to blob storage, error: ${error}`)
     return {
       isSuccess: false
     }

--- a/packages/artifact/src/internal/upload/blob-upload.ts
+++ b/packages/artifact/src/internal/upload/blob-upload.ts
@@ -3,6 +3,8 @@ import {TransferProgressEvent} from '@azure/core-http'
 import {ZipUploadStream} from './zip'
 import {getUploadChunkSize} from '../shared/config'
 import * as core from '@actions/core'
+import * as crypto from 'crypto'
+import * as stream from 'stream'
 
 export interface BlobUploadResponse {
   /**
@@ -14,6 +16,11 @@ export interface BlobUploadResponse {
    * The total reported upload size in bytes. Empty if the upload failed
    */
   uploadSize?: number
+
+  /**
+   * The MD5 hash of the uploaded file. Empty if the upload failed
+   */
+  md5Hash?: string
 }
 
 export async function uploadZipToBlobStorage(
@@ -41,13 +48,28 @@ export async function uploadZipToBlobStorage(
     onProgress: uploadCallback
   }
 
+  let md5Hash: string | undefined = undefined
+  const uploadStream = new stream.PassThrough()
+  const hashStream = crypto.createHash('md5').setEncoding('hex')
+
+  zipUploadStream.pipe(uploadStream) // This stream is used for the upload
+  zipUploadStream.pipe(hashStream) // This stream is used to compute a hash of the zip content that gets used. Integrity check
+
   try {
+    core.info('Beginning upload of artifact content to blob storage')
+
     await blockBlobClient.uploadStream(
-      zipUploadStream,
+      uploadStream,
       bufferSize,
       maxBuffers,
       options
     )
+
+    core.info('Finished uploading artifact content to blob storage!')
+
+    hashStream.end()
+    md5Hash = hashStream.read() as string
+    core.info(`MD5 hash of uploaded artifact zip is ${md5Hash}`)
   } catch (error) {
     core.info(`Failed to upload artifact zip to blob storage, error: ${error}`)
     return {
@@ -56,18 +78,17 @@ export async function uploadZipToBlobStorage(
   }
 
   if (uploadByteCount === 0) {
-    core.warning(`No data was uploaded to blob storage. Reported upload byte count is 0`)
+    core.warning(
+      `No data was uploaded to blob storage. Reported upload byte count is 0`
+    )
     return {
-        isSuccess: false,
+      isSuccess: false
     }
   }
 
-  core.info(
-    `Successfully uploaded all artifact file content. Total reported size: ${uploadByteCount}`
-  )
-
   return {
     isSuccess: true,
-    uploadSize: uploadByteCount
+    uploadSize: uploadByteCount,
+    md5Hash: md5Hash
   }
 }

--- a/packages/artifact/src/internal/upload/blob-upload.ts
+++ b/packages/artifact/src/internal/upload/blob-upload.ts
@@ -50,10 +50,10 @@ export async function uploadZipToBlobStorage(
 
   let md5Hash: string | undefined = undefined
   const uploadStream = new stream.PassThrough()
-  const hashStream = crypto.createHash('md5').setEncoding('hex')
+  const hashStream = crypto.createHash('md5')
 
   zipUploadStream.pipe(uploadStream) // This stream is used for the upload
-  zipUploadStream.pipe(hashStream) // This stream is used to compute a hash of the zip content that gets used. Integrity check
+  zipUploadStream.pipe(hashStream).setEncoding('hex') // This stream is used to compute a hash of the zip content that gets used. Integrity check
 
   try {
     core.info('Beginning upload of artifact content to blob storage')
@@ -70,6 +70,7 @@ export async function uploadZipToBlobStorage(
     hashStream.end()
     md5Hash = hashStream.read() as string
     core.info(`MD5 hash of uploaded artifact zip is ${md5Hash}`)
+
   } catch (error) {
     core.info(`Failed to upload artifact zip to blob storage, error: ${error}`)
     return {
@@ -78,11 +79,9 @@ export async function uploadZipToBlobStorage(
   }
 
   if (uploadByteCount === 0) {
-    core.warning(
-      `No data was uploaded to blob storage. Reported upload byte count is 0`
-    )
+    core.warning(`No data was uploaded to blob storage. Reported upload byte count is 0`)
     return {
-      isSuccess: false
+        isSuccess: false,
     }
   }
 

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -44,7 +44,7 @@ export async function uploadArtifact(
   const backendIds = getBackendIdsFromToken()
   if (!backendIds.workflowRunBackendId || !backendIds.workflowJobRunBackendId) {
     core.warning(
-      `Failed to get the necessary backend ids which are necessary to create the artifact`
+      `Failed to get the necessary backend ids which are required to create the artifact`
     )
     return {
       success: false

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -16,7 +16,7 @@ import {
   CreateArtifactRequest,
   FinalizeArtifactRequest,
   StringValue
-} from '../../../src/generated'
+} from '../../generated'
 
 export async function uploadArtifact(
   name: string,
@@ -121,7 +121,7 @@ export async function uploadArtifact(
 
   const artifactId = parseInt(finalizeArtifactResp.artifactId)
   core.info(
-    `Artifact ${name}.zip successfully finalized. Artifact ID ${artifactId}}`
+    `Artifact ${name}.zip successfully finalized. Artifact ID ${artifactId}`
   )
 
   return {

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -103,7 +103,7 @@ export async function uploadArtifact(
 
   if (uploadResult.md5Hash) {
     finalizeArtifactReq.hash = StringValue.create({
-      value: `md5: ${uploadResult.md5Hash!}`
+      value: `md5:${uploadResult.md5Hash!}`
     })
   }
 
@@ -119,7 +119,7 @@ export async function uploadArtifact(
     }
   }
 
-  const artifactId = parseInt(finalizeArtifactResp.artifactId)
+  const artifactId = BigInt(finalizeArtifactResp.artifactId)
   core.info(
     `Artifact ${name}.zip successfully finalized. Artifact ID ${artifactId}`
   )
@@ -127,6 +127,6 @@ export async function uploadArtifact(
   return {
     success: true,
     size: uploadResult.uploadSize,
-    id: artifactId
+    id: Number(artifactId)
   }
 }

--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -76,7 +76,9 @@ const zipErrorCallback = (error: any): void => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const zipWarningCallback = (error: any): void => {
   if (error.code === 'ENOENT') {
-    core.warning('ENOENT warning during artifact zip creation. No such file or directory')
+    core.warning(
+      'ENOENT warning during artifact zip creation. No such file or directory'
+    )
     core.info(error)
   } else {
     core.warning(


### PR DESCRIPTION
Tracking: https://github.com/github/c2c-actions-checks/issues/1699

This builds up on the work that was done in https://github.com/actions/toolkit/pull/1479, https://github.com/actions/toolkit/pull/1481, https://github.com/actions/toolkit/pull/1486 and https://github.com/actions/toolkit/pull/1487 and https://github.com/actions/toolkit/pull/1488

We want to save a hash of the artifact upload for integrity. Unfortunately the response from `uploadStream` does not have an MD5 hash value. There is a crc64 value in the raw headers but it doesn't appear to be officially documented in the azure blob NPM package so we're not going to try to use it as a result.

We can't also call `blobClient.properties` to get a hash after the upload finished since the token only has permissions to create and write, not read.

I'm using a solution that I found here. We pipe the zip stream to a crypto stream on the side and after the upload finishes we can read the hash and save if with the finalize call. When we get to download artifact we can then return this value and do integrity checks and a host of other things.

Here is an example run with the code running E2E after doing `npm link` and setting everything up with a fork that I've been using for testing: https://github.com/bbq-beets/testing-artifacts-v4/actions/runs/5869253502/job/15913849975

<img width="730" alt="image" src="https://github.com/actions/toolkit/assets/16109154/0d114f04-a75c-40f4-8288-703c3952bcde">

I verified afterwards if the hash of the zip is correct by downloading the artifact and manually inspecting it and things work 👍 
