### PR TITLE
docs: Deprecate references to `@octokit/webhooks-definitions`

### DIFF
--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -59,15 +59,15 @@ const newIssue = await octokit.rest.issues.create({
 
 ## Webhook payload typescript definitions
 
-The npm module `@octokit/webhooks-definitions` provides type definitions for the response payloads. You can cast the payload to these types for better type information.
+The npm module `@octokit/webhooks-types` provides type definitions for the response payloads. You can cast the payload to these types for better type information.
 
-First, install the npm module `npm install @octokit/webhooks-definitions`
+First, install the npm module `npm install @octokit/webhooks-types`
 
 Then, assert the type based on the eventName
 ```ts
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import {PushEvent} from '@octokit/webhooks-definitions/schema'
+import {PushEvent} from '@octokit/webhooks-types'
 
 if (github.context.eventName === 'push') {
   const pushPayload = github.context.payload as PushEvent


### PR DESCRIPTION
Hello actions/toolkit!

I've noticed that the document still references `@octokit/webhooks-types`, which has been deprecated by https://github.com/octokit/webhooks/issues/447.

This PR updates the reference from `@octokit/webhooks-definitions` to `@octokit/webhooks-types` to avoid confusion.
