### PR TITLE
`@actions/core` logging - extract `AnnotationProperties` from `Error` instances

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -49,6 +49,18 @@ const testEnvVars = {
 const UUID = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
 const DELIMITER = `ghadelimiter_${UUID}`
 
+function extractErrorMetadata(error: Error) {
+  const stackLines = error.stack?.split(os.EOL) || []
+  const firstTraceLine = stackLines[1]
+  const match = firstTraceLine.match(/at (?:.*) \((.*):(\d+):(\d+)\)/) || []
+  const [, file, line, column] = match
+  return {
+    file,
+    line,
+    column
+  }
+}
+
 describe('@actions/core', () => {
   beforeAll(() => {
     const filePath = path.join(__dirname, `test`)
@@ -379,9 +391,14 @@ describe('@actions/core', () => {
 
   it('setFailed handles Error', () => {
     const message = 'this is my error message'
-    core.setFailed(new Error(message))
+    const error = new Error(message)
+
+    core.setFailed(error)
     expect(process.exitCode).toBe(core.ExitCode.Failure)
-    assertWriteCalls([`::error::Error: ${message}${os.EOL}`])
+    const {file, line, column} = extractErrorMetadata(error)
+    assertWriteCalls([
+      `::error title=Error,file=${file},line=${line},col=${column}::Error: ${message}${os.EOL}`
+    ])
   })
 
   it('error sets the correct error message', () => {
@@ -396,11 +413,15 @@ describe('@actions/core', () => {
 
   it('error handles an error object', () => {
     const message = 'this is my error message'
-    core.error(new Error(message))
-    assertWriteCalls([`::error::Error: ${message}${os.EOL}`])
+    const error = new Error(message)
+    core.error(error)
+    const {file, line, column} = extractErrorMetadata(error)
+    assertWriteCalls([
+      `::error title=Error,file=${file},line=${line},col=${column}::Error: ${message}${os.EOL}`
+    ])
   })
 
-  it('error handles parameters correctly', () => {
+  it('error handles custom properties correctly', () => {
     const message = 'this is my error message'
     core.error(new Error(message), {
       title: 'A title',
@@ -427,11 +448,15 @@ describe('@actions/core', () => {
 
   it('warning handles an error object', () => {
     const message = 'this is my error message'
-    core.warning(new Error(message))
-    assertWriteCalls([`::warning::Error: ${message}${os.EOL}`])
+    const error = new Error(message)
+    core.warning(error)
+    const {file, line, column} = extractErrorMetadata(error)
+    assertWriteCalls([
+      `::warning title=Error,file=${file},line=${line},col=${column}::Error: ${message}${os.EOL}`
+    ])
   })
 
-  it('warning handles parameters correctly', () => {
+  it('warning handles custom properties correctly', () => {
     const message = 'this is my error message'
     core.warning(new Error(message), {
       title: 'A title',
@@ -458,11 +483,15 @@ describe('@actions/core', () => {
 
   it('notice handles an error object', () => {
     const message = 'this is my error message'
-    core.notice(new Error(message))
-    assertWriteCalls([`::notice::Error: ${message}${os.EOL}`])
+    const error = new Error(message)
+    core.notice(error)
+    const {file, line, column} = extractErrorMetadata(error)
+    assertWriteCalls([
+      `::notice title=Error,file=${file},line=${line},col=${column}::Error: ${message}${os.EOL}`
+    ])
   })
 
-  it('notice handles parameters correctly', () => {
+  it('notice handles custom properties correctly', () => {
     const message = 'this is my error message'
     core.notice(new Error(message), {
       title: 'A title',

--- a/packages/core/__tests__/utils.test.ts
+++ b/packages/core/__tests__/utils.test.ts
@@ -1,0 +1,26 @@
+import {toAnnotationProperties} from '../src/utils'
+
+describe('@actions/core/src/utils', () => {
+  describe('.toAnnotationProperties', () => {
+    it('extracts title only from Error instance without a parseable stack', () => {
+      const error = new TypeError('Test error')
+      error.stack = ''
+      expect(toAnnotationProperties(error)).toEqual({
+        title: 'TypeError',
+        file: undefined,
+        startLine: undefined,
+        startColumn: undefined
+      })
+    })
+
+    it('extracts AnnotationProperties from Error instance', () => {
+      const error = new ReferenceError('Test error')
+      expect(toAnnotationProperties(error)).toEqual({
+        title: 'ReferenceError',
+        file: expect.stringMatching(/utils\.test\.ts$/),
+        startLine: expect.any(Number),
+        startColumn: expect.any(Number)
+      })
+    })
+  })
+})

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1",
+        "error-stack-parser": "^2.1.4",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -50,6 +51,19 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -101,6 +115,19 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
+    },
+    "error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "tunnel": {
       "version": "0.0.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@actions/exec": "^1.1.1",
     "@actions/http-client": "^2.0.1",
+    "error-stack-parser": "^2.1.4",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,7 +1,10 @@
 import {issue, issueCommand} from './command'
 import {issueFileCommand, prepareKeyValueMessage} from './file-command'
-import {toCommandProperties, toCommandValue} from './utils'
-
+import {
+  toAnnotationProperties,
+  toCommandProperties,
+  toCommandValue
+} from './utils'
 import * as os from 'os'
 import * as path from 'path'
 
@@ -251,6 +254,12 @@ export function error(
   message: string | Error,
   properties: AnnotationProperties = {}
 ): void {
+  // If no properties are provided, try to extract them from the Error instance
+  properties =
+    Object.keys(properties).length === 0 && message instanceof Error
+      ? toAnnotationProperties(message)
+      : properties
+
   issueCommand(
     'error',
     toCommandProperties(properties),
@@ -267,6 +276,12 @@ export function warning(
   message: string | Error,
   properties: AnnotationProperties = {}
 ): void {
+  // If no properties are provided, try to extract them from the Error instance
+  properties =
+    Object.keys(properties).length === 0 && message instanceof Error
+      ? toAnnotationProperties(message)
+      : properties
+
   issueCommand(
     'warning',
     toCommandProperties(properties),
@@ -283,6 +298,12 @@ export function notice(
   message: string | Error,
   properties: AnnotationProperties = {}
 ): void {
+  // If no properties are provided, try to extract them from the Error instance
+  properties =
+    Object.keys(properties).length === 0 && message instanceof Error
+      ? toAnnotationProperties(message)
+      : properties
+
   issueCommand(
     'notice',
     toCommandProperties(properties),

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,6 +3,7 @@
 
 import {AnnotationProperties} from './core'
 import {CommandProperties} from './command'
+import ErrorStackParser from 'error-stack-parser'
 
 /**
  * Sanitizes an input into a string so it can be passed into issueCommand safely
@@ -37,5 +38,23 @@ export function toCommandProperties(
     endLine: annotationProperties.endLine,
     col: annotationProperties.startColumn,
     endColumn: annotationProperties.endColumn
+  }
+}
+
+export function toAnnotationProperties(error: Error): AnnotationProperties {
+  let firstFrame
+
+  try {
+    const stack = ErrorStackParser.parse(error)
+    firstFrame = stack?.[0]
+  } catch (parseError) {
+    // If we can't parse the stack, we'll just skip it
+  }
+
+  return {
+    title: error.name,
+    file: firstFrame?.fileName,
+    startLine: firstFrame?.lineNumber,
+    startColumn: firstFrame?.columnNumber
   }
 }


### PR DESCRIPTION
:warning: :octocat: This should probably be considered a breaking change! Ergo, it should result in a SemVer major version bump. ⬆️ 

### Background

While [improving a logging situation in `actions/configure-pages`](https://github.com/actions/configure-pages/pull/138), I had the idea that it might be nice if the `@actions/core` module's `error`, `warning`, and `notice` commands would implicitly extract their optional `AnnotationProperties` metadata from sometimes-provided `Error` instance's stack trace. 💡 

This PR is my rough cut at what that might look like. 💝 

Totally open to revisions, refactoring, etc. 👂🏻 

### Why is it a breaking change? 🛠️ 

This should probably be considered a breaking change because it will alter the default behavior of using the `core.error(error)`, `core.warning(error)`, and `core.notice(error)` method signatures.

More notably, passing in an empty object as the second argument (e.g. `core.warning(error, {})` will _still_ result in the `AnnotationProperties` metadata being extracted from the `error`, which may not be ideal since it makes it a bit harder to workaround.

ℹ️ A feasible workaround would be passing in a second argument that contains at least one key, e.g. `core.warning(error, { title: 'WARNING!' })`,