### PR TITLE
add getCommaSeparatedInput Method

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -34,7 +34,14 @@ const testEnvVars = {
   INPUT_WRONG_BOOLEAN_INPUT: 'wrong',
   INPUT_WITH_TRAILING_WHITESPACE: '  some val  ',
   INPUT_MY_INPUT_LIST: 'val1\nval2\nval3',
+<<<<<<< HEAD
   INPUT_LIST_WITH_TRAILING_WHITESPACE: '  val1  \n  val2  \n  ',
+=======
+
+  INPUT_MY_COMMA_SEPARATED_LIST: 'val1,val2,val3',
+  INPUT_MY_COMMA_SEPARATED_LIST2: '[val1,val2,val3]',
+  INPUT_MY_COMMA_SEPARATED_LIST3: '[val1, val2, val3]',
+>>>>>>> 8e9f896 (feat: add 'getCommaSeparatedInput' method)
 
   // Save inputs
   STATE_TEST_1: 'state_val',
@@ -216,6 +223,36 @@ describe('@actions/core', () => {
     expect(core.getInput('multiple spaces variable')).toBe(
       'I have multiple spaces'
     )
+  })
+
+  it('getMultilineInput works', () => {
+    expect(core.getMultilineInput('my input list')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+
+  })
+
+  it('getCommaSeparatedInput works', () => {
+    expect(core.getCommaSeparatedInput('my comma separated list')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+
+    expect(core.getCommaSeparatedInput('my comma separated list2')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+
+    expect(core.getCommaSeparatedInput('my comma separated list3')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+
   })
 
   it('getInput trims whitespace by default', () => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -153,6 +153,21 @@ export function getMultilineInput(
     .split('\n')
     .filter(x => x !== '')
 
+  return inputs
+}
+
+/**
+ * Gets the values of a comma separated input. Each value is also trimmed.
+ */
+export function getCommaSeparatedInput(
+  name: string,
+  options?: InputOptions
+): string[] {
+  const inputs: string[] = getInput(name, options)
+    .split(/[[\]\n,]+/)
+    .map(s => s.trim())
+    .filter(x => x !== '')
+
   if (options && options.trimWhitespace === false) {
     return inputs
   }


### PR DESCRIPTION
This PR adds a `core.getCommaSeparatedInput` method that can be used to parse comma-separated lists (i.e. `[val1,val2,val3]` and `val1,val2,val3`).

Fixes https://github.com/actions/toolkit/issues/184#issuecomment-1198653452.