### PR TITLE
fix #1579: getCacheVersion mutates arguments

### DIFF
--- a/packages/cache/__tests__/cacheHttpClient.test.ts
+++ b/packages/cache/__tests__/cacheHttpClient.test.ts
@@ -5,6 +5,12 @@ import {DownloadOptions, getDownloadOptions} from '../src/options'
 
 jest.mock('../src/internal/downloadUtils')
 
+test('getCacheVersion does not mutate arguments', async () => {
+  const paths = ['node_modules']
+  getCacheVersion(paths, undefined, true)
+  expect(paths).toEqual(['node_modules'])
+})
+
 test('getCacheVersion with one path returns version', async () => {
   const paths = ['node_modules']
   const result = getCacheVersion(paths, undefined, true)

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -80,7 +80,7 @@ export function getCacheVersion(
   compressionMethod?: CompressionMethod,
   enableCrossOsArchive = false
 ): string {
-  const components = paths
+  const components = [...paths]
 
   // Add compression method to cache version to restore
   // compressed cache as per compression method


### PR DESCRIPTION
Ran into the issue described in https://github.com/actions/toolkit/issues/1579, this fixes it.