### PR TITLE
config rekor to fetch on conflict

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -4,6 +4,7 @@
 
 - Dynamic construction of Sigstore API URLs
 - Switch to new GH provenance build type
+- Fetch existing Rekor entry on 409 conflict error
 - Bump @sigstore/bundle from 2.3.0 to 2.3.2
 - Bump @sigstore/sign from 2.3.0 to 2.3.2
 

--- a/packages/attest/src/sign.ts
+++ b/packages/attest/src/sign.ts
@@ -87,6 +87,7 @@ const initBundleBuilder = (opts: SignOptions): BundleBuilder => {
       new RekorWitness({
         rekorBaseURL: opts.rekorURL,
         entryType: 'dsse',
+        fetchOnConflict: true,
         timeout,
         retry
       })


### PR DESCRIPTION
Updates the configuration of the Sigstore Rekor client to fetch an existing Rekor entry on a 409 conflict error. 

Will help to address issues like the ones reported [here](https://github.com/actions/attest-build-provenance/issues/110) where the Rekor entry already exists. Instead of returning an error, we can instead retrieve the existing Rekor entry and use it to construct the bundle.