### PR TITLE
artifact client: retry on non-JSON response

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,13 @@
 # @actions/artifact Releases
 
+### 2.1.6
+
+- Will retry on invalid request responses.
+
+### 2.1.5
+
+- Bumped `archiver` dependency to 7.0.1
+
 ### 2.1.4
 
 - Adds info-level logging for zip extraction
@@ -11,9 +19,9 @@
 ### 2.1.2
 
 - Updated the stream extract functionality to use `unzip.Parse()` instead of `unzip.Extract()` for greater control of unzipping artifacts
-  
+
 ### 2.1.1
- 
+
 - Updated `isGhes` check to include `.ghe.com` and `.ghe.localhost` as accepted hosts
 
 ### 2.1.0

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -102,7 +102,6 @@ class ArtifactHttpClient implements Rpc {
       } catch (error) {
         if (error instanceof SyntaxError) {
           debug(`Raw Body: ${rawBody}`)
-          throw error
         }
 
         if (error instanceof UsageError) {


### PR DESCRIPTION
Occasionally the upstream artifact client may not respond in time (or other intermittent issues) so the GLB will respond with a 502 and a generic HTML response. We currently throw for non-JSON data as a response.

This tiny change allows us to retry in that scenario.

e.g.
- https://github.com/actions/upload-artifact/issues/543