### PR TITLE
devDeps: remove unused flow-bin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "eslint-plugin-github": "^4.9.2",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-prettier": "^5.0.0",
-        "flow-bin": "^0.115.0",
         "jest": "^29.6.4",
         "lerna": "^7.1.4",
         "nx": "16.6.0",
@@ -5767,18 +5766,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
-    },
-    "node_modules/flow-bin": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.115.0.tgz",
-      "integrity": "sha512-xW+U2SrBaAr0EeLvKmXAmsdnrH6x0Io17P6yRJTNgrrV42G8KXhBAD00s6oGbTTqRyHD0nP47kyuU34zljZpaQ==",
-      "dev": true,
-      "bin": {
-        "flow": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "eslint-plugin-github": "^4.9.2",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-prettier": "^5.0.0",
-    "flow-bin": "^0.115.0",
     "jest": "^29.6.4",
     "lerna": "^7.1.4",
     "nx": "16.6.0",


### PR DESCRIPTION
Was originally added in #298 to satisfy peerDependency from `eslint-plugin-github`. This is no longer necessary as of #815. 