### PR TITLE
Include the package name in the Publish Workflow run

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,5 +1,7 @@
 name: Publish NPM
 
+run-name: Publish NPM - ${{ github.event.inputs.package }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This will give each run a name to help devs understand at a glance which package was published when browsing https://github.com/actions/toolkit/actions/workflows/releases.yml instead of just seeing "Publish NPM" over and over.