### PR TITLE
Consistent error behavior for Artifact methods

### DIFF
--- a/.github/workflows/artifact-tests.yml
+++ b/.github/workflows/artifact-tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 
@@ -54,8 +54,8 @@ jobs:
         echo '${{ env.file1 }}' > artifact-path/first.txt
         echo '${{ env.file2 }}' > artifact-path/second.txt
 
-    - name: Upload Artifacts using actions/github-script@v6
-      uses: actions/github-script@v6
+    - name: Upload Artifacts using actions/github-script@v7
+      uses: actions/github-script@v7
       with:
         script: |
           const artifact = require('./packages/artifact/lib/artifact')
@@ -78,10 +78,10 @@ jobs:
     needs: [build]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 
@@ -96,8 +96,8 @@ jobs:
         npm run tsc
       working-directory: packages/artifact
 
-    - name: List artifacts using actions/github-script@v6
-      uses: actions/github-script@v6
+    - name: List artifacts using actions/github-script@v7
+      uses: actions/github-script@v7
       with:
         script: |
           const artifact = require('./packages/artifact/lib/artifact')

--- a/.github/workflows/artifact-tests.yml
+++ b/.github/workflows/artifact-tests.yml
@@ -68,15 +68,10 @@ jobs:
           const uploadResult = await artifact.create().uploadArtifact(artifactName, fileContents, './')
           console.log(uploadResult)
 
-          const success = uploadResult.success
           const size = uploadResult.size
           const id = uploadResult.id
 
-          if (!success) {
-            throw new Error('Failed to upload artifact')
-          } else {
-            console.log(`Successfully uploaded artifact ${id}`)
-          }
+          console.log(`Successfully uploaded artifact ${id}`)
            
   verify:
     runs-on: ubuntu-latest

--- a/packages/artifact/__tests__/download-artifact.test.ts
+++ b/packages/artifact/__tests__/download-artifact.test.ts
@@ -164,7 +164,6 @@ describe('download-artifact', () => {
         fixtures.blobStorageUrl
       )
       expectExtractedArchive(fixtures.workspaceDir)
-      expect(response.success).toBe(true)
       expect(response.downloadPath).toBe(fixtures.workspaceDir)
     })
 
@@ -214,7 +213,6 @@ describe('download-artifact', () => {
         fixtures.blobStorageUrl
       )
       expectExtractedArchive(customPath)
-      expect(response.success).toBe(true)
       expect(response.downloadPath).toBe(customPath)
     })
 
