### PR TITLE
(@actions/attest) build provenance statement from OIDC claims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5781,9 +5781,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {

--- a/packages/attest/README.md
+++ b/packages/attest/README.md
@@ -112,6 +112,10 @@ export type AttestProvenanceOptions = {
   sigstore?: 'public-good' | 'github'
   // Whether to skip writing the attestation to the GH attestations API.
   skipWrite?: boolean
+  // Issuer URL responsible for minting the OIDC token from which the
+  // provenance data is read. Defaults to
+  // 'https://token.actions.githubusercontent.com".
+  issuer?: string
 }
 ```
 

--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+### 1.1.0
+
+- Updates the `attestProvenance` function to retrieve a token from the GitHub OIDC provider and use the token claims to populate the provenance statement.
+
 ### 1.0.0
 
 - Initial release

--- a/packages/attest/__tests__/__snapshots__/intoto.test.ts.snap
+++ b/packages/attest/__tests__/__snapshots__/intoto.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildIntotoStatement returns a provenance hydrated from env vars 1`] = `
+exports[`buildIntotoStatement returns an intoto statement 1`] = `
 {
   "_type": "https://in-toto.io/Statement/v1",
   "predicate": {

--- a/packages/attest/__tests__/__snapshots__/provenance.test.ts.snap
+++ b/packages/attest/__tests__/__snapshots__/provenance.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildSLSAProvenancePredicate returns a provenance hydrated from env vars 1`] = `
+exports[`provenance functions buildSLSAProvenancePredicate returns a provenance hydrated from an OIDC token 1`] = `
 {
   "params": {
     "buildDefinition": {

--- a/packages/attest/__tests__/intoto.test.ts
+++ b/packages/attest/__tests__/intoto.test.ts
@@ -16,7 +16,7 @@ describe('buildIntotoStatement', () => {
     }
   }
 
-  it('returns a provenance hydrated from env vars', () => {
+  it('returns an intoto statement', () => {
     const statement = buildIntotoStatement(subject, predicate)
     expect(statement).toMatchSnapshot()
   })

--- a/packages/attest/__tests__/oidc.test.ts
+++ b/packages/attest/__tests__/oidc.test.ts
@@ -1,0 +1,147 @@
+import * as jose from 'jose'
+import nock from 'nock'
+import {getIDTokenClaims} from '../src/oidc'
+
+describe('getIDTokenClaims', () => {
+  const originalEnv = process.env
+  const issuer = 'https://example.com'
+  const audience = 'nobody'
+  const requestToken = 'token'
+  const openidConfigPath = '/.well-known/openid-configuration'
+  const jwksPath = '/.well-known/jwks.json'
+  const tokenPath = '/token'
+  const openIDConfig = {jwks_uri: `${issuer}${jwksPath}`}
+
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  let key: any
+
+  beforeEach(async () => {
+    process.env = {
+      ...originalEnv,
+      ACTIONS_ID_TOKEN_REQUEST_URL: `${issuer}${tokenPath}?`,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: requestToken
+    }
+
+    // Generate JWT signing key
+    key = await jose.generateKeyPair('PS256')
+
+    // Create JWK and JWKS
+    const jwk = await jose.exportJWK(key.publicKey)
+    const jwks = {keys: [jwk]}
+
+    nock(issuer).get(openidConfigPath).reply(200, openIDConfig)
+    nock(issuer).get(jwksPath).reply(200, jwks)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('when ID token is valid', () => {
+    const claims = {
+      iss: issuer,
+      aud: audience,
+      ref: 'ref',
+      sha: 'sha',
+      repository: 'repo',
+      event_name: 'push',
+      workflow_ref: 'main',
+      repository_id: '1',
+      repository_owner_id: '1',
+      runner_environment: 'github-hosted',
+      run_id: '1',
+      run_attempt: '1'
+    }
+
+    beforeEach(async () => {
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({alg: 'PS256'})
+        .sign(key.privateKey)
+
+      nock(issuer).get(tokenPath).query({audience}).reply(200, {value: jwt})
+    })
+
+    it('returns the ID token claims', async () => {
+      const result = await getIDTokenClaims(issuer)
+      expect(result).toEqual(claims)
+    })
+  })
+
+  describe('when ID token is missing required claims', () => {
+    const claims = {
+      iss: issuer,
+      aud: audience
+    }
+
+    beforeEach(async () => {
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({alg: 'PS256'})
+        .sign(key.privateKey)
+
+      nock(issuer).get(tokenPath).query({audience}).reply(200, {value: jwt})
+    })
+
+    it('throws an error', async () => {
+      await expect(getIDTokenClaims(issuer)).rejects.toThrow(/missing claims/i)
+    })
+  })
+
+  describe('when ID has the wrong issuer', () => {
+    const claims = {foo: 'bar', iss: 'foo', aud: 'nobody'}
+
+    beforeEach(async () => {
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({alg: 'PS256'})
+        .sign(key.privateKey)
+
+      nock(issuer).get(tokenPath).query({audience}).reply(200, {value: jwt})
+    })
+
+    it('throws an error', async () => {
+      await expect(getIDTokenClaims(issuer)).rejects.toThrow(/issuer invalid/)
+    })
+  })
+
+  describe('when ID has the wrong audience', () => {
+    const claims = {foo: 'bar', iss: issuer, aud: 'bar'}
+
+    beforeEach(async () => {
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({alg: 'PS256'})
+        .sign(key.privateKey)
+
+      nock(issuer).get(tokenPath).query({audience}).reply(200, {value: jwt})
+    })
+
+    it('throw an error', async () => {
+      await expect(getIDTokenClaims(issuer)).rejects.toThrow(/audience invalid/)
+    })
+  })
+
+  describe('when openid config cannot be retrieved', () => {
+    const claims = {foo: 'bar', iss: issuer, aud: 'nobody'}
+
+    beforeEach(async () => {
+      const jwt = await new jose.SignJWT(claims)
+        .setProtectedHeader({alg: 'PS256'})
+        .sign(key.privateKey)
+
+      nock(issuer).get(tokenPath).query({audience}).reply(200, {value: jwt})
+
+      // Disable the openid config endpoint
+      nock.removeInterceptor({
+        proto: 'https',
+        hostname: 'example.com',
+        port: '443',
+        method: 'GET',
+        path: openidConfigPath
+      })
+    })
+
+    it('throws an error', async () => {
+      await expect(getIDTokenClaims(issuer)).rejects.toThrow(
+        /failed to get id/i
+      )
+    })
+  })
+})

--- a/packages/attest/__tests__/provenance.test.ts
+++ b/packages/attest/__tests__/provenance.test.ts
@@ -1,213 +1,240 @@
 import * as github from '@actions/github'
 import {mockFulcio, mockRekor, mockTSA} from '@sigstore/mock'
+import * as jose from 'jose'
 import nock from 'nock'
 import {SIGSTORE_GITHUB, SIGSTORE_PUBLIC_GOOD} from '../src/endpoints'
 import {attestProvenance, buildSLSAProvenancePredicate} from '../src/provenance'
 
-// Dummy workflow environment
-const env = {
-  GITHUB_REPOSITORY: 'owner/repo',
-  GITHUB_REF: 'refs/heads/main',
-  GITHUB_SHA: 'babca52ab0c93ae16539e5923cb0d7403b9a093b',
-  GITHUB_WORKFLOW_REF: 'owner/repo/.github/workflows/main.yml@main',
-  GITHUB_SERVER_URL: 'https://github.com',
-  GITHUB_EVENT_NAME: 'push',
-  GITHUB_REPOSITORY_ID: 'repo-id',
-  GITHUB_REPOSITORY_OWNER_ID: 'owner-id',
-  GITHUB_RUN_ID: 'run-id',
-  GITHUB_RUN_ATTEMPT: 'run-attempt',
-  RUNNER_ENVIRONMENT: 'github-hosted'
-}
-
-describe('buildSLSAProvenancePredicate', () => {
-  it('returns a provenance hydrated from env vars', () => {
-    const predicate = buildSLSAProvenancePredicate(env)
-    expect(predicate).toMatchSnapshot()
-  })
-})
-
-describe('attestProvenance', () => {
-  // Capture original environment variables so we can restore them after each
-  // test
+describe('provenance functions', () => {
   const originalEnv = process.env
+  const issuer = 'https://example.com'
+  const audience = 'nobody'
+  const jwksPath = '/.well-known/jwks.json'
+  const tokenPath = '/token'
 
-  // Subject to attest
-  const subjectName = 'subjective'
-  const subjectDigest = {
-    sha256: '7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'
+  const claims = {
+    iss: issuer,
+    aud: 'nobody',
+    repository: 'owner/repo',
+    ref: 'refs/heads/main',
+    sha: 'babca52ab0c93ae16539e5923cb0d7403b9a093b',
+    workflow_ref: 'owner/repo/.github/workflows/main.yml@main',
+    event_name: 'push',
+    repository_id: 'repo-id',
+    repository_owner_id: 'owner-id',
+    run_id: 'run-id',
+    run_attempt: 'run-attempt',
+    runner_environment: 'github-hosted'
   }
 
-  // Fake an OIDC token
-  const oidcPayload = {sub: 'foo@bar.com', iss: ''}
-  const oidcToken = `.${Buffer.from(JSON.stringify(oidcPayload)).toString(
-    'base64'
-  )}.}`
-
-  const tokenURL = 'https://token.url'
-  const attestationID = '1234567890'
-
   beforeEach(async () => {
-    jest.clearAllMocks()
-
-    nock(tokenURL)
-      .get('/')
-      .query({audience: 'sigstore'})
-      .reply(200, {value: oidcToken})
-
-    // Set-up GHA environment variables
     process.env = {
       ...originalEnv,
-      ...env,
-      ACTIONS_ID_TOKEN_REQUEST_URL: tokenURL,
-      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'token'
+      ACTIONS_ID_TOKEN_REQUEST_URL: `${issuer}${tokenPath}?`,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'token',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_REPOSITORY: claims.repository
     }
+
+    // Generate JWT signing key
+    const key = await jose.generateKeyPair('PS256')
+
+    // Create JWK, JWKS, and JWT
+    const jwk = await jose.exportJWK(key.publicKey)
+    const jwks = {keys: [jwk]}
+    const jwt = await new jose.SignJWT(claims)
+      .setProtectedHeader({alg: 'PS256'})
+      .sign(key.privateKey)
+
+    // Mock OpenID configuration and JWKS endpoints
+    nock(issuer)
+      .get('/.well-known/openid-configuration')
+      .reply(200, {jwks_uri: `${issuer}${jwksPath}`})
+    nock(issuer).get(jwksPath).reply(200, jwks)
+
+    // Mock OIDC token endpoint for populating the provenance
+    nock(issuer).get(tokenPath).query({audience}).reply(200, {value: jwt})
   })
 
   afterEach(() => {
-    // Restore the original environment
     process.env = originalEnv
   })
 
-  describe('when using the github Sigstore instance', () => {
-    const {fulcioURL, tsaServerURL} = SIGSTORE_GITHUB
-
-    beforeEach(async () => {
-      // Mock Sigstore
-      await mockFulcio({baseURL: fulcioURL, strict: false})
-      await mockTSA({baseURL: tsaServerURL})
-
-      // Mock GH attestations API
-      nock('https://api.github.com')
-        .post(/^\/repos\/.*\/.*\/attestations$/)
-        .reply(201, {id: attestationID})
-    })
-
-    describe('when the sigstore instance is explicitly set', () => {
-      it('attests provenance', async () => {
-        const attestation = await attestProvenance({
-          subjectName,
-          subjectDigest,
-          token: 'token',
-          sigstore: 'github'
-        })
-
-        expect(attestation).toBeDefined()
-        expect(attestation.bundle).toBeDefined()
-        expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
-        expect(attestation.tlogID).toBeUndefined()
-        expect(attestation.attestationID).toBe(attestationID)
-      })
-    })
-
-    describe('when the sigstore instance is inferred from the repo visibility', () => {
-      const savedRepository = github.context.payload.repository
-
-      beforeEach(() => {
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        github.context.payload.repository = {visibility: 'private'} as any
-      })
-
-      afterEach(() => {
-        github.context.payload.repository = savedRepository
-      })
-
-      it('attests provenance', async () => {
-        const attestation = await attestProvenance({
-          subjectName,
-          subjectDigest,
-          token: 'token'
-        })
-
-        expect(attestation).toBeDefined()
-        expect(attestation.bundle).toBeDefined()
-        expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
-        expect(attestation.tlogID).toBeUndefined()
-        expect(attestation.attestationID).toBe(attestationID)
-      })
+  describe('buildSLSAProvenancePredicate', () => {
+    it('returns a provenance hydrated from an OIDC token', async () => {
+      const predicate = await buildSLSAProvenancePredicate(issuer)
+      expect(predicate).toMatchSnapshot()
     })
   })
 
-  describe('when using the public-good Sigstore instance', () => {
-    const {fulcioURL, rekorURL} = SIGSTORE_PUBLIC_GOOD
+  describe('attestProvenance', () => {
+    // Subject to attest
+    const subjectName = 'subjective'
+    const subjectDigest = {
+      sha256: '7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'
+    }
+
+    // Fake an OIDC token
+    const oidcPayload = {sub: 'foo@bar.com', iss: ''}
+    const oidcToken = `.${Buffer.from(JSON.stringify(oidcPayload)).toString(
+      'base64'
+    )}.}`
+
+    const attestationID = '1234567890'
 
     beforeEach(async () => {
-      // Mock Sigstore
-      await mockFulcio({baseURL: fulcioURL, strict: false})
-      await mockRekor({baseURL: rekorURL})
-
-      // Mock GH attestations API
-      nock('https://api.github.com')
-        .post(/^\/repos\/.*\/.*\/attestations$/)
-        .reply(201, {id: attestationID})
+      nock(issuer)
+        .get(tokenPath)
+        .query({audience: 'sigstore'})
+        .reply(200, {value: oidcToken})
     })
 
-    describe('when the sigstore instance is explicitly set', () => {
+    describe('when using the github Sigstore instance', () => {
+      const {fulcioURL, tsaServerURL} = SIGSTORE_GITHUB
+
+      beforeEach(async () => {
+        // Mock Sigstore
+        await mockFulcio({baseURL: fulcioURL, strict: false})
+        await mockTSA({baseURL: tsaServerURL})
+
+        // Mock GH attestations API
+        nock('https://api.github.com')
+          .post(/^\/repos\/.*\/.*\/attestations$/)
+          .reply(201, {id: attestationID})
+      })
+
+      describe('when the sigstore instance is explicitly set', () => {
+        it('attests provenance', async () => {
+          const attestation = await attestProvenance({
+            subjectName,
+            subjectDigest,
+            token: 'token',
+            sigstore: 'github',
+            issuer
+          })
+
+          expect(attestation).toBeDefined()
+          expect(attestation.bundle).toBeDefined()
+          expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
+          expect(attestation.tlogID).toBeUndefined()
+          expect(attestation.attestationID).toBe(attestationID)
+        })
+      })
+
+      describe('when the sigstore instance is inferred from the repo visibility', () => {
+        const savedRepository = github.context.payload.repository
+
+        beforeEach(() => {
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          github.context.payload.repository = {visibility: 'private'} as any
+        })
+
+        afterEach(() => {
+          github.context.payload.repository = savedRepository
+        })
+
+        it('attests provenance', async () => {
+          const attestation = await attestProvenance({
+            subjectName,
+            subjectDigest,
+            token: 'token',
+            issuer
+          })
+
+          expect(attestation).toBeDefined()
+          expect(attestation.bundle).toBeDefined()
+          expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
+          expect(attestation.tlogID).toBeUndefined()
+          expect(attestation.attestationID).toBe(attestationID)
+        })
+      })
+    })
+
+    describe('when using the public-good Sigstore instance', () => {
+      const {fulcioURL, rekorURL} = SIGSTORE_PUBLIC_GOOD
+
+      beforeEach(async () => {
+        // Mock Sigstore
+        await mockFulcio({baseURL: fulcioURL, strict: false})
+        await mockRekor({baseURL: rekorURL})
+
+        // Mock GH attestations API
+        nock('https://api.github.com')
+          .post(/^\/repos\/.*\/.*\/attestations$/)
+          .reply(201, {id: attestationID})
+      })
+
+      describe('when the sigstore instance is explicitly set', () => {
+        it('attests provenance', async () => {
+          const attestation = await attestProvenance({
+            subjectName,
+            subjectDigest,
+            token: 'token',
+            sigstore: 'public-good',
+            issuer
+          })
+
+          expect(attestation).toBeDefined()
+          expect(attestation.bundle).toBeDefined()
+          expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
+          expect(attestation.tlogID).toBeDefined()
+          expect(attestation.attestationID).toBe(attestationID)
+        })
+      })
+
+      describe('when the sigstore instance is inferred from the repo visibility', () => {
+        const savedRepository = github.context.payload.repository
+
+        beforeEach(() => {
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          github.context.payload.repository = {visibility: 'public'} as any
+        })
+
+        afterEach(() => {
+          github.context.payload.repository = savedRepository
+        })
+
+        it('attests provenance', async () => {
+          const attestation = await attestProvenance({
+            subjectName,
+            subjectDigest,
+            token: 'token',
+            issuer
+          })
+
+          expect(attestation).toBeDefined()
+          expect(attestation.bundle).toBeDefined()
+          expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
+          expect(attestation.tlogID).toBeDefined()
+          expect(attestation.attestationID).toBe(attestationID)
+        })
+      })
+    })
+
+    describe('when skipWrite is set to true', () => {
+      const {fulcioURL, rekorURL} = SIGSTORE_PUBLIC_GOOD
+      beforeEach(async () => {
+        // Mock Sigstore
+        await mockFulcio({baseURL: fulcioURL, strict: false})
+        await mockRekor({baseURL: rekorURL})
+      })
+
       it('attests provenance', async () => {
         const attestation = await attestProvenance({
           subjectName,
           subjectDigest,
           token: 'token',
-          sigstore: 'public-good'
+          sigstore: 'public-good',
+          skipWrite: true,
+          issuer
         })
 
         expect(attestation).toBeDefined()
         expect(attestation.bundle).toBeDefined()
         expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
         expect(attestation.tlogID).toBeDefined()
-        expect(attestation.attestationID).toBe(attestationID)
+        expect(attestation.attestationID).toBeUndefined()
       })
-    })
-
-    describe('when the sigstore instance is inferred from the repo visibility', () => {
-      const savedRepository = github.context.payload.repository
-
-      beforeEach(() => {
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        github.context.payload.repository = {visibility: 'public'} as any
-      })
-
-      afterEach(() => {
-        github.context.payload.repository = savedRepository
-      })
-
-      it('attests provenance', async () => {
-        const attestation = await attestProvenance({
-          subjectName,
-          subjectDigest,
-          token: 'token'
-        })
-
-        expect(attestation).toBeDefined()
-        expect(attestation.bundle).toBeDefined()
-        expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
-        expect(attestation.tlogID).toBeDefined()
-        expect(attestation.attestationID).toBe(attestationID)
-      })
-    })
-  })
-
-  describe('when skipWrite is set to true', () => {
-    const {fulcioURL, rekorURL} = SIGSTORE_PUBLIC_GOOD
-    beforeEach(async () => {
-      // Mock Sigstore
-      await mockFulcio({baseURL: fulcioURL, strict: false})
-      await mockRekor({baseURL: rekorURL})
-    })
-
-    it('attests provenance', async () => {
-      const attestation = await attestProvenance({
-        subjectName,
-        subjectDigest,
-        token: 'token',
-        sigstore: 'public-good',
-        skipWrite: true
-      })
-
-      expect(attestation).toBeDefined()
-      expect(attestation.bundle).toBeDefined()
-      expect(attestation.certificate).toMatch(/-----BEGIN CERTIFICATE-----/)
-      expect(attestation.tlogID).toBeDefined()
-      expect(attestation.attestationID).toBeUndefined()
     })
   })
 })

--- a/packages/attest/__tests__/store.test.ts
+++ b/packages/attest/__tests__/store.test.ts
@@ -38,7 +38,7 @@ describe('writeAttestation', () => {
         .reply(500, 'oops')
     })
 
-    it('persists the attestation', async () => {
+    it('throws an error', async () => {
       await expect(writeAttestation(attestation, token)).rejects.toThrow(/oops/)
     })
   })

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -9,16 +9,31 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
+        "@actions/http-client": "^2.2.1",
         "@sigstore/bundle": "^2.2.0",
         "@sigstore/sign": "^2.2.3",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "make-fetch-happen": "^13.0.0"
       },
       "devDependencies": {
         "@sigstore/mock": "^0.6.5",
         "@sigstore/rekor-types": "^2.0.0",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/make-fetch-happen": "^10.0.4",
+        "jose": "^5.2.3",
         "nock": "^13.5.1"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@actions/github": {
@@ -33,9 +48,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
-      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
+      "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -463,6 +478,58 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.43",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+      "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/make-fetch-happen": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.4.tgz",
@@ -474,11 +541,15 @@
         "@types/ssri": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
     "node_modules/@types/node": {
       "version": "20.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
       "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -493,11 +564,40 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.14",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
+      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
     "node_modules/@types/retry": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
       "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/ssri": {
       "version": "7.1.5",
@@ -590,6 +690,11 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
@@ -719,6 +824,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -914,9 +1027,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
-      "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -933,6 +1046,115 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.1.0.tgz",
+      "integrity": "sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==",
+      "dependencies": {
+        "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.2",
+        "debug": "^4.3.4",
+        "jose": "^4.14.6",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/jose": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -940,6 +1162,29 @@
       "engines": {
         "node": "14 || >=16.14"
       }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.2.0.tgz",
+      "integrity": "sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==",
+      "dependencies": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/make-fetch-happen": {
       "version": "13.0.0",
@@ -1241,6 +1486,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
     "node_modules/pvtsutils": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
@@ -1272,6 +1522,25 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1565,8 +1834,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -1594,6 +1862,14 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/webcrypto-core": {
       "version": "1.7.8",
@@ -1718,6 +1994,15 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
     "@actions/github": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
@@ -1730,9 +2015,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
-      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
+      "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
       "requires": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -2091,6 +2376,58 @@
         "make-fetch-happen": "^13.0.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.43",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+      "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+    },
+    "@types/jsonwebtoken": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/make-fetch-happen": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.4.tgz",
@@ -2102,11 +2439,15 @@
         "@types/ssri": "*"
       }
     },
+    "@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
     "@types/node": {
       "version": "20.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
       "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
-      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -2121,11 +2462,40 @@
         "form-data": "^4.0.0"
       }
     },
+    "@types/qs": {
+      "version": "6.9.14",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
+      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
     "@types/retry": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
       "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true
+    },
+    "@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "requires": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "@types/ssri": {
       "version": "7.1.5",
@@ -2197,6 +2567,11 @@
       "requires": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "bytestreamjs": {
       "version": "2.0.1",
@@ -2294,6 +2669,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -2436,9 +2819,9 @@
       }
     },
     "jose": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.2.tgz",
-      "integrity": "sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
       "dev": true
     },
     "jsbn": {
@@ -2452,10 +2835,136 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jwks-rsa": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.1.0.tgz",
+      "integrity": "sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==",
+      "requires": {
+        "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.2",
+        "debug": "^4.3.4",
+        "jose": "^4.14.6",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "4.15.5",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+          "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg=="
+        }
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q=="
+    },
+    "lru-memoizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.2.0.tgz",
+      "integrity": "sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "integrity": "sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==",
+          "requires": {
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+        }
+      }
     },
     "make-fetch-happen": {
       "version": "13.0.0",
@@ -2679,6 +3188,11 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
     "pvtsutils": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
@@ -2704,6 +3218,11 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2924,8 +3443,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unique-filename": {
       "version": "3.0.0",
@@ -2947,6 +3465,11 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "webcrypto-core": {
       "version": "1.7.8",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",
@@ -37,13 +37,19 @@
   "devDependencies": {
     "@sigstore/mock": "^0.6.5",
     "@sigstore/rekor-types": "^2.0.0",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/make-fetch-happen": "^10.0.4",
+    "jose": "^5.2.3",
     "nock": "^13.5.1"
   },
   "dependencies": {
+    "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
+    "@actions/http-client": "^2.2.1",
     "@sigstore/bundle": "^2.2.0",
     "@sigstore/sign": "^2.2.3",
+    "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.1.0",
     "make-fetch-happen": "^13.0.0"
   }
 }

--- a/packages/attest/src/oidc.ts
+++ b/packages/attest/src/oidc.ts
@@ -1,0 +1,102 @@
+import {getIDToken} from '@actions/core'
+import {HttpClient} from '@actions/http-client'
+import * as jwt from 'jsonwebtoken'
+import jwks from 'jwks-rsa'
+
+const OIDC_AUDIENCE = 'nobody'
+
+const REQUIRED_CLAIMS = [
+  'iss',
+  'ref',
+  'sha',
+  'repository',
+  'event_name',
+  'workflow_ref',
+  'repository_id',
+  'repository_owner_id',
+  'runner_environment',
+  'run_id',
+  'run_attempt'
+] as const
+
+export type ClaimSet = {[K in (typeof REQUIRED_CLAIMS)[number]]: string}
+
+type OIDCConfig = {
+  jwks_uri: string
+}
+
+export const getIDTokenClaims = async (issuer: string): Promise<ClaimSet> => {
+  try {
+    const token = await getIDToken(OIDC_AUDIENCE)
+    const claims = await decodeOIDCToken(token, issuer)
+    assertClaimSet(claims)
+    return claims
+  } catch (error) {
+    throw new Error(`Failed to get ID token: ${error.message}`)
+  }
+}
+
+const decodeOIDCToken = async (
+  token: string,
+  issuer: string
+): Promise<jwt.JwtPayload> => {
+  // Verify and decode token
+  return new Promise((resolve, reject) => {
+    jwt.verify(
+      token,
+      getPublicKey(issuer),
+      {audience: OIDC_AUDIENCE, issuer},
+      (err, decoded) => {
+        if (err) {
+          reject(err)
+        } else if (!decoded || typeof decoded === 'string') {
+          reject(new Error('No decoded token'))
+        } else {
+          resolve(decoded)
+        }
+      }
+    )
+  })
+}
+
+// Returns a callback to locate the public key for the given JWT header. This
+// involves two calls:
+// 1. Fetch the OpenID configuration to get the JWKS URI.
+// 2. Fetch the public key from the JWKS URI.
+const getPublicKey =
+  (issuer: string): jwt.GetPublicKeyOrSecret =>
+  (header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) => {
+    // Look up the JWKS URI from the issuer's OpenID configuration
+    new HttpClient('actions/attest')
+      .getJson<OIDCConfig>(`${issuer}/.well-known/openid-configuration`)
+      .then(data => {
+        if (!data.result) {
+          callback(new Error('No OpenID configuration found'))
+        } else {
+          // Fetch the public key from the JWKS URI
+          jwks({jwksUri: data.result.jwks_uri}).getSigningKey(
+            header.kid,
+            (err, key) => {
+              callback(err, key?.getPublicKey())
+            }
+          )
+        }
+      })
+      .catch(err => {
+        callback(err)
+      })
+  }
+
+function assertClaimSet(claims: jwt.JwtPayload): asserts claims is ClaimSet {
+  const missingClaims: string[] = []
+
+  for (const claim of REQUIRED_CLAIMS) {
+    if (!(claim in claims)) {
+      missingClaims.push(claim)
+    }
+  }
+
+  if (missingClaims.length > 0) {
+    throw new Error(`Missing claims: ${missingClaims.join(', ')}`)
+  }
+}


### PR DESCRIPTION
Updates the `attestProvenance` function in the `@actions/attest` package so that the provenance statement is populated from data read from a verified GHA OIDC token.

Previously, the provenance data was read directly from the environment. With the new approach, an OIDC token is retrieved from the GHA issuer and the provenance statement is built from the claims present in that token. This more closely mirrors the approach that is used by Sigstore certificate authority (Fulcio) when it populates the claims in the signing certificate.