### PR TITLE
Add glob option to ignore hidden files

### DIFF
--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/glob Releases
 
+### 0.5.0
+- Added `excludeHiddenFiles` option, which is disabled by default to preserve existing behavior [#1791: Add glob option to ignore hidden files](https://github.com/actions/toolkit/pull/1791)
+
 ### 0.4.0
 - Pass in the current workspace as a parameter to HashFiles [#1318](https://github.com/actions/toolkit/pull/1318)
 

--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -751,9 +751,7 @@ describe('globber', () => {
     )
 
     const itemPaths = await glob(root, {excludeHiddenFiles: true})
-    expect(itemPaths).toEqual([
-      root
-    ])
+    expect(itemPaths).toEqual([root])
   })
 
   it('returns normalized paths', async () => {

--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -752,7 +752,7 @@ describe('globber', () => {
 
     const itemPaths = await glob(root, {excludeHiddenFiles: true})
     expect(itemPaths).toEqual([
-      root,
+      root
     ])
   })
 

--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -741,7 +741,7 @@ describe('globber', () => {
     //   <root>/.file
     //   <root>/.folder
     //   <root>/.folder/file
-    const root = path.join(getTestTemp(), 'returns-hidden-files')
+    const root = path.join(getTestTemp(), 'ignores-hidden-files')
     await createHiddenDirectory(path.join(root, '.emptyFolder'))
     await createHiddenDirectory(path.join(root, '.folder'))
     await createHiddenFile(path.join(root, '.file'), 'test .file content')
@@ -751,7 +751,9 @@ describe('globber', () => {
     )
 
     const itemPaths = await glob(root, {excludeHiddenFiles: true})
-    expect(itemPaths).toEqual([])
+    expect(itemPaths).toEqual([
+      root,
+    ])
   })
 
   it('returns normalized paths', async () => {

--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -708,7 +708,7 @@ describe('globber', () => {
     expect(itemPaths).toEqual([])
   })
 
-  it('returns hidden files', async () => {
+  it('returns hidden files by default', async () => {
     // Create the following layout:
     //   <root>
     //   <root>/.emptyFolder
@@ -732,6 +732,26 @@ describe('globber', () => {
       path.join(root, '.folder'),
       path.join(root, '.folder', 'file')
     ])
+  })
+
+  it('ignores hidden files when excludeHiddenFiles is set', async () => {
+    // Create the following layout:
+    //   <root>
+    //   <root>/.emptyFolder
+    //   <root>/.file
+    //   <root>/.folder
+    //   <root>/.folder/file
+    const root = path.join(getTestTemp(), 'returns-hidden-files')
+    await createHiddenDirectory(path.join(root, '.emptyFolder'))
+    await createHiddenDirectory(path.join(root, '.folder'))
+    await createHiddenFile(path.join(root, '.file'), 'test .file content')
+    await fs.writeFile(
+      path.join(root, '.folder', 'file'),
+      'test .folder/file content'
+    )
+
+    const itemPaths = await glob(root, {excludeHiddenFiles: true})
+    expect(itemPaths).toEqual([])
   })
 
   it('returns normalized paths', async () => {

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "description": "Actions glob lib",

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [

--- a/packages/glob/src/internal-glob-options-helper.ts
+++ b/packages/glob/src/internal-glob-options-helper.ts
@@ -9,7 +9,8 @@ export function getOptions(copy?: GlobOptions): GlobOptions {
     followSymbolicLinks: true,
     implicitDescendants: true,
     matchDirectories: true,
-    omitBrokenSymbolicLinks: true
+    omitBrokenSymbolicLinks: true,
+    excludeHiddenFiles: false,
   }
 
   if (copy) {
@@ -31,6 +32,11 @@ export function getOptions(copy?: GlobOptions): GlobOptions {
     if (typeof copy.omitBrokenSymbolicLinks === 'boolean') {
       result.omitBrokenSymbolicLinks = copy.omitBrokenSymbolicLinks
       core.debug(`omitBrokenSymbolicLinks '${result.omitBrokenSymbolicLinks}'`)
+    }
+
+    if (typeof copy.excludeHiddenFiles === 'boolean') {
+      result.excludeHiddenFiles = copy.excludeHiddenFiles
+      core.debug(`excludeHiddenFiles '${result.excludeHiddenFiles}'`)
     }
   }
 

--- a/packages/glob/src/internal-glob-options-helper.ts
+++ b/packages/glob/src/internal-glob-options-helper.ts
@@ -10,7 +10,7 @@ export function getOptions(copy?: GlobOptions): GlobOptions {
     implicitDescendants: true,
     matchDirectories: true,
     omitBrokenSymbolicLinks: true,
-    excludeHiddenFiles: false,
+    excludeHiddenFiles: false
   }
 
   if (copy) {

--- a/packages/glob/src/internal-glob-options.ts
+++ b/packages/glob/src/internal-glob-options.ts
@@ -41,7 +41,7 @@ export interface GlobOptions {
    * Indicates whether to exclude hidden files (files and directories starting with a `.`).
    * This does not apply to Windows files and directories with the hidden attribute unless
    * they are also prefixed with a `.`.
-   * 
+   *
    * @default false
    */
   excludeHiddenFiles?: boolean

--- a/packages/glob/src/internal-glob-options.ts
+++ b/packages/glob/src/internal-glob-options.ts
@@ -36,4 +36,11 @@ export interface GlobOptions {
    * @default true
    */
   omitBrokenSymbolicLinks?: boolean
+
+  /**
+   * Indicates whether to include hidden files (files and directories starting with a `.`).
+   * 
+   * @default false
+   */
+  excludeHiddenFiles?: boolean
 }

--- a/packages/glob/src/internal-glob-options.ts
+++ b/packages/glob/src/internal-glob-options.ts
@@ -39,6 +39,8 @@ export interface GlobOptions {
 
   /**
    * Indicates whether to exclude hidden files (files and directories starting with a `.`).
+   * This does not apply to Windows files and directories with the hidden attribute unless
+   * they are also prefixed with a `.`.
    * 
    * @default false
    */

--- a/packages/glob/src/internal-glob-options.ts
+++ b/packages/glob/src/internal-glob-options.ts
@@ -38,7 +38,7 @@ export interface GlobOptions {
   omitBrokenSymbolicLinks?: boolean
 
   /**
-   * Indicates whether to include hidden files (files and directories starting with a `.`).
+   * Indicates whether to exclude hidden files (files and directories starting with a `.`).
    * 
    * @default false
    */

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -128,6 +128,11 @@ export class DefaultGlobber implements Globber {
         continue
       }
 
+      // Hidden file or directory?
+      if (options.excludeHiddenFiles && item.path.startsWith('.')) {
+        continue
+      }
+
       // Directory
       if (stats.isDirectory()) {
         // Matched

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -129,7 +129,7 @@ export class DefaultGlobber implements Globber {
       }
 
       // Hidden file or directory?
-      if (options.excludeHiddenFiles && item.path.startsWith('.')) {
+      if (options.excludeHiddenFiles && path.basename(item.path).match(/^\./)) {
         continue
       }
 


### PR DESCRIPTION
This PR adds an option to the glob package to exclude hidden files. This includes:
1. Any directory starting with `.`
2. Any file starting with `.`
3. Any files within a directory starting with `.`

This currently *does not* check for the hidden attribute that can be set on Windows files. Based on the discussion in https://github.com/nodejs/node/issues/38809, this isn't natively supported in Node at the moment.
I'm open to working around that limitation, but the primary focus here is for files and directories that use the `.` naming convention.