### PR TITLE
adding hyperlinks for new section of artifacts faq

### DIFF
--- a/packages/artifact/docs/faq.md
+++ b/packages/artifact/docs/faq.md
@@ -44,11 +44,9 @@ For large files that are not easily compressed, a value of 0 is recommended for 
 | v4 | v4 | v2 |
 | <v3 | <v3 | < v1 |
 
-1. **Matching Versions:**
-	- Use matching versions of `actions/upload-artifact` and `actions/download-artifact` to ensure compatibility.
+ Use matching versions of `actions/upload-artifact` and `actions/download-artifact` to ensure compatibility.
 
-2. **Workflow YAML File:**
-   - In your GitHub Actions workflow YAML file, you specify the version of the actions you want to use. For example:
+In your GitHub Actions workflow YAML file, you specify the version of the actions you want to use. For example:
      ```yaml
      uses: actions/upload-artifact@v4
      # ...
@@ -56,8 +54,8 @@ For large files that are not easily compressed, a value of 0 is recommended for 
      # ...
      ```
 
-3. **Release Notes:**
-   - Check the release notes for each repository to see if there are any specific notes about compatibility or changes in behavior.
+**Release Notes:**
+Check the release notes for each repository to see if there are any specific notes about compatibility or changes in behavior.
 
 ## How long will my artifact be available?
 The default retention period is **90 days**. For more information, visit: https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period 

--- a/packages/artifact/docs/faq.md
+++ b/packages/artifact/docs/faq.md
@@ -60,4 +60,4 @@ For large files that are not easily compressed, a value of 0 is recommended for 
    - Check the release notes for each repository to see if there are any specific notes about compatibility or changes in behavior.
 
 ## How long will my artifact be available?
-The default retention period is 90 days. For more information, visit: https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period 
+The default retention period is **90 days**. For more information, visit: https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period 

--- a/packages/artifact/docs/faq.md
+++ b/packages/artifact/docs/faq.md
@@ -37,7 +37,12 @@ Higher levels will result in better compression, but will take longer to complet
 For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.
 
 ## Which versions of the artifacts packages are compatible?
-[actions/upload-artifact](https://github.com/actions/upload-artifact) and [actions/download-artifact](https://github.com/actions/download-artifact), are part of the [GitHub Actions toolkit](https://github.com/actions/toolkit) and are typically used together to upload and download artifacts in your workflows.
+[actions/upload-artifact](https://github.com/actions/upload-artifact) and [actions/download-artifact](https://github.com/actions/download-artifact), leverage [GitHub Actions toolkit](https://github.com/actions/toolkit) and are typically used together to upload and download artifacts in your workflows.
+
+| upload-artifact | download-artifact | toolkit |
+|---|---|---|
+| v4 | v4 | v2 |
+| <v3 | <v3 | < v1 |
 
 1. **Matching Versions:**
 	- Use matching versions of `actions/upload-artifact` and `actions/download-artifact` to ensure compatibility.

--- a/packages/artifact/docs/faq.md
+++ b/packages/artifact/docs/faq.md
@@ -42,7 +42,7 @@ For large files that are not easily compressed, a value of 0 is recommended for 
 | upload-artifact | download-artifact | toolkit |
 |---|---|---|
 | v4 | v4 | v2 |
-| <v3 | <v3 | < v1 |
+| < v3 | < v3 | < v1 |
 
 Use matching versions of `actions/upload-artifact` and `actions/download-artifact` to ensure compatibility.
 

--- a/packages/artifact/docs/faq.md
+++ b/packages/artifact/docs/faq.md
@@ -44,15 +44,16 @@ For large files that are not easily compressed, a value of 0 is recommended for 
 | v4 | v4 | v2 |
 | <v3 | <v3 | < v1 |
 
- Use matching versions of `actions/upload-artifact` and `actions/download-artifact` to ensure compatibility.
+Use matching versions of `actions/upload-artifact` and `actions/download-artifact` to ensure compatibility.
 
 In your GitHub Actions workflow YAML file, you specify the version of the actions you want to use. For example:
-     ```yaml
-     uses: actions/upload-artifact@v4
-     # ...
-     uses: actions/download-artifact@v4
-     # ...
-     ```
+
+```yaml
+  uses: actions/upload-artifact@v4
+  # ...
+  uses: actions/download-artifact@v4
+  # ...
+```
 
 **Release Notes:**
 Check the release notes for each repository to see if there are any specific notes about compatibility or changes in behavior.

--- a/packages/artifact/docs/faq.md
+++ b/packages/artifact/docs/faq.md
@@ -3,6 +3,8 @@
 - [Frequently Asked Questions](#frequently-asked-questions)
   - [Supported Characters](#supported-characters)
   - [Compression? ZIP? How is my artifact stored?](#compression-zip-how-is-my-artifact-stored)
+  - [Which versions of the artifacts packages are compatible?](#which-versions-of-the-artifacts-packages-are-compatible)
+  - [How long will my artifact be available?](#how-long-will-my-artifact-be-available)
 
 ## Supported Characters
 


### PR DESCRIPTION
We now have FAQ docs on upload/artifact and download/artifact version compatibility and retention.

We want to hyperlink to these Question+Answers in the index section. 

## NOTE 
If you have any edits to the updated sections, also please include those in this PR review! 