### PR TITLE
Prevent "too many open files" in artifact upload

### DIFF
--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -1,7 +1,6 @@
 import * as stream from 'stream'
 import * as archiver from 'archiver'
 import * as core from '@actions/core'
-import {createReadStream} from 'fs'
 import {UploadZipSpecification} from './upload-zip-specification'
 import {getUploadChunkSize} from '../shared/config'
 

--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -44,7 +44,7 @@ export async function createZipUploadStream(
   for (const file of uploadSpecification) {
     if (file.sourcePath !== null) {
       // Add a normal file to the zip
-      zip.append(createReadStream(file.sourcePath), {
+      zip.file(file.sourcePath, {
         name: file.destinationPath
       })
     } else {


### PR DESCRIPTION
Fixes https://github.com/actions/upload-artifact/issues/485.

[The `.file` method](https://www.archiverjs.com/docs/archiver/#file) uses "a [lazystream](https://github.com/jpommerening/node-lazystream) wrapper to prevent issues with open file limits", which is precisely the scenario we're running into with https://github.com/actions/upload-artifact/issues/485.

This was originally part of https://github.com/actions/toolkit/pull/1723, but I pulled the bugfix out into its own PR so it can be reviewed separately from the bugfix that https://github.com/actions/toolkit/pull/1723 was for (preserving Unix file permissions in uploaded .zip files). This one is more urgent than the Unix file permissions, which can be worked around by uploading a .tar file.