### PR TITLE
Add specific messages for network-specific node error codes

### DIFF
--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -4,6 +4,7 @@ import {info, debug} from '@actions/core'
 import {ArtifactServiceClientJSON} from '../../generated'
 import {getResultsServiceUrl, getRuntimeToken} from './config'
 import {getUserAgentString} from './user-agent'
+import {NetworkError} from './errors'
 
 // The twirp http client must implement this interface
 interface Rpc {
@@ -96,6 +97,9 @@ class ArtifactHttpClient implements Rpc {
       } catch (error) {
         isRetryable = true
         errorMessage = error.message
+        if (NetworkError.isNetworkErrorCode(error?.code)) {
+          throw new NetworkError(error?.code)
+        }
       }
 
       if (!isRetryable) {

--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -35,3 +35,25 @@ export class GHESNotSupportedError extends Error {
     this.name = 'GHESNotSupportedError'
   }
 }
+
+export class NetworkError extends Error {
+  code: string
+
+  constructor(code: string) {
+    const message = `Unable to make request: ${code}\nIf you are using self-hosted runners, please make sure your runner has access to all GitHub endpoints: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#communication-between-self-hosted-runners-and-github`
+    super(message)
+    this.code = code
+    this.name = 'NetworkError'
+  }
+
+  static isNetworkErrorCode = (code?: string): boolean => {
+    if (!code) return false
+    return [
+      'ECONNRESET',
+      'ENOTFOUND',
+      'ETIMEDOUT',
+      'ECONNREFUSED',
+      'EHOSTUNREACH'
+    ].includes(code)
+  }
+}


### PR DESCRIPTION
Will help customers debug network failures with self hosted runners faster.

Example error text would be:

> Failed to CreateArtifact: Unable to make request: ENOTFOUND
> If you are using self-hosted runners, please make sure your runner has access to all GitHub endpoints: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#communication-between-self-hosted-runners-and-github

Closes: https://github.com/github/actions-results-team/issues/1805