### PR TITLE
Update `@actions/glob` compat

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.0.1",
-    "@actions/glob": "^0.1.0",
+    "@actions/glob": "^0.4.0",
     "@actions/http-client": "^2.1.1",
     "@actions/io": "^1.0.1",
     "@azure/abort-controller": "^1.1.0",


### PR DESCRIPTION
v0.1.0 of `@actions/glob` returns all files rather than just files with .ext for `**/*.ext`