### PR TITLE
Cleanup artifact handlers hanging node process

### DIFF
--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -62,7 +62,7 @@ class ArtifactHttpClient implements Rpc {
       const {body} = await this.retryableRequest(async () =>
         this.httpClient.post(url, JSON.stringify(data), headers)
       )
-      
+
       return JSON.parse(body)
     } catch (error) {
       throw new Error(`Failed to ${method}: ${error.message}`)
@@ -71,7 +71,7 @@ class ArtifactHttpClient implements Rpc {
 
   async retryableRequest(
     operation: () => Promise<HttpClientResponse>
-  ): Promise<{response: HttpClientResponse, body: string}> {
+  ): Promise<{response: HttpClientResponse; body: string}> {
     let attempt = 0
     let errorMessage = ''
     while (attempt < this.maxAttempts) {

--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -80,11 +80,10 @@ class ArtifactHttpClient implements Rpc {
       try {
         const response = await operation()
         const statusCode = response.message.statusCode
-        const raw = await response.readBody()
-        const body = JSON.parse(raw)
+        const body = await response.readBody()
         debug(`[Response] - ${response.message.statusCode}`)
         debug(`Headers: ${JSON.stringify(response.message.headers, null, 2)}`)
-        debug(`Body: ${JSON.stringify(body, null, 2)}`)
+        debug(`Body: ${body}`)
 
         if (this.isSuccessStatusCode(statusCode)) {
           return {response, body}

--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -59,10 +59,10 @@ class ArtifactHttpClient implements Rpc {
       'Content-Type': contentType
     }
     try {
-      const response = await this.retryableRequest(async () =>
+      const {body} = await this.retryableRequest(async () =>
         this.httpClient.post(url, JSON.stringify(data), headers)
       )
-      const body = await response.readBody()
+      
       return JSON.parse(body)
     } catch (error) {
       throw new Error(`Failed to ${method}: ${error.message}`)
@@ -71,7 +71,7 @@ class ArtifactHttpClient implements Rpc {
 
   async retryableRequest(
     operation: () => Promise<HttpClientResponse>
-  ): Promise<HttpClientResponse> {
+  ): Promise<{response: HttpClientResponse, body: string}> {
     let attempt = 0
     let errorMessage = ''
     while (attempt < this.maxAttempts) {
@@ -80,11 +80,14 @@ class ArtifactHttpClient implements Rpc {
       try {
         const response = await operation()
         const statusCode = response.message.statusCode
-        debug(`[Response] ${response.message.statusCode}`)
-        debug(JSON.stringify(response.message.headers, null, 2))
+        const raw = await response.readBody()
+        const body = JSON.parse(raw)
+        debug(`[Response] - ${response.message.statusCode}`)
+        debug(`Headers: ${JSON.stringify(response.message.headers, null, 2)}`)
+        debug(`Body: ${JSON.stringify(body, null, 2)}`)
 
         if (this.isSuccessStatusCode(statusCode)) {
-          return response
+          return {response, body}
         }
 
         isRetryable = this.isRetryableHttpStatusCode(statusCode)

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -40,11 +40,6 @@ export async function uploadArtifact(
     )
   }
 
-  const zipUploadStream = await createZipUploadStream(
-    zipSpecification,
-    options?.compressionLevel
-  )
-
   // get the IDs needed for the artifact creation
   const backendIds = getBackendIdsFromToken()
 
@@ -72,6 +67,11 @@ export async function uploadArtifact(
       'CreateArtifact: response from backend was not ok'
     )
   }
+
+  const zipUploadStream = await createZipUploadStream(
+    zipSpecification,
+    options?.compressionLevel
+  )
 
   // Upload zip to blob storage
   const uploadResult = await uploadZipToBlobStorage(


### PR DESCRIPTION
Fixes a bug where an error response causes the actions to hang for ~2 min.

Using [`why-is-node-running`](https://www.npmjs.com/package/why-is-node-running) we were able to track down the `ZLIB`, `TCPWRAP`, and `TLSWRAP` handlers clogging things up.

tl;dr

1. ZIP stream was being created way too early, we encounter an error & throw (reject) and the stream just hangs around.
2. In our retry http wrapper, we weren't reading the body on the request if it's a non-200 status code. For some reason (more investigation needed) this keeps things going until the keep-alive is met for the request? (or some other 2 minute timeout)