### PR TITLE
Add back 429 to list of retryable requests

### DIFF
--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -132,7 +132,8 @@ class ArtifactHttpClient implements Rpc {
       HttpCodes.BadGateway,
       HttpCodes.GatewayTimeout,
       HttpCodes.InternalServerError,
-      HttpCodes.ServiceUnavailable
+      HttpCodes.ServiceUnavailable,
+      HttpCodes.TooManyRequests,
     ]
 
     return retryableStatusCodes.includes(statusCode)


### PR DESCRIPTION
This was removed when working through a bug. [429 status codes are often associated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) with a retry request to going to add this back in for now.