### PR TITLE
Update artifact readme with required rootDirectory for uploadArtifact

### DIFF
--- a/packages/artifact/README.md
+++ b/packages/artifact/README.md
@@ -90,6 +90,8 @@ const {id, size} = await artifact.uploadArtifact(
   'my-artifact',
   // files to include (supports absolute and relative paths)
   ['/absolute/path/file1.txt', './relative/file2.txt'],
+  // An absolute or relative file path that denotes the root parent directory of the files being uploaded
+  '/',
   {
     // optional: how long to retain the artifact
     // if unspecified, defaults to repository/org retention settings (the limit of this value)


### PR DESCRIPTION
Just updating the readme with a required argument as per the documented interface: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/generated/interfaces/ArtifactClient.md#uploadartifact