### PR TITLE
Add info level logging for zip extract

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/artifact Releases
 
+### 2.1.4
+
+- Adds info-level logging for zip extraction
+
 ### 2.1.3
 
 - Fixes a bug in the extract logic updated in 2.1.2

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -112,7 +112,6 @@ export async function streamExtractExternal(
               reject(new Error(`Malformed extraction path: ${fullPath}`))
             }
 
-            core.debug(`Extracting artifact entry: ${fullPath}`)
             if (entry.type === 'Directory') {
               if (!createdDirectories.has(fullPath)) {
                 createdDirectories.add(fullPath)
@@ -125,6 +124,7 @@ export async function streamExtractExternal(
                 callback()
               }
             } else {
+              core.info(`Extracting artifact entry: ${fullPath}`)
               if (!createdDirectories.has(path.dirname(fullPath))) {
                 createdDirectories.add(path.dirname(fullPath))
                 await resolveOrCreateDirectory(path.dirname(fullPath))


### PR DESCRIPTION
Adding info level logging for extraction provides more clarity to end users on what is being extracted.