### PR TITLE
Better error message for artifact usage limits

### DIFF
--- a/packages/artifact/src/internal/shared/errors.ts
+++ b/packages/artifact/src/internal/shared/errors.ts
@@ -57,3 +57,16 @@ export class NetworkError extends Error {
     ].includes(code)
   }
 }
+
+export class UsageError extends Error {
+  constructor() {
+    const message = `Artifact storage quota has been hit. Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.\nMore info on storage limits: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#calculating-minute-and-storage-spending`
+    super(message)
+    this.name = 'UsageError'
+  }
+
+  static isUsageErrorMessage = (msg?: string): boolean => {
+    if (!msg) return false
+    return msg.includes('insufficient usage')
+  }
+}


### PR DESCRIPTION
If customers encounter storage quota limits, they'll hit an error when trying to create artifacts.

This'll make the error more useful for the customers:
> Failed to CreateArtifact: Artifact storage quota has been hit. Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.
> More info on storage limits: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#calculating-minute-and-storage-spending

Let me know if there's any other context we'd like to add to the message 👍 