### PR TITLE
Use latest `unzip-stream` and `unzip.Extract`

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/artifact Releases
 
+### 2.1.7
+
+- Update unzip-stream dependency and reverted to using `unzip.Extract()`
+
 ### 2.1.6
 
 - Will retry on invalid request responses.

--- a/packages/artifact/__tests__/download-artifact.test.ts
+++ b/packages/artifact/__tests__/download-artifact.test.ts
@@ -223,8 +223,8 @@ describe('download-artifact', () => {
       )
 
       // ensure path traversal was not possible
-      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'x/etc/hosts'))).toBe(true);
-      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'y/etc/hosts'))).toBe(true);
+      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'x/etc/hosts'))).toBe(true)
+      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'y/etc/hosts'))).toBe(true)
 
       expect(response.downloadPath).toBe(fixtures.workspaceDir)
     })

--- a/packages/artifact/__tests__/download-artifact.test.ts
+++ b/packages/artifact/__tests__/download-artifact.test.ts
@@ -223,8 +223,12 @@ describe('download-artifact', () => {
       )
 
       // ensure path traversal was not possible
-      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'x/etc/hosts'))).toBe(true)
-      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'y/etc/hosts'))).toBe(true)
+      expect(
+        fs.existsSync(path.join(fixtures.workspaceDir, 'x/etc/hosts'))
+      ).toBe(true)
+      expect(
+        fs.existsSync(path.join(fixtures.workspaceDir, 'y/etc/hosts'))
+      ).toBe(true)
 
       expect(response.downloadPath).toBe(fixtures.workspaceDir)
     })

--- a/packages/artifact/__tests__/download-artifact.test.ts
+++ b/packages/artifact/__tests__/download-artifact.test.ts
@@ -200,14 +200,12 @@ describe('download-artifact', () => {
         }
       )
 
-      await expect(
-        downloadArtifactPublic(
-          fixtures.artifactID,
-          fixtures.repositoryOwner,
-          fixtures.repositoryName,
-          fixtures.token
-        )
-      ).rejects.toBeInstanceOf(Error)
+      const response = await downloadArtifactPublic(
+        fixtures.artifactID,
+        fixtures.repositoryOwner,
+        fixtures.repositoryName,
+        fixtures.token
+      )
 
       expect(downloadArtifactMock).toHaveBeenCalledWith({
         owner: fixtures.repositoryOwner,
@@ -223,6 +221,12 @@ describe('download-artifact', () => {
       expect(mockGetArtifactMalicious).toHaveBeenCalledWith(
         fixtures.blobStorageUrl
       )
+
+      // ensure path traversal was not possible
+      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'x/etc/hosts'))).toBe(true);
+      expect(fs.existsSync(path.join(fixtures.workspaceDir, 'y/etc/hosts'))).toBe(true);
+
+      expect(response.downloadPath).toBe(fixtures.workspaceDir)
     })
 
     it('should successfully download an artifact to user defined path', async () => {

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
@@ -1738,9 +1738,9 @@
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "node_modules/unzip-stream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.1.tgz",
-      "integrity": "sha512-RzaGXLNt+CW+T41h1zl6pGz3EaeVhYlK+rdAap+7DxW5kqsqePO8kRtWPaCiVqdhZc86EctSPVYNix30YOMzmw==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.4.tgz",
+      "integrity": "sha512-PyofABPVv+d7fL7GOpusx7eRT9YETY2X04PhwbSipdj6bMxVCFJrr+nm0Mxqbf9hUiTin/UsnuFWBXlDZFy0Cw==",
       "dependencies": {
         "binary": "^0.3.0",
         "mkdirp": "^0.5.1"

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -90,7 +90,7 @@ export async function streamExtractExternal(
         reject(error)
       })
       .pipe(unzip.Extract({path: directory}))
-      .on('close', () => { 
+      .on('close', () => {
         clearTimeout(timer)
         resolve()
       })


### PR DESCRIPTION
This updates the `unzip-stream` dependency and goes back to using `unzip.Extract` over `unzip.Parse`.