### PR TITLE
Remove 429 request from list of retry-able status codes

### DIFF
--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -133,7 +133,6 @@ class ArtifactHttpClient implements Rpc {
       HttpCodes.GatewayTimeout,
       HttpCodes.InternalServerError,
       HttpCodes.ServiceUnavailable,
-      HttpCodes.TooManyRequests,
       413 // Payload Too Large
     ]
 

--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -132,7 +132,7 @@ class ArtifactHttpClient implements Rpc {
       HttpCodes.BadGateway,
       HttpCodes.GatewayTimeout,
       HttpCodes.InternalServerError,
-      HttpCodes.ServiceUnavailable,
+      HttpCodes.ServiceUnavailable
     ]
 
     return retryableStatusCodes.includes(statusCode)

--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -133,7 +133,6 @@ class ArtifactHttpClient implements Rpc {
       HttpCodes.GatewayTimeout,
       HttpCodes.InternalServerError,
       HttpCodes.ServiceUnavailable,
-      413 // Payload Too Large
     ]
 
     return retryableStatusCodes.includes(statusCode)


### PR DESCRIPTION
We are returning a [429 Status code in our Twirp handlers](https://github.com/twitchtv/twirp/blob/206451d552e13701fa1111430aa81235029cb329/errors.go#L216). We shouldn't be retrying when we come across a 429.