### PR TITLE
HTTP Client 2.2.2 Release

### DIFF
--- a/packages/http-client/RELEASES.md
+++ b/packages/http-client/RELEASES.md
@@ -1,10 +1,10 @@
 ## Releases
 
 ## 2.2.2
-- Better handling of url encoded usernames and passwords in proxy config
+- Better handling of url encoded usernames and passwords in proxy config [#1782](https://github.com/actions/toolkit/pull/1782)
 
 ## 2.2.1
-- Make sure RequestOptions.keepAlive is applied properly on node20 runtime
+- Make sure RequestOptions.keepAlive is applied properly on node20 runtime [#1572](https://github.com/actions/toolkit/pull/1572)
 
 ## 2.2.0
 - Add function to return proxy agent dispatcher for compatibility with latest octokit packages [#1547](https://github.com/actions/toolkit/pull/1547)

--- a/packages/http-client/RELEASES.md
+++ b/packages/http-client/RELEASES.md
@@ -1,5 +1,11 @@
 ## Releases
 
+## 2.2.2
+- Better handling of url encoded usernames and passwords in proxy config
+
+## 2.2.1
+- Make sure RequestOptions.keepAlive is applied properly on node20 runtime
+
 ## 2.2.0
 - Add function to return proxy agent dispatcher for compatibility with latest octokit packages [#1547](https://github.com/actions/toolkit/pull/1547)
 

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Actions Http Client",
   "keywords": [
     "github",


### PR DESCRIPTION
Looks like we missed the release notes for 2.2.1, so I added those as well.