### PR TITLE
docs(glob): Fix glob.create call in README example.

### DIFF
--- a/packages/glob/README.md
+++ b/packages/glob/README.md
@@ -70,7 +70,7 @@ const glob = require('@actions/glob')
 const globOptions = {
   followSymbolicLinks: core.getInput('follow-symbolic-links').toUpper() !== 'FALSE'
 }
-const globber = glob.create(core.getInput('files'), globOptions)
+const globber = await glob.create(core.getInput('files'), globOptions)
 for await (const file of globber.globGenerator()) {
   console.log(file)
 }


### PR DESCRIPTION
Copy-pasting official docs into my code and getting this blob of text is not ideal:
```
TypeError: globber.globGenerator(...) is not a function or its return value is not async iterable
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:8:34)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35425:12)
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:26)
Error: Unhandled error: TypeError: globber.globGenerator(...) is not a function or its return value is not async iterable
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35497:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35553:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35556:12)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
```
It took me a while to figure out what's wrong, raising the PR to reduce the investigation for the next non-JavaScript expert coming along.