### PR TITLE
updating artifact not found error message

### DIFF
--- a/packages/artifact/src/internal/find/get-artifact.ts
+++ b/packages/artifact/src/internal/find/get-artifact.ts
@@ -91,7 +91,9 @@ export async function getArtifactInternal(
 
   if (res.artifacts.length === 0) {
     throw new ArtifactNotFoundError(
-      `Artifact not found for name: ${artifactName}`
+      `Artifact not found for name: ${artifactName}\n
+        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.\n
+        For more information, visit the Github Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md`
     )
   }
 

--- a/packages/artifact/src/internal/find/get-artifact.ts
+++ b/packages/artifact/src/internal/find/get-artifact.ts
@@ -49,9 +49,9 @@ export async function getArtifactPublic(
 
   if (getArtifactResp.data.artifacts.length === 0) {
     throw new ArtifactNotFoundError(
-      `Artifact not found for name: ${artifactName}\n
-        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.\n
-        For more information, visit the Github Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md`
+      `Artifact not found for name: ${artifactName}
+        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
+        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md`
     )
   }
 
@@ -91,9 +91,9 @@ export async function getArtifactInternal(
 
   if (res.artifacts.length === 0) {
     throw new ArtifactNotFoundError(
-      `Artifact not found for name: ${artifactName}\n
-        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.\n
-        For more information, visit the Github Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md`
+      `Artifact not found for name: ${artifactName}
+        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
+        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md`
     )
   }
 

--- a/packages/artifact/src/internal/find/get-artifact.ts
+++ b/packages/artifact/src/internal/find/get-artifact.ts
@@ -49,7 +49,9 @@ export async function getArtifactPublic(
 
   if (getArtifactResp.data.artifacts.length === 0) {
     throw new ArtifactNotFoundError(
-      `Artifact not found for name: ${artifactName}`
+      `Artifact not found for name: ${artifactName}\n
+        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.\n
+        For more information, visit the Github Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md`
     )
   }
 


### PR DESCRIPTION
## What are we doing?
We want to be more descriptive in the reason why users might experience an artifact not being found. This error message update helps direct users to troubleshoot using the FAQ docs and common reasons for this issue. 

## How are we doing it?
Updating the `ArtifactNotFoundError` in `getArtifactPublic` and `getArtifactInternal` to include more information.

## How do I test?
Use the updated toolkit in a workflow using an outdated artifact or an artifact uploaded using a previous version. Expect the new error message. 