### PR TITLE
(@actions/attest) remove dep on make-fetch-happen

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -5,6 +5,7 @@
 - Generate attestations using the v0.3 Sigstore bundle format.
 - Bump @sigstore/bundle from 2.2.0 to 2.3.0.
 - Bump @sigstore/sign from 2.2.3 to 2.3.0.
+- Remove dependency on make-fetch-happen
 
 ### 1.1.0
 

--- a/packages/attest/__tests__/store.test.ts
+++ b/packages/attest/__tests__/store.test.ts
@@ -1,10 +1,13 @@
-import nock from 'nock'
+import {MockAgent, setGlobalDispatcher} from 'undici'
 import {writeAttestation} from '../src/store'
 
 describe('writeAttestation', () => {
   const originalEnv = process.env
   const attestation = {foo: 'bar '}
   const token = 'token'
+
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
 
   beforeEach(() => {
     process.env = {
@@ -19,9 +22,14 @@ describe('writeAttestation', () => {
 
   describe('when the api call is successful', () => {
     beforeEach(() => {
-      nock('https://api.github.com')
-        .matchHeader('authorization', `token ${token}`)
-        .post('/repos/foo/bar/attestations', {bundle: attestation})
+      mockAgent
+        .get('https://api.github.com')
+        .intercept({
+          path: '/repos/foo/bar/attestations',
+          method: 'POST',
+          headers: {authorization: `token ${token}`},
+          body: JSON.stringify({bundle: attestation})
+        })
         .reply(201, {id: '123'})
     })
 
@@ -32,9 +40,14 @@ describe('writeAttestation', () => {
 
   describe('when the api call fails', () => {
     beforeEach(() => {
-      nock('https://api.github.com')
-        .matchHeader('authorization', `token ${token}`)
-        .post('/repos/foo/bar/attestations', {bundle: attestation})
+      mockAgent
+        .get('https://api.github.com')
+        .intercept({
+          path: '/repos/foo/bar/attestations',
+          method: 'POST',
+          headers: {authorization: `token ${token}`},
+          body: JSON.stringify({bundle: attestation})
+        })
         .reply(500, 'oops')
     })
 

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -15,16 +15,15 @@
         "@sigstore/bundle": "^2.3.0",
         "@sigstore/sign": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
-        "jwks-rsa": "^3.1.0",
-        "make-fetch-happen": "^13.0.0"
+        "jwks-rsa": "^3.1.0"
       },
       "devDependencies": {
         "@sigstore/mock": "^0.6.5",
         "@sigstore/rekor-types": "^2.0.0",
         "@types/jsonwebtoken": "^9.0.6",
-        "@types/make-fetch-happen": "^10.0.4",
         "jose": "^5.2.3",
-        "nock": "^13.5.1"
+        "nock": "^13.5.1",
+        "undici": "^5.28.4"
       }
     },
     "node_modules/@actions/core": {
@@ -530,17 +529,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/make-fetch-happen": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.4.tgz",
-      "integrity": "sha512-jKzweQaEMMAi55ehvR1z0JF6aSVQm/h1BXBhPLOJriaeQBctjw5YbpIGs7zAx9dN0Sa2OO5bcXwCkrlgenoPEA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node-fetch": "*",
-        "@types/retry": "*",
-        "@types/ssri": "*"
-      }
-    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -554,16 +542,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.14",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
@@ -573,12 +551,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
-      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
-      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -596,15 +568,6 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ssri": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.5.tgz",
-      "integrity": "sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==",
-      "dev": true,
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -666,12 +629,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -765,18 +722,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -804,15 +749,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/deprecation": {
@@ -865,20 +801,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-minipass": {
@@ -1205,27 +1127,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -1743,9 +1644,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -1821,9 +1722,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -2428,17 +2329,6 @@
         "@types/node": "*"
       }
     },
-    "@types/make-fetch-happen": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.4.tgz",
-      "integrity": "sha512-jKzweQaEMMAi55ehvR1z0JF6aSVQm/h1BXBhPLOJriaeQBctjw5YbpIGs7zAx9dN0Sa2OO5bcXwCkrlgenoPEA==",
-      "dev": true,
-      "requires": {
-        "@types/node-fetch": "*",
-        "@types/retry": "*",
-        "@types/ssri": "*"
-      }
-    },
     "@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2452,16 +2342,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
     "@types/qs": {
       "version": "6.9.14",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
@@ -2471,12 +2351,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
-    },
-    "@types/retry": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
-      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
-      "dev": true
     },
     "@types/send": {
       "version": "0.17.4",
@@ -2494,15 +2368,6 @@
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/ssri": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.5.tgz",
-      "integrity": "sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==",
-      "dev": true,
-      "requires": {
         "@types/node": "*"
       }
     },
@@ -2543,12 +2408,6 @@
         "pvutils": "^1.1.3",
         "tslib": "^2.4.0"
       }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2627,15 +2486,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2653,12 +2503,6 @@
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
     },
     "deprecation": {
       "version": "2.3.1",
@@ -2704,17 +2548,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "fs-minipass": {
@@ -2982,21 +2815,6 @@
         "negotiator": "^0.6.3",
         "promise-retry": "^2.0.1",
         "ssri": "^10.0.0"
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
@@ -3367,9 +3185,9 @@
       }
     },
     "tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -3433,9 +3251,9 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -38,9 +38,9 @@
     "@sigstore/mock": "^0.6.5",
     "@sigstore/rekor-types": "^2.0.0",
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/make-fetch-happen": "^10.0.4",
     "jose": "^5.2.3",
-    "nock": "^13.5.1"
+    "nock": "^13.5.1",
+    "undici": "^5.28.4"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
@@ -49,7 +49,6 @@
     "@sigstore/bundle": "^2.3.0",
     "@sigstore/sign": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
-    "jwks-rsa": "^3.1.0",
-    "make-fetch-happen": "^13.0.0"
+    "jwks-rsa": "^3.1.0"
   }
 }

--- a/packages/attest/src/store.ts
+++ b/packages/attest/src/store.ts
@@ -1,5 +1,4 @@
 import * as github from '@actions/github'
-import fetch from 'make-fetch-happen'
 
 const CREATE_ATTESTATION_REQUEST = 'POST /repos/{owner}/{repo}/attestations'
 
@@ -14,7 +13,7 @@ export const writeAttestation = async (
   attestation: unknown,
   token: string
 ): Promise<string> => {
-  const octokit = github.getOctokit(token, {request: {fetch}})
+  const octokit = github.getOctokit(token)
 
   try {
     const response = await octokit.request(CREATE_ATTESTATION_REQUEST, {
@@ -23,7 +22,11 @@ export const writeAttestation = async (
       data: {bundle: attestation}
     })
 
-    return response.data?.id
+    const data =
+      typeof response.data == 'string'
+        ? JSON.parse(response.data)
+        : response.data
+    return data?.id
   } catch (err) {
     const message = err instanceof Error ? err.message : err
     throw new Error(`Failed to persist attestation: ${message}`)


### PR DESCRIPTION
Removes the dependency on the `make-fetch-happen` library.

Previously, `make-fetch-happen` was being used as the fetch client to ease the process of mocking requests for the associated unit tests. This PR uses a new approach to mock the interaction with the GH API, so we no longer need this library.