### PR TITLE
Use native `crypto` package from node

### DIFF
--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -19,7 +19,6 @@
         "@octokit/request-error": "^5.0.0",
         "@protobuf-ts/plugin": "^2.2.3-alpha.1",
         "archiver": "^7.0.1",
-        "crypto": "^1.0.1",
         "jwt-decode": "^3.1.2",
         "twirp-ts": "^2.5.0",
         "unzip-stream": "^0.3.1"
@@ -851,12 +850,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -50,7 +50,6 @@
     "@octokit/request-error": "^5.0.0",
     "@protobuf-ts/plugin": "^2.2.3-alpha.1",
     "archiver": "^7.0.1",
-    "crypto": "^1.0.1",
     "jwt-decode": "^3.1.2",
     "twirp-ts": "^2.5.0",
     "unzip-stream": "^0.3.1"


### PR DESCRIPTION
Closes https://github.com/actions/toolkit/issues/1614

As far as I can tell, there is no need to actually have this dependency anymore, it should just use the native module instead. This trips up certain bundlers, probably because the package is not really correct - it refers to a `index.js` entrypoint that does not exist (I suspect node does some internal stuff for this??) - see https://www.npmjs.com/package/crypto?activeTab=code