### PR TITLE
Update semver to mitigate CVE-2022-25883

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -45,7 +45,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/ms-rest-js": "^2.6.0",
     "@azure/storage-blob": "^12.13.0",
-    "semver": "^6.1.0",
+    "semver": "^6.3.2",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
We were seeing libraries well downstream from here being reported by Dependabot with this vulnerability:

https://nvd.nist.gov/vuln/detail/CVE-2022-25883