### PR TITLE
Add isGhes utility to the core

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -342,5 +342,3 @@ toPlatformPath('/foo/bar') // => \foo\bar
 // On a Linux runner.
 toPlatformPath('\\foo\\bar') // => /foo/bar
 ```
-
-

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -262,6 +262,15 @@ var pid = core.getState("pidToKill");
 
 process.kill(pid);
 ```
+#### Environment
+
+To check whether action runs on [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server@3.10/admin/overview/about-github-enterprise-server) you can use isGhes helper:
+
+```js
+const core = require('@actions/core')
+
+const isGithubEnterpriseServer = core.isGhes()
+```
 
 #### OIDC Token
 
@@ -333,3 +342,5 @@ toPlatformPath('/foo/bar') // => \foo\bar
 // On a Linux runner.
 toPlatformPath('\\foo\\bar') // => /foo/bar
 ```
+
+

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -373,6 +373,14 @@ export async function getIDToken(aud?: string): Promise<string> {
 }
 
 /**
+ * Returns whether action runs on GitHub Enterprise Server or not.
+ */
+export function isGhes(): boolean {
+  const url = process.env['GITHUB_SERVER_URL'] || 'https://github.com'
+  return new URL(url).hostname.toUpperCase() !== 'GITHUB.COM'
+}
+
+/**
  * Summary exports
  */
 export {summary} from './summary'
@@ -386,8 +394,3 @@ export {markdownSummary} from './summary'
  * Path exports
  */
 export {toPosixPath, toWin32Path, toPlatformPath} from './path-utils'
-
-/**
- * isGhes helper export
- */
-export {isGhes} from './utils'

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -386,3 +386,8 @@ export {markdownSummary} from './summary'
  * Path exports
  */
 export {toPosixPath, toWin32Path, toPlatformPath} from './path-utils'
+
+/**
+ * isGhes helper export
+ */
+export {isGhes} from './utils'

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -39,3 +39,11 @@ export function toCommandProperties(
     endColumn: annotationProperties.endColumn
   }
 }
+
+/**
+ * Returns this action runs on GitHub Enterprise Server or not.
+ */
+export function isGhes(): boolean {
+  const url = process.env['GITHUB_SERVER_URL'] || 'https://github.com'
+  return new URL(url).hostname.toUpperCase() !== 'GITHUB.COM'
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -39,11 +39,3 @@ export function toCommandProperties(
     endColumn: annotationProperties.endColumn
   }
 }
-
-/**
- * Returns this action runs on GitHub Enterprise Server or not.
- */
-export function isGhes(): boolean {
-  const url = process.env['GITHUB_SERVER_URL'] || 'https://github.com'
-  return new URL(url).hostname.toUpperCase() !== 'GITHUB.COM'
-}


### PR DESCRIPTION
Adds isGhes utility that allows to determine whether action runs on Github Enterprise Server.

As it's been seen continuously reimplemented across setup actions:
- [setup-go](https://github.com/actions/setup-go/blob/db8764c1e24b94e6bf86c7b9195ce862c97a4090/src/cache-utils.ts#L62)
- [setup-node](https://github.com/actions/setup-node/blob/ca2d4e0cdd8c63d9ebfedc3d16d450a870caf31c/src/cache-utils.ts#L294)
- [setup-python](https://github.com/actions/setup-python/blob/61a6322f88396a6271a6ee3565807d608ecaddd1/src/utils.ts#L102)
- [setup-dotnet](https://github.com/actions/setup-dotnet/blob/ada8800330ab5b086010be13121dd25e9297111e/src/cache-utils.ts#L95)
- [setup-java](https://github.com/actions/setup-java/blob/4fb397523b853fa75ed64fd1d10a967e1eb3148a/src/util.ts#L90)