@@ -344,7 +342,6 @@ describe('download-artifact', () => {
       const response = await downloadArtifactInternal(fixtures.artifactID)
 
       expectExtractedArchive(fixtures.workspaceDir)
-      expect(response.success).toBe(true)
       expect(response.downloadPath).toBe(fixtures.workspaceDir)
       expect(mockHttpClient).toHaveBeenCalledWith(getUserAgentString())
       expect(mockListArtifacts).toHaveBeenCalledWith({
@@ -396,7 +393,6 @@ describe('download-artifact', () => {
       })
 
       expectExtractedArchive(customPath)
-      expect(response.success).toBe(true)
       expect(response.downloadPath).toBe(customPath)
       expect(mockHttpClient).toHaveBeenCalledWith(getUserAgentString())
       expect(mockListArtifacts).toHaveBeenCalledWith({

--- a/packages/artifact/src/artifact.ts
+++ b/packages/artifact/src/artifact.ts
@@ -4,6 +4,7 @@ import {ArtifactClient, Client} from './internal/client'
  * Exported functionality that we want to expose for any users of @actions/artifact
  */
 export * from './internal/shared/interfaces'
+export * from './internal/shared/errors'
 export {ArtifactClient}
 
 export function create(): ArtifactClient {

--- a/packages/artifact/src/internal/client.ts
+++ b/packages/artifact/src/internal/client.ts
@@ -17,6 +17,7 @@ import {
 } from './download/download-artifact'
 import {getArtifactPublic, getArtifactInternal} from './find/get-artifact'
 import {listArtifactsPublic, listArtifactsInternal} from './find/list-artifacts'
+import {GHESNotSupportError} from './shared/errors'
 
 export interface ArtifactClient {
   /**
@@ -52,6 +53,7 @@ export interface ArtifactClient {
   /**
    * Finds an artifact by name.
    * If there are multiple artifacts with the same name in the same workflow run, this will return the latest.
+   * If the artifact is not found, it will throw.
    *
    * If options.findBy is specified, this will use the public List Artifacts API with a name filter which can get artifacts from other runs.
    * https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts
@@ -99,16 +101,11 @@ export class Client implements ArtifactClient {
     rootDirectory: string,
     options?: UploadArtifactOptions
   ): Promise<UploadArtifactResponse> {
-    if (isGhes()) {
-      warning(
-        `@actions/artifact v2.0.0+ and upload-artifact@v4+ are not currently supported on GHES.`
-      )
-      return {
-        success: false
-      }
-    }
-
     try {
+      if (isGhes()) {
+        throw new GHESNotSupportError()
+      }
+
       return uploadArtifact(name, files, rootDirectory, options)
     } catch (error) {
       warning(
@@ -118,9 +115,8 @@ Errors can be temporary, so please try again and optionally run the action with 
 
 If the error persists, please check whether Actions is operating normally at [https://githubstatus.com](https://www.githubstatus.com).`
       )
-      return {
-        success: false
-      }
+
+      throw error
     }
   }
 
@@ -131,16 +127,11 @@ If the error persists, please check whether Actions is operating normally at [ht
     artifactId: number,
     options?: DownloadArtifactOptions & FindOptions
   ): Promise<DownloadArtifactResponse> {
-    if (isGhes()) {
-      warning(
-        `@actions/artifact v2.0.0+ and download-artifact@v4+ are not currently supported on GHES.`
-      )
-      return {
-        success: false
-      }
-    }
-
     try {
+      if (isGhes()) {
+        throw new GHESNotSupportError()
+      }
+
       if (options?.findBy) {
         const {
           findBy: {repositoryOwner, repositoryName, token},
@@ -159,16 +150,14 @@ If the error persists, please check whether Actions is operating normally at [ht
       return downloadArtifactInternal(artifactId, options)
     } catch (error) {
       warning(
-        `Artifact download failed with error: ${error}.
+        `Download Artifact failed with error: ${error}.
 
 Errors can be temporary, so please try again and optionally run the action with debug mode enabled for more information.
 
 If the error persists, please check whether Actions and API requests are operating normally at [https://githubstatus.com](https://www.githubstatus.com).`
       )
 
-      return {
-        success: false
-      }
+      throw error
     }
   }
 
@@ -178,16 +167,11 @@ If the error persists, please check whether Actions and API requests are operati
   async listArtifacts(
     options?: ListArtifactsOptions & FindOptions
   ): Promise<ListArtifactsResponse> {
-    if (isGhes()) {
-      warning(
-        `@actions/artifact v2.0.0+ and download-artifact@v4+ are not currently supported on GHES.`
-      )
-      return {
-        artifacts: []
-      }
-    }
-
     try {
+      if (isGhes()) {
+        throw new GHESNotSupportError()
+      }
+
       if (options?.findBy) {
         const {
           findBy: {workflowRunId, repositoryOwner, repositoryName, token}
@@ -212,9 +196,7 @@ Errors can be temporary, so please try again and optionally run the action with 
 If the error persists, please check whether Actions and API requests are operating normally at [https://githubstatus.com](https://www.githubstatus.com).`
       )
 
-      return {
-        artifacts: []
-      }
+      throw error
     }
   }
 
@@ -225,16 +207,11 @@ If the error persists, please check whether Actions and API requests are operati
     artifactName: string,
     options?: FindOptions
   ): Promise<GetArtifactResponse> {
-    if (isGhes()) {
-      warning(
-        `@actions/artifact v2.0.0+ and download-artifact@v4+ are not currently supported on GHES.`
-      )
-      return {
-        success: false
-      }
-    }
-
     try {
+      if (isGhes()) {
+        throw new GHESNotSupportError()
+      }
+
       if (options?.findBy) {
         const {
           findBy: {workflowRunId, repositoryOwner, repositoryName, token}
@@ -252,15 +229,13 @@ If the error persists, please check whether Actions and API requests are operati
       return getArtifactInternal(artifactName)
     } catch (error: unknown) {
       warning(
-        `Fetching Artifact failed with error: ${error}.
+        `Get Artifact failed with error: ${error}.
 
 Errors can be temporary, so please try again and optionally run the action with debug mode enabled for more information.
 
 If the error persists, please check whether Actions and API requests are operating normally at [https://githubstatus.com](https://www.githubstatus.com).`
       )
-      return {
-        success: false
-      }
+      throw error
     }
   }
 }

--- a/packages/artifact/src/internal/client.ts
+++ b/packages/artifact/src/internal/client.ts
@@ -17,7 +17,7 @@ import {
 } from './download/download-artifact'
 import {getArtifactPublic, getArtifactInternal} from './find/get-artifact'
 import {listArtifactsPublic, listArtifactsInternal} from './find/list-artifacts'
-import {GHESNotSupportError} from './shared/errors'
+import {GHESNotSupportedError} from './shared/errors'
 
 export interface ArtifactClient {
   /**
@@ -103,7 +103,7 @@ export class Client implements ArtifactClient {
   ): Promise<UploadArtifactResponse> {
     try {
       if (isGhes()) {
-        throw new GHESNotSupportError()
+        throw new GHESNotSupportedError()
       }
 
       return uploadArtifact(name, files, rootDirectory, options)
@@ -129,7 +129,7 @@ If the error persists, please check whether Actions is operating normally at [ht
   ): Promise<DownloadArtifactResponse> {
     try {
       if (isGhes()) {
-        throw new GHESNotSupportError()
+        throw new GHESNotSupportedError()
       }
 
       if (options?.findBy) {
@@ -169,7 +169,7 @@ If the error persists, please check whether Actions and API requests are operati
   ): Promise<ListArtifactsResponse> {
     try {
       if (isGhes()) {
-        throw new GHESNotSupportError()
+        throw new GHESNotSupportedError()
       }
 
       if (options?.findBy) {
@@ -209,7 +209,7 @@ If the error persists, please check whether Actions and API requests are operati
   ): Promise<GetArtifactResponse> {
     try {
       if (isGhes()) {
-        throw new GHESNotSupportError()
+        throw new GHESNotSupportedError()
       }
 
       if (options?.findBy) {

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -16,6 +16,7 @@ import {
   ListArtifactsRequest
 } from '../../generated'
 import {getBackendIdsFromToken} from '../shared/util'
+import {ArtifactNotFoundError} from '../shared/errors'
 
 const scrubQueryParameters = (url: string): string => {
   const parsed = new URL(url)
@@ -95,7 +96,7 @@ export async function downloadArtifactPublic(
     throw new Error(`Unable to download and extract artifact: ${error.message}`)
   }
 
-  return {success: true, downloadPath}
+  return {downloadPath}
 }
 
 export async function downloadArtifactInternal(
@@ -118,10 +119,9 @@ export async function downloadArtifactInternal(
   const {artifacts} = await artifactClient.ListArtifacts(listReq)
 
   if (artifacts.length === 0) {
-    core.warning(
+    throw new ArtifactNotFoundError(
       `No artifacts found for ID: ${artifactId}\nAre you trying to download from a different run? Try specifying a github-token with \`actions:read\` scope.`
     )
-    return {success: false}
   }
 
   if (artifacts.length > 1) {
@@ -148,7 +148,7 @@ export async function downloadArtifactInternal(
     throw new Error(`Unable to download and extract artifact: ${error.message}`)
   }
 
-  return {success: true, downloadPath}
+  return {downloadPath}
 }
 
 async function resolveOrCreateDirectory(

--- a/packages/artifact/src/internal/find/get-artifact.ts
+++ b/packages/artifact/src/internal/find/get-artifact.ts
@@ -48,7 +48,9 @@ export async function getArtifactPublic(
   }
 
   if (getArtifactResp.data.artifacts.length === 0) {
-    throw new ArtifactNotFoundError(artifactName)
+    throw new ArtifactNotFoundError(
+      `Artifact not found for name: ${artifactName}`
+    )
   }
 
   let artifact = getArtifactResp.data.artifacts[0]
@@ -86,7 +88,9 @@ export async function getArtifactInternal(
   const res = await artifactClient.ListArtifacts(req)
 
   if (res.artifacts.length === 0) {
-    throw new ArtifactNotFoundError(artifactName)
+    throw new ArtifactNotFoundError(
+      `Artifact not found for name: ${artifactName}`
+    )
   }
 
   let artifact = res.artifacts[0]

--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -21,8 +21,7 @@ export class InvalidResponseError extends Error {
 }
 
 export class ArtifactNotFoundError extends Error {
-  constructor(name: string) {
-    const message = `No artifact found for name: ${name}`
+  constructor(message = 'Artifact not found') {
     super(message)
     this.name = 'ArtifactNotFoundError'
   }

--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -26,3 +26,12 @@ export class ArtifactNotFoundError extends Error {
     this.name = 'ArtifactNotFoundError'
   }
 }
+
+export class GHESNotSupportError extends Error {
+  constructor(
+    message = '@actions/artifact v2.0.0+ and download-artifact@v4+ are not currently supported on GHES.'
+  ) {
+    super(message)
+    this.name = 'NotSupportedGHESError'
+  }
+}

--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -19,3 +19,11 @@ export class InvalidResponseError extends Error {
     this.name = 'InvalidResponseError'
   }
 }
+
+export class ArtifactNotFoundError extends Error {
+  constructor(name: string) {
+    const message = `No artifact found for name: ${name}`
+    super(message)
+    this.name = 'ArtifactNotFoundError'
+  }
+}

--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -27,11 +27,11 @@ export class ArtifactNotFoundError extends Error {
   }
 }
 
-export class GHESNotSupportError extends Error {
+export class GHESNotSupportedError extends Error {
   constructor(
     message = '@actions/artifact v2.0.0+ and download-artifact@v4+ are not currently supported on GHES.'
   ) {
     super(message)
-    this.name = 'NotSupportedGHESError'
+    this.name = 'GHESNotSupportedError'
   }
 }

--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -1,0 +1,21 @@
+export class FilesNotFoundError extends Error {
+  files: string[]
+
+  constructor(files: string[] = []) {
+    let message = 'No files were found to upload'
+    if (files.length > 0) {
+      message += `: ${files.join(', ')}`
+    }
+
+    super(message)
+    this.files = files
+    this.name = 'FilesNotFoundError'
+  }
+}
+
+export class InvalidResponseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidResponseError'
+  }
+}

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -54,11 +54,6 @@ export interface UploadArtifactOptions {
 
 export interface GetArtifactResponse {
   /**
-   * If an artifact was found
-   */
-  success: boolean
-
-  /**
    * Metadata about the artifact that was found
    */
   artifact?: Artifact

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -5,11 +5,6 @@
  *****************************************************************************/
 export interface UploadArtifactResponse {
   /**
-   * Denotes if an artifact was successfully uploaded
-   */
-  success: boolean
-
-  /**
    * Total size of the artifact in bytes. Not provided if no artifact was uploaded
    */
   size?: number

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -87,10 +87,6 @@ export interface ListArtifactsResponse {
  *****************************************************************************/
 export interface DownloadArtifactResponse {
   /**
-   * If the artifact download was successful
-   */
-  success: boolean
-  /**
    * The path where the artifact was downloaded to
    */
   downloadPath?: string

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -56,7 +56,7 @@ export interface GetArtifactResponse {
   /**
    * Metadata about the artifact that was found
    */
-  artifact?: Artifact
+  artifact: Artifact
 }
 
 /*****************************************************************************

--- a/packages/artifact/src/internal/upload/blob-upload.ts
+++ b/packages/artifact/src/internal/upload/blob-upload.ts
@@ -8,11 +8,6 @@ import * as stream from 'stream'
 
 export interface BlobUploadResponse {
   /**
-   * If the upload was successful or not
-   */
-  isSuccess: boolean
-
-  /**
    * The total reported upload size in bytes. Empty if the upload failed
    */
   uploadSize?: number
@@ -55,41 +50,28 @@ export async function uploadZipToBlobStorage(
   zipUploadStream.pipe(uploadStream) // This stream is used for the upload
   zipUploadStream.pipe(hashStream).setEncoding('hex') // This stream is used to compute a hash of the zip content that gets used. Integrity check
 
-  try {
-    core.info('Beginning upload of artifact content to blob storage')
+  core.info('Beginning upload of artifact content to blob storage')
 
-    await blockBlobClient.uploadStream(
-      uploadStream,
-      bufferSize,
-      maxConcurrency,
-      options
-    )
+  await blockBlobClient.uploadStream(
+    uploadStream,
+    bufferSize,
+    maxConcurrency,
+    options
+  )
 
-    core.info('Finished uploading artifact content to blob storage!')
+  core.info('Finished uploading artifact content to blob storage!')
 
-    hashStream.end()
-    sha256Hash = hashStream.read() as string
-    core.info(`SHA256 hash of uploaded artifact zip is ${sha256Hash}`)
-  } catch (error) {
-    core.warning(
-      `Failed to upload artifact zip to blob storage, error: ${error}`
-    )
-    return {
-      isSuccess: false
-    }
-  }
+  hashStream.end()
+  sha256Hash = hashStream.read() as string
+  core.info(`SHA256 hash of uploaded artifact zip is ${sha256Hash}`)
 
   if (uploadByteCount === 0) {
     core.warning(
-      `No data was uploaded to blob storage. Reported upload byte count is 0`
+      `No data was uploaded to blob storage. Reported upload byte count is 0.`
     )
-    return {
-      isSuccess: false
-    }
   }
 
   return {
-    isSuccess: true,
     uploadSize: uploadByteCount,
     sha256Hash
   }


### PR DESCRIPTION
Partially addresses:
- https://github.com/github/actions-results-team/issues/1805

For our artifact operations, we weren't being consistent on how we were surfacing errors. Sometimes we'd resolve with a response object of `{success:false}` or we'd reject via an error throw.

This PR changes the behavior so that the errors consistently throw/reject for promises to "bubble up" and don't require a bunch of `if(success) { }` logic. Any common errors are exposed that support additional debugging information.

Also, the workflow tests used for this package were updated to reflect these changes.
