### PR TITLE
Ensure callback is only called once

### DIFF
--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -128,10 +128,7 @@ export async function streamExtractExternal(
               if (!createdDirectories.has(path.dirname(fullPath))) {
                 createdDirectories.add(path.dirname(fullPath))
                 await resolveOrCreateDirectory(path.dirname(fullPath)).then(
-                  () => {
-                    entry.autodrain()
-                    callback()
-                  }
+                  () => {}
                 )
               }
 

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -127,9 +127,7 @@ export async function streamExtractExternal(
             } else {
               if (!createdDirectories.has(path.dirname(fullPath))) {
                 createdDirectories.add(path.dirname(fullPath))
-                await resolveOrCreateDirectory(path.dirname(fullPath)).then(
-                  () => {}
-                )
+                await resolveOrCreateDirectory(path.dirname(fullPath))
               }
 
               const writeStream = createWriteStream(fullPath)


### PR DESCRIPTION
We have gotten reports of errors using the latest download-artifact@main:
```
##[debug]Failed to download artifact after 5 retries due to Callback called multiple times. Retrying in 5 seconds...
Error: Unable to download artifact(s): Unable to download and extract artifact: Artifact download failed after 5 retries.
##[debug]response.message: Artifact download failed: Blob storage chunk did not respond in 30000ms
##[debug]response.message: Artifact download failed: Blob storage chunk did not respond in 30000ms
##[debug]response.message: Artifact download failed: Blob storage chunk did not respond in 30000ms
##[debug]response.message: Artifact download failed: Blob storage chunk did not respond in 30000ms
##[debug]response.message: Artifact download failed: Blob storage chunk did not respond in 30000ms
##[debug]Node Action run completed with exit code 1
``` 
Given `Callback called multiple times` it seems like it's attempting to create the directory and calling `callback` twice. It should only be called once when the file is extracted.

Part of https://github.com/actions/download-artifact/issues/302