### PR TITLE
Updating artifacts (download-artifact related) release notes

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -97,7 +97,11 @@
 
 ### 2.0.0
 
-Major release. Supports new Artifact backend for improved speed, reliability and behavior.
-Numerous API changes, [some breaking](./README.md#breaking-changes).
+- Major release. Supports new Artifact backend for improved speed, reliability and behavior.
+- Numerous API changes, [some breaking](./README.md#breaking-changes).
 
-Blog post with more info: TBD
+- Blog post with more info: TBD
+
+### 2.0.1
+
+- Patch to fix transient request timeouts https://github.com/actions/download-artifact/issues/249

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [


### PR DESCRIPTION
Adds a fix for transient request timeouts
Related to https://github.com/actions/download-artifact/issues/249