### PR TITLE
refactor: set chunk timeout back to 5 minutes

### DIFF
--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -59,5 +59,5 @@ export function getConcurrency(): number {
 }
 
 export function getUploadChunkTimeout(): number {
-  return 30_000 // 30 seconds
+  return 300_000 // 5 minutes
 }


### PR DESCRIPTION
As mentioned in https://github.com/actions/upload-artifact/issues/591, changes of https://github.com/actions/toolkit/pull/1774 changed the upload chunk timeout from 5 minutes to 30 seconds which leads some repos to `Error: Upload progress stalled.`

This PR reverts the timeout to its original value.