### PR TITLE
bump @actions/attest to 1.0.0

### DIFF
--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/attest",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/github": "^6.0.0",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",


### PR DESCRIPTION
Updating the version for the `@actions/attest` package to 1.0.0 before initial publish.