### PR TITLE
support for headers param in attest functions

### DIFF
--- a/packages/attest/README.md
+++ b/packages/attest/README.md
@@ -63,6 +63,8 @@ export type AttestOptions = {
   // Sigstore instance to use for signing. Must be one of "public-good" or
   // "github".
   sigstore?: 'public-good' | 'github'
+  // HTTP headers to include in request to attestations API.
+  headers?: {[header: string]: string | number | undefined}
   // Whether to skip writing the attestation to the GH attestations API.
   skipWrite?: boolean
 }
@@ -113,6 +115,8 @@ export type AttestProvenanceOptions = {
   // Sigstore instance to use for signing. Must be one of "public-good" or
   // "github".
   sigstore?: 'public-good' | 'github'
+  // HTTP headers to include in request to attestations API.
+  headers?: {[header: string]: string | number | undefined}
   // Whether to skip writing the attestation to the GH attestations API.
   skipWrite?: boolean
   // Issuer URL responsible for minting the OIDC token from which the

--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+### 1.4.0
+
+- Add new `headers` parameter to the `attest` and `attestProvenance` functions.
+
 ### 1.3.1
 
 - Fix bug with proxy support when retrieving JWKS for OIDC issuer

--- a/packages/attest/__tests__/store.test.ts
+++ b/packages/attest/__tests__/store.test.ts
@@ -5,6 +5,7 @@ describe('writeAttestation', () => {
   const originalEnv = process.env
   const attestation = {foo: 'bar '}
   const token = 'token'
+  const headers = {'X-GitHub-Foo': 'true'}
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -27,14 +28,16 @@ describe('writeAttestation', () => {
         .intercept({
           path: '/repos/foo/bar/attestations',
           method: 'POST',
-          headers: {authorization: `token ${token}`},
+          headers: {authorization: `token ${token}`, ...headers},
           body: JSON.stringify({bundle: attestation})
         })
         .reply(201, {id: '123'})
     })
 
     it('persists the attestation', async () => {
-      await expect(writeAttestation(attestation, token)).resolves.toEqual('123')
+      await expect(
+        writeAttestation(attestation, token, {headers})
+      ).resolves.toEqual('123')
     })
   })
 

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/attest",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",

--- a/packages/attest/src/attest.ts
+++ b/packages/attest/src/attest.ts
@@ -28,6 +28,8 @@ export type AttestOptions = {
   // Sigstore instance to use for signing. Must be one of "public-good" or
   // "github".
   sigstore?: SigstoreInstance
+  // HTTP headers to include in request to attestations API.
+  headers?: {[header: string]: string | number | undefined}
   // Whether to skip writing the attestation to the GH attestations API.
   skipWrite?: boolean
 }
@@ -61,7 +63,11 @@ export async function attest(options: AttestOptions): Promise<Attestation> {
   // Store the attestation
   let attestationID: string | undefined
   if (options.skipWrite !== true) {
-    attestationID = await writeAttestation(bundleToJSON(bundle), options.token)
+    attestationID = await writeAttestation(
+      bundleToJSON(bundle),
+      options.token,
+      {headers: options.headers}
+    )
   }
 
   return toAttestation(bundle, attestationID)

--- a/packages/attest/src/store.ts
+++ b/packages/attest/src/store.ts
@@ -1,11 +1,13 @@
 import * as github from '@actions/github'
 import {retry} from '@octokit/plugin-retry'
+import {RequestHeaders} from '@octokit/types'
 
 const CREATE_ATTESTATION_REQUEST = 'POST /repos/{owner}/{repo}/attestations'
 const DEFAULT_RETRY_COUNT = 5
 
 export type WriteOptions = {
   retry?: number
+  headers?: RequestHeaders
 }
 /**
  * Writes an attestation to the repository's attestations endpoint.
@@ -26,6 +28,7 @@ export const writeAttestation = async (
     const response = await octokit.request(CREATE_ATTESTATION_REQUEST, {
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
+      headers: options.headers,
       data: {bundle: attestation}
     })
 


### PR DESCRIPTION
Updates the `attest` and `attestProvenance` functions to accept a new, optional `headers` parameter.

If supplied, any headers will be passed-along to the GH attestations API in addition to the required auth header.