### PR TITLE
`restoreCache` only cleanup in `finally` if `archivePath` is set

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -142,11 +142,13 @@ export async function restoreCache(
       core.warning(`Failed to restore: ${(error as Error).message}`)
     }
   } finally {
-    // Try to delete the archive to save space
-    try {
-      await utils.unlinkFile(archivePath)
-    } catch (error) {
-      core.debug(`Failed to delete archive: ${error}`)
+    if (archivePath) {
+      // Try to delete the archive to save space
+      try {
+        await utils.unlinkFile(archivePath)
+      } catch (error) {
+        core.debug(`Failed to delete archive: ${error}`)
+      }
     }
   }
 


### PR DESCRIPTION
When running tests for actions/download-artifact, I see output akin to:

```
[Test/Build]   💬  ::debug::Resource Url: http://192.168.1.131:60101/_apis/artifactcache/cache?keys=node-cache-Linux-npm-e6ea06a810d13d06734e17284172c796edb36687728216c316fe3e8dbe04d235&version=b3f0cb83629d634645a5146420c017462ebb5229bd60271a7a86e489a6066469
[Test/Build]   💬  ::debug::Failed to delete archive: Error: ENOENT: no such file or directory, unlink ''
```

The current code is broken. -- The `try` block includes a lot of code that runs and can return early before it sets `archivePath`, and yet the `finally` **unconditionally** calls `utils.unlinkFile(archivePath)`.