### PR TITLE
publish npm packages with build provenance

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -62,7 +62,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.TOKEN }}
 
       - name: publish
-        run: npm publish *.tgz
+        run: npm publish --provenance *.tgz
 
       - name: notify slack on failure
         if: failure()


### PR DESCRIPTION
Updates the `releases` workflow to publish npm packages with build provenance information.

The build provenance attestation will be attached the package and can be verified with the `npm audit signatures` command.

Packages published with provenance also get a badge like this when viewed on the npmjs registry.
<img width="800" alt="image" src="https://github.com/actions/toolkit/assets/398027/cbbf81ef-4796-41c9-8fd3-e5c454232531">

See https://docs.npmjs.com/generating-provenance-statements
