### PR TITLE
Expose RequestError

### DIFF
--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -12,7 +12,8 @@
         "@actions/http-client": "^2.2.0",
         "@octokit/core": "^5.0.1",
         "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/request-error": "^5.0.1"
       },
       "devDependencies": {
         "proxy": "^2.1.1"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -41,7 +41,8 @@
     "@actions/http-client": "^2.2.0",
     "@octokit/core": "^5.0.1",
     "@octokit/plugin-paginate-rest": "^9.0.0",
-    "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+    "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+    "@octokit/request-error": "^5.0.1"
   },
   "devDependencies": {
     "proxy": "^2.1.1"

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -3,6 +3,7 @@ import {GitHub, getOctokitOptions} from './utils'
 
 // octokit + plugins
 import {OctokitOptions, OctokitPlugin} from '@octokit/core/dist-types/types'
+export {RequestError} from '@octokit/request-error';
 
 export const context = new Context.Context()
 


### PR DESCRIPTION
This PR exposes `RequestError` which is the error class used by any of the octokit request functions:

```ts
try {
   await octokit.rest.git.getRef({
      owner,
      repo,
      ref,
    });
  } catch (err: unknown | RequestError) {
    if (err instanceof RequestError && err.status === 404) {
      // ...
    }
  }
 ```
 
 It is important that this is exposed by this library because it originates from the `@octokit/request-error` package, however if the user installs the wrong version of `@octokit/request-error` that does not match the one imported by this library via `@octokit/core` then you are unable to use `instanceof` checks to narrow this error.
 
 As an end user of this library it is not easy to keep these versions in lock-step and is greatly simplified if this library just exports the specific object it already uses.