### PR TITLE
Correct path on codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 /packages/artifact/   @actions/artifacts-actions
 /packages/cache/      @actions/actions-cache
-/package/attest/      @actions/package-security
+/packages/attest/      @actions/package-security


### PR DESCRIPTION
This newly added package should have a different owner, but the package path is incorrect. This fix addresses that