### PR TITLE
Update workflows to use v4 actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 

--- a/.github/workflows/cache-tests.yml
+++ b/.github/workflows/cache-tests.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: verify package exists
         run: ls packages/${{ github.event.inputs.package }}
 
       - name: Set Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
 
@@ -40,7 +40,7 @@ jobs:
         working-directory: packages/${{ github.event.inputs.package }}
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.inputs.package }}
           path: packages/${{ github.event.inputs.package }}/*.tgz
@@ -52,7 +52,7 @@ jobs:
     steps:
 
       - name: download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.event.inputs.package }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Node.js 20.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
 

--- a/.github/workflows/update-github.yaml
+++ b/.github/workflows/update-github.yaml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.repository_owner == 'actions' }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Update Octokit
       working-directory: packages/github 
       run: |

--- a/docs/action-types.md
+++ b/docs/action-types.md
@@ -32,7 +32,7 @@ jobs:
         os: [ubuntu-16.04, windows-2019]
     runs-on: ${{matrix.os}}
     actions:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         version: ${{matrix.node}}
     - run: | 

--- a/docs/container-action.md
+++ b/docs/container-action.md
@@ -18,7 +18,7 @@ e.g. To use https://github.com/actions/setup-node, users will author:
 
 ```yaml
 steps:
-    using: actions/setup-node@v3
+    using: actions/setup-node@v4
 ```
 
 # Define Metadata


### PR DESCRIPTION
v3 actions run on node16 which will be deprecated. We should move to the latest and greatest