### PR TITLE
Make sure RequestOptions.keepAlive is applied properly on node20 runtime

### DIFF
--- a/packages/http-client/__tests__/keepalive.test.ts
+++ b/packages/http-client/__tests__/keepalive.test.ts
@@ -11,6 +11,12 @@ describe('basics', () => {
     _http.dispose()
   })
 
+  it.each([true, false])('creates Agent with keepAlive %s', keepAlive => {
+    const http = new httpm.HttpClient('http-client-tests', [], {keepAlive})
+    const agent = http.getAgent('http://postman-echo.com')
+    expect(agent).toHaveProperty('keepAlive', keepAlive)
+  })
+
   it('does basic http get request with keepAlive true', async () => {
     const res: httpm.HttpClientResponse = await _http.get(
       'http://postman-echo.com/get'

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -649,7 +649,7 @@ export class HttpClient {
       agent = this._proxyAgent
     }
 
-    if (this._keepAlive && !useProxy) {
+    if (!useProxy) {
       agent = this._agent
     }
 
@@ -690,16 +690,11 @@ export class HttpClient {
       this._proxyAgent = agent
     }
 
-    // if reusing agent across request and tunneling agent isn't assigned create a new agent
-    if (this._keepAlive && !agent) {
+    // if tunneling agent isn't assigned create a new agent
+    if (!agent) {
       const options = {keepAlive: this._keepAlive, maxSockets}
       agent = usingSsl ? new https.Agent(options) : new http.Agent(options)
       this._agent = agent
-    }
-
-    // if not using private agent and tunnel agent isn't setup then use global agent
-    if (!agent) {
-      agent = usingSsl ? https.globalAgent : http.globalAgent
     }
 
     if (usingSsl && this._ignoreSslError) {


### PR DESCRIPTION
Starting with Node.js v19, http(s) `globalAgent` now uses `keep-alive` by default. The current `HttpClient` implementation uses `globalAgent` when `RequestOptions.keepAlive` is set to `false` (default), which is fine for `node16` runtime but incorrect for `node20`.

This PR fixes `HttpClient` to use a custom agent regardless of `RequestOptions.keepAlive` so that the option works correctly on both runtimes.

- [Node.js v19.9.0 documentation | `http.globalAgent`](https://nodejs.org/docs/latest-v19.x/api/http.html#httpglobalagent)
- https://github.com/nodejs/node/pull/43522