### PR TITLE
feat: Add option to modify whether symlink if followed in ZIP archive

### DIFF
--- a/packages/artifact/__tests__/upload-zip-specification.test.ts
+++ b/packages/artifact/__tests__/upload-zip-specification.test.ts
@@ -38,6 +38,7 @@ const extraFileInFolderCPath = path.join(
   'extra-file-in-folder-c.txt'
 )
 const amazingFileInFolderHPath = path.join(root, 'folder-h', 'amazing-item.txt')
+const symlinkToFolderDPath = path.join(root, 'symlink-to-folder-d')
 
 const artifactFilesToUpload = [
   goodItem1Path,
@@ -46,7 +47,8 @@ const artifactFilesToUpload = [
   goodItem4Path,
   goodItem5Path,
   extraFileInFolderCPath,
-  amazingFileInFolderHPath
+  amazingFileInFolderHPath,
+  symlinkToFolderDPath
 ]
 
 describe('Search', () => {
@@ -89,6 +91,8 @@ describe('Search', () => {
     await fs.writeFile(extraFileInFolderCPath, 'extra file')
 
     await fs.writeFile(amazingFileInFolderHPath, 'amazing file')
+
+    await fs.symlink(path.join(root, 'folder-d'), symlinkToFolderDPath)
     /*
       Directory structure of files that get created:
       root/
@@ -112,6 +116,7 @@ describe('Search', () => {
               folder-i/
                   bad-item4.txt
                   bad-item5.txt
+          symlink-to-folder-d -> folder-d/
           good-item5.txt
     */
   })
@@ -168,7 +173,7 @@ describe('Search', () => {
       artifactFilesToUpload,
       root
     )
-    expect(specifications.length).toEqual(7)
+    expect(specifications.length).toEqual(8)
 
     const absolutePaths = specifications.map(item => item.sourcePath)
     expect(absolutePaths).toContain(goodItem1Path)
@@ -178,6 +183,7 @@ describe('Search', () => {
     expect(absolutePaths).toContain(goodItem5Path)
     expect(absolutePaths).toContain(extraFileInFolderCPath)
     expect(absolutePaths).toContain(amazingFileInFolderHPath)
+    expect(absolutePaths).toContain(symlinkToFolderDPath)
 
     for (const specification of specifications) {
       if (specification.sourcePath === goodItem1Path) {
@@ -212,6 +218,13 @@ describe('Search', () => {
       } else if (specification.sourcePath === amazingFileInFolderHPath) {
         expect(specification.destinationPath).toEqual(
           path.join('/folder-h', 'amazing-item.txt')
+        )
+      } else if (specification.sourcePath === symlinkToFolderDPath) {
+        expect(specification.destinationPath).toEqual(
+          path.join('/symlink-to-folder-d')
+        )
+        expect(specification.symlinkTargetPath).toEqual(
+          path.join(root, '/folder-d')
         )
       } else {
         throw new Error(
@@ -227,7 +240,7 @@ describe('Search', () => {
       artifactFilesToUpload,
       rootWithSlash
     )
-    expect(specifications.length).toEqual(7)
+    expect(specifications.length).toEqual(8)
 
     const absolutePaths = specifications.map(item => item.sourcePath)
     expect(absolutePaths).toContain(goodItem1Path)
@@ -237,6 +250,7 @@ describe('Search', () => {
     expect(absolutePaths).toContain(goodItem5Path)
     expect(absolutePaths).toContain(extraFileInFolderCPath)
     expect(absolutePaths).toContain(amazingFileInFolderHPath)
+    expect(absolutePaths).toContain(symlinkToFolderDPath)
 
     for (const specification of specifications) {
       if (specification.sourcePath === goodItem1Path) {
@@ -271,6 +285,13 @@ describe('Search', () => {
       } else if (specification.sourcePath === amazingFileInFolderHPath) {
         expect(specification.destinationPath).toEqual(
           path.join('/folder-h', 'amazing-item.txt')
+        )
+      } else if (specification.sourcePath === symlinkToFolderDPath) {
+        expect(specification.destinationPath).toEqual(
+          path.join('/symlink-to-folder-d')
+        )
+        expect(specification.symlinkTargetPath).toEqual(
+          path.join(root, '/folder-d')
         )
       } else {
         throw new Error(

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -45,6 +45,13 @@ export interface UploadArtifactOptions {
    * For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.
    */
   compressionLevel?: number
+
+  /**
+   * Whether or not symlinks in artifact ZIP should be followed.
+   *
+   * By default, artifact ZIP will follow symlinks.
+   */
+  followSymlinks?: boolean
 }
 
 /**

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -70,7 +70,8 @@ export async function uploadArtifact(
 
   const zipUploadStream = await createZipUploadStream(
     zipSpecification,
-    options?.compressionLevel
+    options?.compressionLevel,
+    options?.followSymlinks
   )
 
   // Upload zip to blob storage

--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -23,7 +23,8 @@ export class ZipUploadStream extends stream.Transform {
 
 export async function createZipUploadStream(
   uploadSpecification: UploadZipSpecification[],
-  compressionLevel: number = DEFAULT_COMPRESSION_LEVEL
+  compressionLevel: number = DEFAULT_COMPRESSION_LEVEL,
+  followSymlinks = true
 ): Promise<ZipUploadStream> {
   core.debug(
     `Creating Artifact archive with compressionLevel: ${compressionLevel}`
@@ -42,10 +43,15 @@ export async function createZipUploadStream(
 
   for (const file of uploadSpecification) {
     if (file.sourcePath !== null) {
-      // Add a normal file to the zip
-      zip.file(file.sourcePath, {
-        name: file.destinationPath
-      })
+      if (file.symlinkTargetPath !== undefined && !followSymlinks) {
+        // Add a symlink to the zip
+        zip.symlink(file.destinationPath, file.symlinkTargetPath)
+      } else {
+        // Add a normal file to the zip
+        zip.file(file.sourcePath, {
+          name: file.destinationPath
+        })
+      }
     } else {
       // Add a directory to the zip
       zip.append('', {name: file.destinationPath})

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -21,7 +21,7 @@
   "packages": {
     "": {
       "name": "@actions/glob",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@actions/http-client",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",


### PR DESCRIPTION
First step at fixing actions/upload-artifact#93

Currently, `upload-artifact` automatically follows symlinks present in specified paths. The problem with this approach is that it breaks macOS code-signed application packages that contains symlinks (like Electron) if the `.app` folder is specified to path without it being zipped. If we don't follow the symlink and simply preserve the symlinks as is, macOS code-signed Electron application no longer stops working.

Two changes are required to be able to allow disabling follow symlink.

[The first is to return the target path of a symlink with `getUploadZipSpecification`, modifying `createZipUploadStream` with option to follow symlinks and adding symlink to zip as necessary.](https://github.com/eXhumer/toolkit/commit/49751122cfc15a637f22181885f7479ee08cb683)

[The second is to add the option to `upload-artifact` and passing the option to `uploadArtifact` method.](https://github.com/eXhumer/upload-artifact/commit/0b7d5f5684d3f642f978d2faad9ade64f5b4dd57)

I have already done both of the changes and have tested it to make sure it is working as intended with forked upload-artifact `eXhumer/upload-artifact@0b7d5f5684d3f642f978d2faad9ade64f5b4dd57`.

[With the changes and specifying `follow-symlinks: false` in my GitHub Action workflow, upload-artifact no longer breaks the macOS application package](https://github.com/eXhumer/eXViewer/actions/runs/10507315804).