### PR TITLE
actions/exec: add `timeout` option to `exec` function

### DIFF
--- a/packages/exec/__tests__/exec.test.ts
+++ b/packages/exec/__tests__/exec.test.ts
@@ -820,6 +820,15 @@ describe('@actions/exec', () => {
     expect(stdout).toBe('©')
   })
 
+  it('allows to specify timeouts on running the child process', async () => {
+    const options = getExecOptions()
+    // The `cat` command will be killed after 100ms
+    options.timeout = 100
+    await expect(exec.exec('cat', [], options)).rejects.toThrowError(
+      'failed with exit code null'
+    )
+  })
+
   if (IS_WINDOWS) {
     it('Exec roots relative tool path using process.cwd (Windows path separator)', async () => {
       let exitCode: number

--- a/packages/exec/src/interfaces.ts
+++ b/packages/exec/src/interfaces.ts
@@ -30,6 +30,9 @@ export interface ExecOptions {
   /** optional. How long in ms to wait for STDIO streams to close after the exit event of the process before terminating. defaults to 10000 */
   delay?: number
 
+  /** optional. Timeout in ms for the child process */
+  timeout?: number
+
   /** optional. input to write to the process on STDIN. */
   input?: Buffer
 

--- a/packages/exec/src/toolrunner.ts
+++ b/packages/exec/src/toolrunner.ts
@@ -374,6 +374,7 @@ export class ToolRunner extends events.EventEmitter {
     const result = <child.SpawnOptions>{}
     result.cwd = options.cwd
     result.env = options.env
+    result.timeout = options.timeout
     result['windowsVerbatimArguments'] =
       options.windowsVerbatimArguments || this._isCmdFile()
     if (options.windowsVerbatimArguments) {


### PR DESCRIPTION
Fixes #1777