### PR TITLE
(@actions/attest) generate attestations using v0.3 bundle format

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,11 @@
 # @actions/attest Releases
 
+### 1.2.0
+
+- Generate attestations using the v0.3 Sigstore bundle format.
+- Bump @sigstore/bundle from 2.2.0 to 2.3.0.
+- Bump @sigstore/sign from 2.2.3 to 2.3.0.
+
 ### 1.1.0
 
 - Updates the `attestProvenance` function to retrieve a token from the GitHub OIDC provider and use the token claims to populate the provenance statement.

--- a/packages/attest/__tests__/sign.test.ts
+++ b/packages/attest/__tests__/sign.test.ts
@@ -64,13 +64,11 @@ describe('signProvenance', () => {
 
       expect(att).toBeDefined()
       expect(att.mediaType).toEqual(
-        'application/vnd.dev.sigstore.bundle+json;version=0.2'
+        'application/vnd.dev.sigstore.bundle.v0.3+json'
       )
 
       expect(att.content.$case).toEqual('dsseEnvelope')
-      expect(att.verificationMaterial.content.$case).toEqual(
-        'x509CertificateChain'
-      )
+      expect(att.verificationMaterial.content.$case).toEqual('certificate')
       expect(att.verificationMaterial.tlogEntries).toHaveLength(1)
       expect(
         att.verificationMaterial.timestampVerificationData?.rfc3161Timestamps
@@ -89,13 +87,11 @@ describe('signProvenance', () => {
 
       expect(att).toBeDefined()
       expect(att.mediaType).toEqual(
-        'application/vnd.dev.sigstore.bundle+json;version=0.2'
+        'application/vnd.dev.sigstore.bundle.v0.3+json'
       )
 
       expect(att.content.$case).toEqual('dsseEnvelope')
-      expect(att.verificationMaterial.content.$case).toEqual(
-        'x509CertificateChain'
-      )
+      expect(att.verificationMaterial.content.$case).toEqual('certificate')
       expect(att.verificationMaterial.tlogEntries).toHaveLength(0)
       expect(
         att.verificationMaterial.timestampVerificationData?.rfc3161Timestamps

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@actions/attest",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
         "@actions/http-client": "^2.2.1",
-        "@sigstore/bundle": "^2.2.0",
-        "@sigstore/sign": "^2.2.3",
+        "@sigstore/bundle": "^2.3.0",
+        "@sigstore/sign": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",
         "make-fetch-happen": "^13.0.0"
@@ -408,11 +408,11 @@
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.2.0.tgz",
-      "integrity": "sha512-5VI58qgNs76RDrwXNhpmyN/jKpq9evV/7f1XrcqcAfvxDl5SeVY/I5Rmfe96ULAV7/FK5dge9RBKGBJPhL1WsQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.0.tgz",
+      "integrity": "sha512-MU3XYHkOvKEFnuUtcAtVh0s4RTemRyi1NN87+v9fAL0qR9JZuK/nF27YJ79wjPvvi1W9sz3qc7cTgshH5tji6Q==",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.0"
+        "@sigstore/protobuf-specs": "^0.3.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -448,11 +448,11 @@
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.0.tgz",
-      "integrity": "sha512-zxiQ66JFOjVvP9hbhGj/F/qNdsZfkGb/dVXSanNRNuAzMlr4MC95voPUBX8//ZNnmv3uSYzdfR/JSkrgvZTGxA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.1.tgz",
+      "integrity": "sha512-aIL8Z9NsMr3C64jyQzE0XlkEyBLpgEJJFDHLVVStkFV5Q3Il/r/YtY6NJWKQ4cy4AE7spP1IX5Jq7VCAxHHMfQ==",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@sigstore/rekor-types": {
@@ -465,13 +465,13 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.3.tgz",
-      "integrity": "sha512-LqlA+ffyN02yC7RKszCdMTS6bldZnIodiox+IkT8B2f8oRYXCB3LQ9roXeiEL21m64CVH1wyveYAORfD65WoSw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.0.tgz",
+      "integrity": "sha512-tsAyV6FC3R3pHmKS880IXcDJuiFJiKITO1jxR1qbplcsBkZLBmjrEw5GbC7ikD6f5RU1hr7WnmxB/2kKc1qUWQ==",
       "dependencies": {
-        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/bundle": "^2.3.0",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.0",
+        "@sigstore/protobuf-specs": "^0.3.1",
         "make-fetch-happen": "^13.0.0"
       },
       "engines": {
@@ -2324,11 +2324,11 @@
       "optional": true
     },
     "@sigstore/bundle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.2.0.tgz",
-      "integrity": "sha512-5VI58qgNs76RDrwXNhpmyN/jKpq9evV/7f1XrcqcAfvxDl5SeVY/I5Rmfe96ULAV7/FK5dge9RBKGBJPhL1WsQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.0.tgz",
+      "integrity": "sha512-MU3XYHkOvKEFnuUtcAtVh0s4RTemRyi1NN87+v9fAL0qR9JZuK/nF27YJ79wjPvvi1W9sz3qc7cTgshH5tji6Q==",
       "requires": {
-        "@sigstore/protobuf-specs": "^0.3.0"
+        "@sigstore/protobuf-specs": "^0.3.1"
       }
     },
     "@sigstore/core": {
@@ -2355,9 +2355,9 @@
       }
     },
     "@sigstore/protobuf-specs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.0.tgz",
-      "integrity": "sha512-zxiQ66JFOjVvP9hbhGj/F/qNdsZfkGb/dVXSanNRNuAzMlr4MC95voPUBX8//ZNnmv3uSYzdfR/JSkrgvZTGxA=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.1.tgz",
+      "integrity": "sha512-aIL8Z9NsMr3C64jyQzE0XlkEyBLpgEJJFDHLVVStkFV5Q3Il/r/YtY6NJWKQ4cy4AE7spP1IX5Jq7VCAxHHMfQ=="
     },
     "@sigstore/rekor-types": {
       "version": "2.0.0",
@@ -2366,13 +2366,13 @@
       "dev": true
     },
     "@sigstore/sign": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.3.tgz",
-      "integrity": "sha512-LqlA+ffyN02yC7RKszCdMTS6bldZnIodiox+IkT8B2f8oRYXCB3LQ9roXeiEL21m64CVH1wyveYAORfD65WoSw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.0.tgz",
+      "integrity": "sha512-tsAyV6FC3R3pHmKS880IXcDJuiFJiKITO1jxR1qbplcsBkZLBmjrEw5GbC7ikD6f5RU1hr7WnmxB/2kKc1qUWQ==",
       "requires": {
-        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/bundle": "^2.3.0",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.0",
+        "@sigstore/protobuf-specs": "^0.3.1",
         "make-fetch-happen": "^13.0.0"
       }
     },

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",
@@ -46,8 +46,8 @@
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
     "@actions/http-client": "^2.2.1",
-    "@sigstore/bundle": "^2.2.0",
-    "@sigstore/sign": "^2.2.3",
+    "@sigstore/bundle": "^2.3.0",
+    "@sigstore/sign": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",
     "make-fetch-happen": "^13.0.0"

--- a/packages/attest/src/attest.ts
+++ b/packages/attest/src/attest.ts
@@ -1,10 +1,11 @@
-import {Bundle, bundleToJSON} from '@sigstore/bundle'
+import {bundleToJSON} from '@sigstore/bundle'
 import {X509Certificate} from 'crypto'
 import {SigstoreInstance, signingEndpoints} from './endpoints'
 import {buildIntotoStatement} from './intoto'
 import {Payload, signPayload} from './sign'
 import {writeAttestation} from './store'
 
+import type {Bundle} from '@sigstore/sign'
 import type {Attestation, Predicate, Subject} from './shared.types'
 
 const INTOTO_PAYLOAD_TYPE = 'application/vnd.in-toto+json'

--- a/packages/attest/src/sign.ts
+++ b/packages/attest/src/sign.ts
@@ -1,5 +1,5 @@
-import {Bundle} from '@sigstore/bundle'
 import {
+  Bundle,
   BundleBuilder,
   CIContextProvider,
   DSSEBundleBuilder,
@@ -103,5 +103,7 @@ const initBundleBuilder = (opts: SignOptions): BundleBuilder => {
     )
   }
 
-  return new DSSEBundleBuilder({signer, witnesses})
+  // Build the bundle with the singleCertificate option which will
+  // trigger the creation of v0.3 DSSE bundles
+  return new DSSEBundleBuilder({signer, witnesses, singleCertificate: true})
 }


### PR DESCRIPTION
Updates the `@actions/attest` package to generate attestations using a new version (v0.3) Sigstore bundle format. This new format includes a new media type ("application/vnd.dev.sigstore.bundle.v0.3+json") and some structural changes to the way that the signing certificate is represented.

Includes updates to two dependent packages:
* Bump `@sigstore/bundle` from 2.2.0 to 2.3.0
* Bump `@sgistore/sign` from 2.2.3 to 2.3.0