### PR TITLE
updating cache version and release to include ghes check change

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -168,3 +168,7 @@
 ### 3.2.3
 
 - Fixed a bug that mutated path arguments to `getCacheVersion` [#1378](https://github.com/actions/toolkit/pull/1378)
+
+### 3.2.4
+
+- Updated `isGhes` check to include `.ghe.com` and `.ghe.localhost` as accepted hosts

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "3.2.2",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "3.2.2",
+      "version": "3.2.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
## What are we doing?
We updated the `isGhes` check for `@actions/artifact` in https://github.com/actions/toolkit/pull/1648 and want to release a new version with this change 