### PR TITLE
Fix tool output mangled with spawned cmd string

### DIFF
--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -418,8 +418,8 @@ export class ToolRunner extends events.EventEmitter {
       }
 
       const optionsNonNull = this._cloneExecOptions(this.options)
-      if (!optionsNonNull.silent && optionsNonNull.outStream) {
-        optionsNonNull.outStream.write(
+      if (!optionsNonNull.silent && optionsNonNull.errStream) {
+        optionsNonNull.errStream.write(
           this._getCommandString(optionsNonNull) + os.EOL
         )
       }


### PR DESCRIPTION
Presently if the exec'd tool is expected to produce an output (i.e. to write to stdout) that can be consumed in a Unix pipeline, assigned to a variable, or similar; the `silent` option must be set in order to avoid the output being mangled by `@actions/exec` to include the full command string that it spawns (and then re-writing out from the provided stdout
listener).

This commit writes the spawned command string to stderr instead of stdout, as would be expected for logging/debug information as opposed to consumable output data.

Closes #649.