### PR TITLE
Update @actions/attest README

### DIFF
--- a/packages/attest/README.md
+++ b/packages/attest/README.md
@@ -12,6 +12,9 @@ Once the attestation has been created and signed, it will be uploaded to the GH
 attestations API and associated with the repository from which the workflow was
 initiated.
 
+See [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+for more information on artifact attestations.
+
 ## Usage
 
 ### `attest`


### PR DESCRIPTION
Adds a link to the GH docs from the `@actions/attest` README