### PR TITLE
Update GHES host check

### DIFF
--- a/packages/artifact/__tests__/config.test.ts
+++ b/packages/artifact/__tests__/config.test.ts
@@ -1,29 +1,27 @@
 import * as config from '../src/internal/shared/config'
 
-
 beforeEach(() => {
-    jest.resetModules() 
-  });
-  
+  jest.resetModules()
+})
 
 describe('isGhes', () => {
-    it('should return false when the request domain is github.com', () => {
-        process.env.GITHUB_SERVER_URL = 'https://github.com'
-        expect(config.isGhes()).toBe(false)
-    })
+  it('should return false when the request domain is github.com', () => {
+    process.env.GITHUB_SERVER_URL = 'https://github.com'
+    expect(config.isGhes()).toBe(false)
+  })
 
-    it('should return false when the request domain ends with ghe.com', () => {
-        process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.com'
-        expect(config.isGhes()).toBe(false)
-    })
+  it('should return false when the request domain ends with ghe.com', () => {
+    process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.com'
+    expect(config.isGhes()).toBe(false)
+  })
 
-    it('should return false when the request domain ends with ghe.localhost', () => {
-        process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.localhost'
-        expect(config.isGhes()).toBe(false)
-    })
+  it('should return false when the request domain ends with ghe.localhost', () => {
+    process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.localhost'
+    expect(config.isGhes()).toBe(false)
+  })
 
-    it('should return false when the request domain is specific to an enterprise', () => {
-        process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
-        expect(config.isGhes()).toBe(true)
-    })
+  it('should return false when the request domain is specific to an enterprise', () => {
+    process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+    expect(config.isGhes()).toBe(true)
+  })
 })

--- a/packages/artifact/__tests__/config.test.ts
+++ b/packages/artifact/__tests__/config.test.ts
@@ -1,0 +1,29 @@
+import * as config from '../src/internal/shared/config'
+
+
+beforeEach(() => {
+    jest.resetModules() 
+  });
+  
+
+describe('isGhes', () => {
+    it('should return false when the request domain is github.com', () => {
+        process.env.GITHUB_SERVER_URL = 'https://github.com'
+        expect(config.isGhes()).toBe(false)
+    })
+
+    it('should return false when the request domain ends with ghe.com', () => {
+        process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.com'
+        expect(config.isGhes()).toBe(false)
+    })
+
+    it('should return false when the request domain ends with ghe.localhost', () => {
+        process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.localhost'
+        expect(config.isGhes()).toBe(false)
+    })
+
+    it('should return false when the request domain is specific to an enterprise', () => {
+        process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+        expect(config.isGhes()).toBe(true)
+    })
+})

--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -27,7 +27,12 @@ export function isGhes(): boolean {
   const ghUrl = new URL(
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   )
-  return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM'
+
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
+  const isGitHubHost = (hostname == 'GITHUB.COM')
+  const isGheHost = (hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST'))
+
+  return !isGitHubHost && !isGheHost
 }
 
 export function getGitHubWorkspaceDir(): string {

--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -29,8 +29,9 @@ export function isGhes(): boolean {
   )
 
   const hostname = ghUrl.hostname.trimEnd().toUpperCase()
-  const isGitHubHost = (hostname == 'GITHUB.COM')
-  const isGheHost = (hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST'))
+  const isGitHubHost = hostname === 'GITHUB.COM'
+  const isGheHost =
+    hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST')
 
   return !isGitHubHost && !isGheHost
 }

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -2,6 +2,10 @@ import {promises as fs} from 'fs'
 import * as path from 'path'
 import * as cacheUtils from '../src/internal/cacheUtils'
 
+beforeEach(() => {
+  jest.resetModules() 
+});
+
 test('getArchiveFileSizeInBytes returns file size', () => {
   const filePath = path.join(__dirname, '__fixtures__', 'helloWorld.txt')
 
@@ -37,4 +41,24 @@ test('resolvePaths works on github workspace directory', async () => {
   const workspace = process.env['GITHUB_WORKSPACE'] ?? '.'
   const paths = await cacheUtils.resolvePaths([workspace])
   expect(paths.length).toBeGreaterThan(0)
+})
+
+test('isGhes returns false for github.com', async () => {
+  process.env.GITHUB_SERVER_URL = 'https://github.com'
+  expect(cacheUtils.isGhes()).toBe(false)
+})
+
+test('isGhes returns false for ghe.com', async () => {
+  process.env.GITHUB_SERVER_URL = 'https://somedomain.ghe.com'
+  expect(cacheUtils.isGhes()).toBe(false)
+})
+
+test('isGhes returns true for enterprise URL', async () => {
+  process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+  expect(cacheUtils.isGhes()).toBe(true)
+})
+
+test('isGhes returns false for ghe.localhost', () => {
+  process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.localhost'
+  expect(cacheUtils.isGhes()).toBe(false)
 })

--- a/packages/cache/__tests__/cacheUtils.test.ts
+++ b/packages/cache/__tests__/cacheUtils.test.ts
@@ -3,8 +3,8 @@ import * as path from 'path'
 import * as cacheUtils from '../src/internal/cacheUtils'
 
 beforeEach(() => {
-  jest.resetModules() 
-});
+  jest.resetModules()
+})
 
 test('getArchiveFileSizeInBytes returns file size', () => {
   const filePath = path.join(__dirname, '__fixtures__', 'helloWorld.txt')

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -137,8 +137,9 @@ export function isGhes(): boolean {
   )
 
   const hostname = ghUrl.hostname.trimEnd().toUpperCase()
-  const isGitHubHost = (hostname == 'GITHUB.COM')
-  const isGheHost = (hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST'))
+  const isGitHubHost = hostname === 'GITHUB.COM'
+  const isGheHost =
+    hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST')
 
   return !isGitHubHost && !isGheHost
 }

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -135,5 +135,10 @@ export function isGhes(): boolean {
   const ghUrl = new URL(
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   )
-  return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM'
+
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
+  const isGitHubHost = (hostname == 'GITHUB.COM')
+  const isGheHost = (hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST'))
+
+  return !isGitHubHost && !isGheHost
 }


### PR DESCRIPTION
## What are we doing?
Currently, we are only checking equality against `github.com` to ensure artifact and cache actions are being run in a non-enterprise host. We need to update this check to allow requests from `ghe.com` and `ghe.localhost`, additional allowed hostnames for production and local development. 

Fixes https://github.com/github/actions-results-team/issues/2208

## How are we doing it?
- We are including the known GItHub hostnames in the _negative_ condition for `isGhes`

## How do I test?
- Run upload or download artifact from an allowed host using this toolkit package version 