### PR TITLE
Allow localhost hostnames for artifact checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5175,12 +5175,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -6400,9 +6400,9 @@
       "dev": true
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -7457,9 +7457,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/artifact Releases
 
+### 2.1.8
+
+- Allows `*.localhost` domains for hostname checks for local development.
+
 ### 2.1.7
 
 - Update unzip-stream dependency and reverted to using `unzip.Extract()`

--- a/packages/artifact/__tests__/config.test.ts
+++ b/packages/artifact/__tests__/config.test.ts
@@ -20,6 +20,11 @@ describe('isGhes', () => {
     expect(config.isGhes()).toBe(false)
   })
 
+  it('should return false when the request domain ends with .localhost', () => {
+    process.env.GITHUB_SERVER_URL = 'https://github.localhost'
+    expect(config.isGhes()).toBe(false)
+  })
+
   it('should return false when the request domain is specific to an enterprise', () => {
     process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
     expect(config.isGhes()).toBe(true)

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -30,10 +30,10 @@ export function isGhes(): boolean {
 
   const hostname = ghUrl.hostname.trimEnd().toUpperCase()
   const isGitHubHost = hostname === 'GITHUB.COM'
-  const isGheHost =
-    hostname.endsWith('.GHE.COM') || hostname.endsWith('.GHE.LOCALHOST')
+  const isGheHost = hostname.endsWith('.GHE.COM')
+  const isLocalHost = hostname.endsWith('.LOCALHOST')
 
-  return !isGitHubHost && !isGheHost
+  return !isGitHubHost && !isGheHost && !isLocalHost
 }
 
 export function getGitHubWorkspaceDir(): string {


### PR DESCRIPTION
Reduces friction of local development by allowing `*.localhost` domains for hostname checks. These were failing fast by the GHES hostname checker.