### PR TITLE
derive default OIDC issuer from current tenant

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -3,6 +3,7 @@
 ### 1.4.0
 
 - Add new `headers` parameter to the `attest` and `attestProvenance` functions.
+- Update `buildSLSAProvenancePredicate`/`attestProvenance` to automatically derive default OIDC issuer URL from current execution context.
 
 ### 1.3.1
 

--- a/packages/attest/__tests__/__snapshots__/provenance.test.ts.snap
+++ b/packages/attest/__tests__/__snapshots__/provenance.test.ts.snap
@@ -9,7 +9,7 @@ exports[`provenance functions buildSLSAProvenancePredicate returns a provenance 
         "workflow": {
           "path": ".github/workflows/main.yml",
           "ref": "main",
-          "repository": "https://github.com/owner/repo",
+          "repository": "https://foo.ghe.com/owner/repo",
         },
       },
       "internalParameters": {
@@ -25,16 +25,16 @@ exports[`provenance functions buildSLSAProvenancePredicate returns a provenance 
           "digest": {
             "gitCommit": "babca52ab0c93ae16539e5923cb0d7403b9a093b",
           },
-          "uri": "git+https://github.com/owner/repo@refs/heads/main",
+          "uri": "git+https://foo.ghe.com/owner/repo@refs/heads/main",
         },
       ],
     },
     "runDetails": {
       "builder": {
-        "id": "https://github.com/owner/workflows/.github/workflows/publish.yml@main",
+        "id": "https://foo.ghe.com/owner/workflows/.github/workflows/publish.yml@main",
       },
       "metadata": {
-        "invocationId": "https://github.com/owner/repo/actions/runs/run-id/attempts/run-attempt",
+        "invocationId": "https://foo.ghe.com/owner/repo/actions/runs/run-id/attempts/run-attempt",
       },
     },
   },

--- a/packages/attest/__tests__/provenance.test.ts
+++ b/packages/attest/__tests__/provenance.test.ts
@@ -8,7 +8,7 @@ import {attestProvenance, buildSLSAProvenancePredicate} from '../src/provenance'
 
 describe('provenance functions', () => {
   const originalEnv = process.env
-  const issuer = 'https://example.com'
+  const issuer = 'https://token.actions.foo.ghe.com'
   const audience = 'nobody'
   const jwksPath = '/.well-known/jwks.json'
   const tokenPath = '/token'
@@ -38,7 +38,7 @@ describe('provenance functions', () => {
       ...originalEnv,
       ACTIONS_ID_TOKEN_REQUEST_URL: `${issuer}${tokenPath}?`,
       ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'token',
-      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_SERVER_URL: 'https://foo.ghe.com',
       GITHUB_REPOSITORY: claims.repository
     }
 
@@ -68,7 +68,7 @@ describe('provenance functions', () => {
 
   describe('buildSLSAProvenancePredicate', () => {
     it('returns a provenance hydrated from an OIDC token', async () => {
-      const predicate = await buildSLSAProvenancePredicate(issuer)
+      const predicate = await buildSLSAProvenancePredicate()
       expect(predicate).toMatchSnapshot()
     })
   })
@@ -96,9 +96,9 @@ describe('provenance functions', () => {
     })
 
     describe('when using the github Sigstore instance', () => {
-      const {fulcioURL, tsaServerURL} = signingEndpoints('github')
-
       beforeEach(async () => {
+        const {fulcioURL, tsaServerURL} = signingEndpoints('github')
+
         // Mock Sigstore
         await mockFulcio({baseURL: fulcioURL, strict: false})
         await mockTSA({baseURL: tsaServerURL})
@@ -118,8 +118,7 @@ describe('provenance functions', () => {
             subjectName,
             subjectDigest,
             token: 'token',
-            sigstore: 'github',
-            issuer
+            sigstore: 'github'
           })
 
           expect(attestation).toBeDefined()
@@ -146,8 +145,7 @@ describe('provenance functions', () => {
           const attestation = await attestProvenance({
             subjectName,
             subjectDigest,
-            token: 'token',
-            issuer
+            token: 'token'
           })
 
           expect(attestation).toBeDefined()
@@ -183,8 +181,7 @@ describe('provenance functions', () => {
             subjectName,
             subjectDigest,
             token: 'token',
-            sigstore: 'public-good',
-            issuer
+            sigstore: 'public-good'
           })
 
           expect(attestation).toBeDefined()
@@ -211,8 +208,7 @@ describe('provenance functions', () => {
           const attestation = await attestProvenance({
             subjectName,
             subjectDigest,
-            token: 'token',
-            issuer
+            token: 'token'
           })
 
           expect(attestation).toBeDefined()
@@ -238,8 +234,7 @@ describe('provenance functions', () => {
           subjectDigest,
           token: 'token',
           sigstore: 'public-good',
-          skipWrite: true,
-          issuer
+          skipWrite: true
         })
 
         expect(attestation).toBeDefined()

--- a/packages/attest/src/provenance.ts
+++ b/packages/attest/src/provenance.ts
@@ -5,8 +5,6 @@ import type {Attestation, Predicate} from './shared.types'
 const SLSA_PREDICATE_V1_TYPE = 'https://slsa.dev/provenance/v1'
 const GITHUB_BUILD_TYPE = 'https://actions.github.io/buildtypes/workflow/v1'
 
-const DEFAULT_ISSUER = 'https://token.actions.githubusercontent.com'
-
 export type AttestProvenanceOptions = Omit<
   AttestOptions,
   'predicate' | 'predicateType'
@@ -24,7 +22,7 @@ export type AttestProvenanceOptions = Omit<
  * @returns The SLSA provenance predicate.
  */
 export const buildSLSAProvenancePredicate = async (
-  issuer: string = DEFAULT_ISSUER
+  issuer?: string
 ): Promise<Predicate> => {
   const serverURL = process.env.GITHUB_SERVER_URL
   const claims = await getIDTokenClaims(issuer)


### PR DESCRIPTION
Closes: https://github.com/actions/toolkit/issues/1795

Updates the attestation logic so that the default OIDC issuer is derived from the current GH tenant context. 

This change should mean that most callers can omit the `issuer` parameter when calling `buildSLSAProvenancePredicate`/`attestProvenance` and rely on the library to select the correct OIDC issuer.