### PR TITLE
Include fs stats in zip archive

### DIFF
--- a/packages/artifact/__tests__/upload-artifact.test.ts
+++ b/packages/artifact/__tests__/upload-artifact.test.ts
@@ -8,6 +8,7 @@ import * as blobUpload from '../src/internal/upload/blob-upload'
 import {uploadArtifact} from '../src/internal/upload/upload-artifact'
 import {noopLogs} from './common'
 import {FilesNotFoundError} from '../src/internal/shared/errors'
+import {Stats} from 'fs'
 
 describe('upload-artifact', () => {
   beforeEach(() => {
@@ -28,15 +29,18 @@ describe('upload-artifact', () => {
       .mockReturnValue([
         {
           sourcePath: '/home/user/files/plz-upload/file1.txt',
-          destinationPath: 'file1.txt'
+          destinationPath: 'file1.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/file2.txt',
-          destinationPath: 'file2.txt'
+          destinationPath: 'file2.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/dir/file3.txt',
-          destinationPath: 'dir/file3.txt'
+          destinationPath: 'dir/file3.txt',
+          stats: new Stats()
         }
       ])
 
@@ -136,15 +140,18 @@ describe('upload-artifact', () => {
       .mockReturnValue([
         {
           sourcePath: '/home/user/files/plz-upload/file1.txt',
-          destinationPath: 'file1.txt'
+          destinationPath: 'file1.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/file2.txt',
-          destinationPath: 'file2.txt'
+          destinationPath: 'file2.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/dir/file3.txt',
-          destinationPath: 'dir/file3.txt'
+          destinationPath: 'dir/file3.txt',
+          stats: new Stats()
         }
       ])
 
@@ -175,15 +182,18 @@ describe('upload-artifact', () => {
       .mockReturnValue([
         {
           sourcePath: '/home/user/files/plz-upload/file1.txt',
-          destinationPath: 'file1.txt'
+          destinationPath: 'file1.txt',
+          stats: Stats.prototype
         },
         {
           sourcePath: '/home/user/files/plz-upload/file2.txt',
-          destinationPath: 'file2.txt'
+          destinationPath: 'file2.txt',
+          stats: Stats.prototype
         },
         {
           sourcePath: '/home/user/files/plz-upload/dir/file3.txt',
-          destinationPath: 'dir/file3.txt'
+          destinationPath: 'dir/file3.txt',
+          stats: Stats.prototype
         }
       ])
 
@@ -230,15 +240,18 @@ describe('upload-artifact', () => {
       .mockReturnValue([
         {
           sourcePath: '/home/user/files/plz-upload/file1.txt',
-          destinationPath: 'file1.txt'
+          destinationPath: 'file1.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/file2.txt',
-          destinationPath: 'file2.txt'
+          destinationPath: 'file2.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/dir/file3.txt',
-          destinationPath: 'dir/file3.txt'
+          destinationPath: 'dir/file3.txt',
+          stats: new Stats()
         }
       ])
 
@@ -293,15 +306,18 @@ describe('upload-artifact', () => {
       .mockReturnValue([
         {
           sourcePath: '/home/user/files/plz-upload/file1.txt',
-          destinationPath: 'file1.txt'
+          destinationPath: 'file1.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/file2.txt',
-          destinationPath: 'file2.txt'
+          destinationPath: 'file2.txt',
+          stats: new Stats()
         },
         {
           sourcePath: '/home/user/files/plz-upload/dir/file3.txt',
-          destinationPath: 'dir/file3.txt'
+          destinationPath: 'dir/file3.txt',
+          stats: new Stats()
         }
       ])
 

--- a/packages/artifact/__tests__/upload-zip-specification.test.ts
+++ b/packages/artifact/__tests__/upload-zip-specification.test.ts
@@ -287,14 +287,14 @@ describe('Search', () => {
     expect(specifications.length).toEqual(2)
     const absolutePaths = specifications.map(item => item.sourcePath)
     expect(absolutePaths).toContain(goodItem1Path)
-    expect(absolutePaths).toContain(null)
+    expect(absolutePaths).toContain(folderEPath)
 
     for (const specification of specifications) {
       if (specification.sourcePath === goodItem1Path) {
         expect(specification.destinationPath).toEqual(
           path.join('/folder-a', 'folder-b', 'folder-c', 'good-item1.txt')
         )
-      } else if (specification.sourcePath === null) {
+      } else if (specification.sourcePath === folderEPath) {
         expect(specification.destinationPath).toEqual(
           path.join('/folder-a', 'folder-b', 'folder-e')
         )

--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -42,14 +42,18 @@ export async function createZipUploadStream(
   zip.on('end', zipEndCallback)
 
   for (const file of uploadSpecification) {
-    if (file.sourcePath !== null) {
+    if (!file.stats.isDirectory()) {
       // Add a normal file to the zip
       zip.append(createReadStream(file.sourcePath), {
-        name: file.destinationPath
+        name: file.destinationPath,
+        stats: file.stats
       })
     } else {
       // Add a directory to the zip
-      zip.append('', {name: file.destinationPath})
+      zip.append('', {
+        name: file.destinationPath,
+        stats: file.stats
+      })
     }
   }
 


### PR DESCRIPTION
The main driver of this is that artifact permissions are lost on upload:

https://github.com/actions/upload-artifact/issues/37
https://github.com/actions/upload-artifact/issues/38

But this will also keep file creation and modification timestamps to assist troubleshooting.