### PR TITLE
feat: add 'core.getCommaSeparatedInput' method

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -35,6 +35,11 @@ const testEnvVars = {
   INPUT_WITH_TRAILING_WHITESPACE: '  some val  ',
   INPUT_MY_INPUT_LIST: 'val1\nval2\nval3',
   INPUT_LIST_WITH_TRAILING_WHITESPACE: '  val1  \n  val2  \n  ',
+  INPUT_COMMA_SEPARATED_LIST: 'val1,val2,val3',
+  INPUT_COMMA_SEPARATED_LIST2: '[val1,val2,val3]',
+  INPUT_COMMA_SEPARATED_LIST_WITH_TRAILING_WHITESPACE: '  val1  ,  val2  ,  ',
+  INPUT_COMMA_SEPARATED_LIST_WITH_TRAILING_WHITESPACE2:
+    '[  val1  ,  val2  ,  ]',
 
   // Save inputs
   STATE_TEST_1: 'state_val',
@@ -286,6 +291,66 @@ describe('@actions/core', () => {
       core.getMultilineInput('list with trailing whitespace', {
         trimWhitespace: false
       })
+    ).toEqual(['  val1  ', '  val2  ', '  '])
+  })
+
+  it('getCommaSeparatedInput works', () => {
+    expect(core.getCommaSeparatedInput('comma separated list')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+
+    expect(core.getCommaSeparatedInput('comma separated list2')).toEqual([
+      'val1',
+      'val2',
+      'val3'
+    ])
+  })
+
+  it('getCommaSeparatedInput trims whitespace by default', () => {
+    expect(
+      core.getCommaSeparatedInput(
+        'comma separated list with trailing whitespace'
+      )
+    ).toEqual(['val1', 'val2'])
+
+    expect(
+      core.getCommaSeparatedInput(
+        'comma separated list with trailing whitespace2'
+      )
+    ).toEqual(['val1', 'val2', ''])
+  })
+
+  it('getCommaSeparatedInput trims whitespace when option is explicitly true', () => {
+    expect(
+      core.getCommaSeparatedInput(
+        'comma separated list with trailing whitespace',
+        {trimWhitespace: true}
+      )
+    ).toEqual(['val1', 'val2'])
+
+    expect(
+      core.getCommaSeparatedInput(
+        'comma separated list with trailing whitespace2',
+        {trimWhitespace: true}
+      )
+    ).toEqual(['val1', 'val2', ''])
+  })
+
+  it('getCommaSeparatedInput does not trim whitespace when option is false', () => {
+    expect(
+      core.getCommaSeparatedInput(
+        'comma separated list with trailing whitespace',
+        {trimWhitespace: false}
+      )
+    ).toEqual(['  val1  ', '  val2  ', '  '])
+
+    expect(
+      core.getCommaSeparatedInput(
+        'comma separated list with trailing whitespace2',
+        {trimWhitespace: false}
+      )
     ).toEqual(['  val1  ', '  val2  ', '  '])
   })
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -161,6 +161,29 @@ export function getMultilineInput(
 }
 
 /**
+ * Gets the values of a comma separated input. Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+export function getCommaSeparatedInput(
+  name: string,
+  options?: InputOptions
+): string[] {
+  const inputs: string[] = getInput(name, options)
+    .split(/[[\]\n,]+/)
+    .filter(x => x !== '')
+
+  if (options && options.trimWhitespace === false) {
+    return inputs
+  }
+
+  return inputs.map(input => input.trim())
+}
+
+/**
  * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
  * Support boolean input list: `true | True | TRUE | false | False | FALSE` .
  * The return value is also in boolean type.


### PR DESCRIPTION
This commit adds a `core.getCommaSeparatedInput` method that can be
used to parse comma-separated lists (i.e. `[val1,val2,val3]` and
`val1,val2,val3`).
