### PR TITLE
Update artifact module quick start

### DIFF
--- a/packages/artifact/README.md
+++ b/packages/artifact/README.md
@@ -63,10 +63,16 @@ Import the module:
 
 ```js
 // ES6 module
-import artifact from '@actions/artifact'
+import {DefaultArtifactClient} from '@actions/artifact'
 
 // CommonJS
-const {default: artifact} = require('@actions/artifact')
+const {DefaultArtifactClient} = require('@actions/artifact')
+```
+
+Then instantiate:
+
+```js
+const artifact = new DefaultArtifactClient()
 ```
 
 ℹ️ For a comprehensive list of classes, interfaces, functions and more, see the [generated documentation](./docs/generated/README.md).


### PR DESCRIPTION
The instructions for the default export don't work for es modules (`.mjs`) files, so lets instruct users to just import the default client and instantiate instead.

Moving to `"type": "module"` is not something we want to commit to yet for `@actions/artifact`

Addresses:
- https://github.com/actions/toolkit/issues/1606