### PR TITLE
Read the server url from the environment variable.

### DIFF
--- a/packages/attest/__tests__/endpoints.test.ts
+++ b/packages/attest/__tests__/endpoints.test.ts
@@ -1,0 +1,41 @@
+import {signingEndpoints} from '../src/endpoints'
+
+describe('signingEndpoints', () => {
+  const originalEnv = process.env
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('when using github.com', () => {
+    beforeEach(async () => {
+      process.env = {
+        ...originalEnv,
+        GITHUB_SERVER_URL: 'https://github.com'
+      }
+    })
+
+    it('returns expected endpoints', async () => {
+      const endpoints = signingEndpoints('github')
+
+      expect(endpoints.fulcioURL).toEqual('https://fulcio.githubapp.com')
+      expect(endpoints.tsaServerURL).toEqual('https://timestamp.githubapp.com')
+    })
+  })
+
+  describe('when using custom domain', () => {
+    beforeEach(async () => {
+      process.env = {
+        ...originalEnv,
+        GITHUB_SERVER_URL: 'https://foo.bar.com'
+      }
+    })
+
+    it('returns a expected endpoints', async () => {
+      const endpoints = signingEndpoints('github')
+
+      expect(endpoints.fulcioURL).toEqual('https://fulcio.foo.bar.com')
+      expect(endpoints.tsaServerURL).toEqual('https://timestamp.foo.bar.com')
+    })
+  })
+})

--- a/packages/attest/__tests__/provenance.test.ts
+++ b/packages/attest/__tests__/provenance.test.ts
@@ -3,7 +3,7 @@ import {mockFulcio, mockRekor, mockTSA} from '@sigstore/mock'
 import * as jose from 'jose'
 import nock from 'nock'
 import {MockAgent, setGlobalDispatcher} from 'undici'
-import {SIGSTORE_GITHUB, SIGSTORE_PUBLIC_GOOD} from '../src/endpoints'
+import {SIGSTORE_PUBLIC_GOOD, signingEndpoints} from '../src/endpoints'
 import {attestProvenance, buildSLSAProvenancePredicate} from '../src/provenance'
 
 describe('provenance functions', () => {
@@ -95,7 +95,7 @@ describe('provenance functions', () => {
     })
 
     describe('when using the github Sigstore instance', () => {
-      const {fulcioURL, tsaServerURL} = SIGSTORE_GITHUB
+      const {fulcioURL, tsaServerURL} = signingEndpoints('github')
 
       beforeEach(async () => {
         // Mock Sigstore

--- a/packages/attest/src/endpoints.ts
+++ b/packages/attest/src/endpoints.ts
@@ -42,15 +42,14 @@ export const signingEndpoints = (sigstore?: SigstoreInstance): Endpoints => {
 }
 
 function buildGitHubEndpoints(): Endpoints {
-  const serverURL = process.env.GITHUB_SERVER_URL ?? `https://github.com`
-  let url = serverURL.replace('https://', '')
+  const serverURL = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  let host = new URL(serverURL).hostname
 
-  if (url === 'github.com') {
-    url = 'githubapp.com'
+  if (host === 'github.com') {
+    host = 'githubapp.com'
   }
-  const endpoints: Endpoints = {
-    fulcioURL: `https://fulcio.${url}`,
-    tsaServerURL: `https://timestamp.${url}`
+  return {
+    fulcioURL: `https://fulcio.${hostl}`,
+    tsaServerURL: `https://timestamp.${host}`
   }
-  return endpoints
 }

--- a/packages/attest/src/endpoints.ts
+++ b/packages/attest/src/endpoints.ts
@@ -6,9 +6,6 @@ const GITHUB_ID = 'github'
 const FULCIO_PUBLIC_GOOD_URL = 'https://fulcio.sigstore.dev'
 const REKOR_PUBLIC_GOOD_URL = 'https://rekor.sigstore.dev'
 
-const FULCIO_INTERNAL_URL = 'https://fulcio.githubapp.com'
-const TSA_INTERNAL_URL = 'https://timestamp.githubapp.com'
-
 export type SigstoreInstance = typeof PUBLIC_GOOD_ID | typeof GITHUB_ID
 
 export type Endpoints = {
@@ -20,11 +17,6 @@ export type Endpoints = {
 export const SIGSTORE_PUBLIC_GOOD: Endpoints = {
   fulcioURL: FULCIO_PUBLIC_GOOD_URL,
   rekorURL: REKOR_PUBLIC_GOOD_URL
-}
-
-export const SIGSTORE_GITHUB: Endpoints = {
-  fulcioURL: FULCIO_INTERNAL_URL,
-  tsaServerURL: TSA_INTERNAL_URL
 }
 
 export const signingEndpoints = (sigstore?: SigstoreInstance): Endpoints => {
@@ -45,6 +37,20 @@ export const signingEndpoints = (sigstore?: SigstoreInstance): Endpoints => {
     case PUBLIC_GOOD_ID:
       return SIGSTORE_PUBLIC_GOOD
     case GITHUB_ID:
-      return SIGSTORE_GITHUB
+      return buildGitHubEndpoints()
   }
+}
+
+function buildGitHubEndpoints(): Endpoints {
+  const serverURL = process.env.GITHUB_SERVER_URL ?? `https://github.com`
+  let url = serverURL.replace('https://', '')
+
+  if (url === 'github.com') {
+    url = 'githubapp.com'
+  }
+  const endpoints: Endpoints = {
+    fulcioURL: `https://fulcio.${url}`,
+    tsaServerURL: `https://timestamp.${url}`
+  }
+  return endpoints
 }

--- a/packages/attest/src/endpoints.ts
+++ b/packages/attest/src/endpoints.ts
@@ -49,7 +49,7 @@ function buildGitHubEndpoints(): Endpoints {
     host = 'githubapp.com'
   }
   return {
-    fulcioURL: `https://fulcio.${hostl}`,
+    fulcioURL: `https://fulcio.${host}`,
     tsaServerURL: `https://timestamp.${host}`
   }
 }


### PR DESCRIPTION
Instead of having the urls hardcoded, read them from the environment. I opted to read from the environment variable instead of the github context because it would be easier to test.