### PR TITLE
bump @actions/http-client from 2.2.1 to 2.2.3

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+### 1.4.1
+
+- Bump @actions/http-client from 2.2.1 to 2.2.3 [#1805](https://github.com/actions/toolkit/pull/1805)
+
 ### 1.4.0
 
 - Add new `headers` parameter to the `attest` and `attestProvenance` functions [#1790](https://github.com/actions/toolkit/pull/1790)

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@actions/attest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
-        "@actions/http-client": "^2.2.1",
+        "@actions/http-client": "^2.2.3",
         "@octokit/plugin-retry": "^6.0.1",
         "@sigstore/bundle": "^2.3.2",
         "@sigstore/sign": "^2.3.2",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
-      "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -1767,9 +1767,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
-      "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "requires": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Actions attestation lib",
   "keywords": [
     "github",
@@ -44,7 +44,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@actions/http-client": "^2.2.1",
+    "@actions/http-client": "^2.2.3",
     "@octokit/plugin-retry": "^6.0.1",
     "@sigstore/bundle": "^2.3.2",
     "@sigstore/sign": "^2.3.2",


### PR DESCRIPTION
Bumps `@actions/http-client` from version 2.2.1 to 2.2.3. Includes the fix for #1799.