### PR TITLE
fix encoding for proxy auth token

### DIFF
--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -726,7 +726,9 @@ export class HttpClient {
       uri: proxyUrl.href,
       pipelining: !this._keepAlive ? 0 : 1,
       ...((proxyUrl.username || proxyUrl.password) && {
-        token: `${proxyUrl.username}:${proxyUrl.password}`
+        token: `Basic ${Buffer.from(
+          `${proxyUrl.username}:${proxyUrl.password}`
+        ).toString('base64')}`
       })
     })
     this._proxyAgentDispatcher = proxyAgent


### PR DESCRIPTION
Fixes: #1798 

Applies the correct encoding to the proxy auth token in the `HttpClient` class.

The `token` parameter to the `ProxyAgent` is used literally in the `Proxy-Authorization` header and needs to be encoded as a proper basic-auth value.

See: https://undici.nodejs.org/#/docs/api/ProxyAgent?id=example-basic-proxy-request-with-authentication

Note: I tried, but couldn't find any reasonable way to write a unit test for this change 😬 