### PR TITLE
Fix error message reference in oidc utils

### DIFF
--- a/packages/core/src/oidc-utils.ts
+++ b/packages/core/src/oidc-utils.ts
@@ -52,7 +52,7 @@ export class OidcClient {
         throw new Error(
           `Failed to get ID Token. \n 
         Error Code : ${error.statusCode}\n 
-        Error Message: ${error.result.message}`
+        Error Message: ${error.message}`
         )
       })
 


### PR DESCRIPTION
oidc utils attempts to reference `error.results.message` instead of `error.message` when encountering a failure.  This PR corrects that.