### PR TITLE
fix #1579: add test to check getCacheVersion does not mutate arguments

### DIFF
--- a/packages/cache/__tests__/cacheHttpClient.test.ts
+++ b/packages/cache/__tests__/cacheHttpClient.test.ts
@@ -5,6 +5,12 @@ import {DownloadOptions, getDownloadOptions} from '../src/options'
 
 jest.mock('../src/internal/downloadUtils')
 
+test('getCacheVersion does not mutate arguments', async () => {
+  const paths = ['node_modules']
+  getCacheVersion(paths, undefined, true)
+  expect(paths).toEqual(['node_modules'])
+})
+
 test('getCacheVersion with one path returns version', async () => {
   const paths = ['node_modules']
   const result = getCacheVersion(paths, undefined, true)


### PR DESCRIPTION
Hi @bethanyj28 - this is just the (tiny) test from [this PR](https://github.com/actions/toolkit/pull/1587). I couldn't reopen the PR due to permissions, so I made a new one.