### PR TITLE
feat: allow passing custom `ACTIONS_CACHE_URL`

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -50,7 +50,7 @@ function checkKey(key: string): void {
  */
 
 export function isFeatureAvailable(): boolean {
-  return !!process.env['ACTIONS_CACHE_URL']
+  return !!process.env['CUSTOM_ACTIONS_CACHE_URL'] || !!process.env['ACTIONS_CACHE_URL']
 }
 
 /**

--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -40,7 +40,7 @@ import {
 const versionSalt = '1.0'
 
 function getCacheApiUrl(resource: string): string {
-  const baseUrl: string = process.env['ACTIONS_CACHE_URL'] || ''
+  const baseUrl: string = process.env['CUSTOM_ACTIONS_CACHE_URL'] || process.env['ACTIONS_CACHE_URL'] || ''
   if (!baseUrl) {
     throw new Error('Cache Service Url not found, unable to restore cache.')
   }


### PR DESCRIPTION
Closes #1051 

Currently it is not possible to overwrite the `ACTIONS_CACHE_URL` which is used for communicating with the cache api. The `ACTIONS_CACHE_URL` is always overwritten by the runner itself ([runner code snippet](https://github.com/actions/runner/blob/77e0bfbb8a8fde1f01fc1cf1ed2d7f0e81a0a407/src/Runner.Worker/Handlers/NodeScriptActionHandler.cs#L59)).

Being able to overwrite this environment variable is crucial for using the `actions/cache` action with self-hosted runners, as it allows for a self-hosted caching solution.

To set a custom `ACTIONS_CACHE_URL`, you just need to define the `CUSTOM_ACTIONS_CACHE_URL` (open for naming suggestions) env var, which takes precedence over the default cache url env var. 

Self-hosting an actions cache server is a much requested feature and this PR would make that way easier

Other issues/discussions:
- https://github.com/orgs/community/discussions/18549
- https://github.com/github/docs/issues/2271
- https://github.com/actions/runner/pull/3411