### PR TITLE
(@actions/attest) retry request on failure to save attestation

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+### 1.2.1
+
+- Retry request on attestation persistence failure
+
 ### 1.2.0
 
 - Generate attestations using the v0.3 Sigstore bundle format.

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
         "@actions/http-client": "^2.2.1",
+        "@octokit/plugin-retry": "^6.0.1",
         "@sigstore/bundle": "^2.3.0",
         "@sigstore/sign": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
@@ -114,15 +115,15 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.0.0",
-        "@octokit/request": "^8.0.2",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -130,29 +131,68 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@octokit/endpoint": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
-      "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/openapi-types": "^22.1.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
-    "node_modules/@octokit/graphql": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-      "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
       "dependencies": {
-        "@octokit/request": "^8.0.1",
-        "@octokit/types": "^12.0.0",
+        "@octokit/openapi-types": "^22.1.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "dependencies": {
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.1.0"
       }
     },
     "node_modules/@octokit/openapi-types": {
@@ -188,14 +228,30 @@
         "@octokit/core": ">=5"
       }
     },
-    "node_modules/@octokit/request": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
-      "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+    "node_modules/@octokit/plugin-retry": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+      "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^12.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -203,16 +259,42 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.1.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+      "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.1.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -639,6 +721,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -1968,36 +2055,81 @@
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
     },
     "@octokit/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "requires": {
         "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.0.0",
-        "@octokit/request": "^8.0.2",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+          "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+        },
+        "@octokit/types": {
+          "version": "13.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+          "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+          "requires": {
+            "@octokit/openapi-types": "^22.1.0"
+          }
+        }
       }
     },
     "@octokit/endpoint": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
-      "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
       "requires": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+          "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+        },
+        "@octokit/types": {
+          "version": "13.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+          "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+          "requires": {
+            "@octokit/openapi-types": "^22.1.0"
+          }
+        }
       }
     },
     "@octokit/graphql": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-      "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
       "requires": {
-        "@octokit/request": "^8.0.1",
-        "@octokit/types": "^12.0.0",
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+          "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+        },
+        "@octokit/types": {
+          "version": "13.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+          "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+          "requires": {
+            "@octokit/openapi-types": "^22.1.0"
+          }
+        }
       }
     },
     "@octokit/openapi-types": {
@@ -2021,25 +2153,65 @@
         "@octokit/types": "^12.4.0"
       }
     },
-    "@octokit/request": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
-      "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+    "@octokit/plugin-retry": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+      "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
       "requires": {
-        "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^12.0.0",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/request": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "requires": {
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+          "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+        },
+        "@octokit/types": {
+          "version": "13.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+          "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+          "requires": {
+            "@octokit/openapi-types": "^22.1.0"
+          }
+        }
       }
     },
     "@octokit/request-error": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
       "requires": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+          "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+        },
+        "@octokit/types": {
+          "version": "13.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+          "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+          "requires": {
+            "@octokit/openapi-types": "^22.1.0"
+          }
+        }
       }
     },
     "@octokit/types": {
@@ -2418,6 +2590,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "brace-expansion": {
       "version": "2.0.1",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Actions attestation lib",
   "keywords": [
     "github",
@@ -46,9 +46,15 @@
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
     "@actions/http-client": "^2.2.1",
+    "@octokit/plugin-retry": "^6.0.1",
     "@sigstore/bundle": "^2.3.0",
     "@sigstore/sign": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0"
+  },
+  "overrides": {
+    "@octokit/plugin-retry": {
+      "@octokit/core": "^5.2.0"
+    }
   }
 }

--- a/packages/attest/src/store.ts
+++ b/packages/attest/src/store.ts
@@ -1,7 +1,12 @@
 import * as github from '@actions/github'
+import {retry} from '@octokit/plugin-retry'
 
 const CREATE_ATTESTATION_REQUEST = 'POST /repos/{owner}/{repo}/attestations'
+const DEFAULT_RETRY_COUNT = 5
 
+export type WriteOptions = {
+  retry?: number
+}
 /**
  * Writes an attestation to the repository's attestations endpoint.
  * @param attestation - The attestation to write.
@@ -11,9 +16,11 @@ const CREATE_ATTESTATION_REQUEST = 'POST /repos/{owner}/{repo}/attestations'
  */
 export const writeAttestation = async (
   attestation: unknown,
-  token: string
+  token: string,
+  options: WriteOptions = {}
 ): Promise<string> => {
-  const octokit = github.getOctokit(token)
+  const retries = options.retry ?? DEFAULT_RETRY_COUNT
+  const octokit = github.getOctokit(token, {retry: {retries}}, retry)
 
   try {
     const response = await octokit.request(CREATE_ATTESTATION_REQUEST, {


### PR DESCRIPTION
Updates the attestations API client to be more resilient to intermittent errors.

Enables the `@octokit/plugin-retry` plugin for the Octokit client and configures a (default) retry count of 3. Any attempt to persist the generated attestation which results in a 5XX error will be retried up to 3 times (with [exponential backoff](https://github.com/octokit/plugin-retry.js/blob/v6.0.1/src/error-request.ts#L13)).