### PR TITLE
updating artifact version and release to include ghes check change

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -110,3 +110,7 @@
 
 - Added `ArtifactClient#deleteArtifact` to delete artifacts by name [#1626](https://github.com/actions/toolkit/pull/1626)
 - Update error messaging to be more useful [#1628](https://github.com/actions/toolkit/pull/1628)
+
+### 2.1.1
+ 
+- Updated `isGhes` check to include `.ghe.com` and `.ghe.localhost` as accepted hosts

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [


### PR DESCRIPTION
## What are we doing?
We updated the `isGhes` check for `@actions/artifact` in https://github.com/actions/toolkit/pull/1648 and want to release a new version with this change 