### PR TITLE
Remove dependency on `uuid` package

### DIFF
--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -17,12 +17,10 @@
         "@azure/abort-controller": "^1.1.0",
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/storage-blob": "^12.13.0",
-        "semver": "^6.3.1",
-        "uuid": "^3.3.3"
+        "semver": "^6.3.1"
       },
       "devDependencies": {
         "@types/semver": "^6.0.0",
-        "@types/uuid": "^3.4.5",
         "typescript": "^5.2.2"
       }
     },
@@ -296,12 +294,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/uuid": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
-      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==",
-      "dev": true
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -484,15 +476,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {
@@ -764,12 +747,6 @@
         "@types/node": "*"
       }
     },
-    "@types/uuid": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
-      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==",
-      "dev": true
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -899,11 +876,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -45,12 +45,10 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/ms-rest-js": "^2.6.0",
     "@azure/storage-blob": "^12.13.0",
-    "semver": "^6.3.1",
-    "uuid": "^3.3.3"
+    "semver": "^6.3.1"
   },
   "devDependencies": {
     "@types/semver": "^6.0.0",
-    "@types/uuid": "^3.4.5",
     "typescript": "^5.2.2"
   }
 }

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -6,7 +6,6 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as semver from 'semver'
 import * as util from 'util'
-import {v4 as uuidV4} from 'uuid'
 import {
   CacheFilename,
   CompressionMethod,
@@ -34,7 +33,7 @@ export async function createTempDirectory(): Promise<string> {
     tempDirectory = path.join(baseLocation, 'actions', 'temp')
   }
 
-  const dest = path.join(tempDirectory, uuidV4())
+  const dest = path.join(tempDirectory, crypto.randomUUID())
   await io.mkdirP(dest)
   return dest
 }

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -4,9 +4,6 @@ import * as path from 'path'
 import * as core from '../src/core'
 import {HttpClient} from '@actions/http-client'
 import {toCommandProperties} from '../src/utils'
-import * as uuid from 'uuid'
-
-jest.mock('uuid')
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
@@ -49,11 +46,18 @@ const testEnvVars = {
 const UUID = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
 const DELIMITER = `ghadelimiter_${UUID}`
 
+const TEMP_DIR = path.join(__dirname, '_temp')
+
 describe('@actions/core', () => {
   beforeAll(() => {
-    const filePath = path.join(__dirname, `test`)
+    const filePath = TEMP_DIR
     if (!fs.existsSync(filePath)) {
       fs.mkdirSync(filePath)
+    } else {
+      // Clear out the temp directory
+      for (const file of fs.readdirSync(filePath)) {
+        fs.unlinkSync(path.join(filePath, file))
+      }
     }
   })
 
@@ -63,7 +67,7 @@ describe('@actions/core', () => {
     }
     process.stdout.write = jest.fn()
 
-    jest.spyOn(uuid, 'v4').mockImplementation(() => {
+    jest.spyOn(crypto, 'randomUUID').mockImplementation(() => {
       return UUID
     })
   })
@@ -141,7 +145,7 @@ describe('@actions/core', () => {
       `Unexpected input: value should not contain the delimiter "${DELIMITER}"`
     )
 
-    const filePath = path.join(__dirname, `test/${command}`)
+    const filePath = path.join(TEMP_DIR, command)
     fs.unlinkSync(filePath)
   })
 
@@ -155,7 +159,7 @@ describe('@actions/core', () => {
       `Unexpected input: name should not contain the delimiter "${DELIMITER}"`
     )
 
-    const filePath = path.join(__dirname, `test/${command}`)
+    const filePath = path.join(TEMP_DIR, command)
     fs.unlinkSync(filePath)
   })
 
@@ -347,7 +351,7 @@ describe('@actions/core', () => {
       `Unexpected input: value should not contain the delimiter "${DELIMITER}"`
     )
 
-    const filePath = path.join(__dirname, `test/${command}`)
+    const filePath = path.join(TEMP_DIR, command)
     fs.unlinkSync(filePath)
   })
 
@@ -361,7 +365,7 @@ describe('@actions/core', () => {
       `Unexpected input: name should not contain the delimiter "${DELIMITER}"`
     )
 
-    const filePath = path.join(__dirname, `test/${command}`)
+    const filePath = path.join(TEMP_DIR, command)
     fs.unlinkSync(filePath)
   })
 
@@ -585,7 +589,7 @@ describe('@actions/core', () => {
       `Unexpected input: value should not contain the delimiter "${DELIMITER}"`
     )
 
-    const filePath = path.join(__dirname, `test/${command}`)
+    const filePath = path.join(TEMP_DIR, command)
     fs.unlinkSync(filePath)
   })
 
@@ -599,7 +603,7 @@ describe('@actions/core', () => {
       `Unexpected input: name should not contain the delimiter "${DELIMITER}"`
     )
 
-    const filePath = path.join(__dirname, `test/${command}`)
+    const filePath = path.join(TEMP_DIR, command)
     fs.unlinkSync(filePath)
   })
 
@@ -641,7 +645,7 @@ function assertWriteCalls(calls: string[]): void {
 }
 
 function createFileCommandFile(command: string): void {
-  const filePath = path.join(__dirname, `test/${command}`)
+  const filePath = path.join(__dirname, `_temp/${command}`)
   process.env[`GITHUB_${command}`] = filePath
   fs.appendFileSync(filePath, '', {
     encoding: 'utf8'
@@ -649,7 +653,7 @@ function createFileCommandFile(command: string): void {
 }
 
 function verifyFileCommand(command: string, expectedContents: string): void {
-  const filePath = path.join(__dirname, `test/${command}`)
+  const filePath = path.join(__dirname, `_temp/${command}`)
   const contents = fs.readFileSync(filePath, 'utf8')
   try {
     expect(contents).toEqual(expectedContents)

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,12 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
+        "@actions/http-client": "^2.0.1"
       },
       "devDependencies": {
-        "@types/node": "^12.0.2",
-        "@types/uuid": "^8.3.4"
+        "@types/node": "^12.0.2"
       }
     },
     "node_modules/@actions/exec": {
@@ -45,26 +43,12 @@
       "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
       "dev": true
     },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
-    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     }
   },
@@ -96,21 +80,10 @@
       "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
       "dev": true
     },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
-    },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,11 +37,9 @@
   },
   "dependencies": {
     "@actions/exec": "^1.1.1",
-    "@actions/http-client": "^2.0.1",
-    "uuid": "^8.3.2"
+    "@actions/http-client": "^2.0.1"
   },
   "devDependencies": {
-    "@types/node": "^12.0.2",
-    "@types/uuid": "^8.3.4"
+    "@types/node": "^12.0.2"
   }
 }

--- a/packages/core/src/file-command.ts
+++ b/packages/core/src/file-command.ts
@@ -5,7 +5,6 @@
 
 import * as fs from 'fs'
 import * as os from 'os'
-import {v4 as uuidv4} from 'uuid'
 import {toCommandValue} from './utils'
 
 export function issueFileCommand(command: string, message: any): void {
@@ -25,7 +24,7 @@ export function issueFileCommand(command: string, message: any): void {
 }
 
 export function prepareKeyValueMessage(key: string, value: any): string {
-  const delimiter = `ghadelimiter_${uuidv4()}`
+  const delimiter = `ghadelimiter_${crypto.randomUUID()}`
   const convertedValue = toCommandValue(value)
 
   // These should realistically never happen, but just in case someone finds a

--- a/packages/tool-cache/package-lock.json
+++ b/packages/tool-cache/package-lock.json
@@ -13,13 +13,11 @@
         "@actions/exec": "^1.0.0",
         "@actions/http-client": "^2.0.1",
         "@actions/io": "^1.1.1",
-        "semver": "^6.1.0",
-        "uuid": "^3.3.2"
+        "semver": "^6.1.0"
       },
       "devDependencies": {
         "@types/nock": "^11.1.0",
         "@types/semver": "^6.0.0",
-        "@types/uuid": "^3.4.4",
         "nock": "^13.2.9"
       }
     },
@@ -71,26 +69,11 @@
         "nock": "*"
       }
     },
-    "node_modules/@types/node": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-      "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw==",
-      "dev": true
-    },
     "node_modules/@types/semver": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
       "integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
       "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
-      "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -166,15 +149,6 @@
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
-    },
-    "node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     }
   },
   "dependencies": {
@@ -224,26 +198,11 @@
         "nock": "*"
       }
     },
-    "@types/node": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-      "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw==",
-      "dev": true
-    },
     "@types/semver": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
       "integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
       "dev": true
-    },
-    "@types/uuid": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
-      "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "debug": {
       "version": "4.3.4",
@@ -299,11 +258,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     }
   }
 }

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -40,13 +40,11 @@
     "@actions/exec": "^1.0.0",
     "@actions/http-client": "^2.0.1",
     "@actions/io": "^1.1.1",
-    "semver": "^6.1.0",
-    "uuid": "^3.3.2"
+    "semver": "^6.1.0"
   },
   "devDependencies": {
     "@types/nock": "^11.1.0",
     "@types/semver": "^6.0.0",
-    "@types/uuid": "^3.4.4",
     "nock": "^13.2.9"
   }
 }

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -10,7 +10,6 @@ import * as stream from 'stream'
 import * as util from 'util'
 import {ok} from 'assert'
 import {OutgoingHttpHeaders} from 'http'
-import uuidV4 from 'uuid/v4'
 import {exec} from '@actions/exec/lib/exec'
 import {ExecOptions} from '@actions/exec/lib/interfaces'
 import {RetryHelper} from './retry-helper'
@@ -41,7 +40,7 @@ export async function downloadTool(
   auth?: string,
   headers?: OutgoingHttpHeaders
 ): Promise<string> {
-  dest = dest || path.join(_getTempDirectory(), uuidV4())
+  dest = dest || path.join(_getTempDirectory(), crypto.randomUUID())
   await io.mkdirP(path.dirname(dest))
   core.debug(`Downloading ${url}`)
   core.debug(`Destination ${dest}`)
@@ -651,7 +650,7 @@ export async function findFromManifest(
 async function _createExtractFolder(dest?: string): Promise<string> {
   if (!dest) {
     // create a temp dir
-    dest = path.join(_getTempDirectory(), uuidV4())
+    dest = path.join(_getTempDirectory(), crypto.randomUUID())
   }
   await io.mkdirP(dest)
   return dest


### PR DESCRIPTION
- Supports https://github.com/actions/toolkit/issues/925

A common pattern in the toolkit is to create temporary file or directory within the existing temp directory using a random UUID.

Versions of the `uuid` package below `v7` are deprecated, so we shouldn't depend on them. Additionally, Node has a built-in [`crypto.randomUUID()`](https://nodejs.org/docs/latest-v20.x/api/crypto.html#cryptorandomuuidoptions) method that can be used to generate UUIDs without the need for an external package. This function was introduced in versions of Node 14 and 15, so we should be safe to use it for actions that depend on both Node 16 and 20 (which are our only supported versions at this time).

I also went ahead and updated `@actions/core`, even though it was using a non-deprecated version of the `uuid` package.

Since these use cases is purely for temporary files, I don't think we strictly need a cryptographically secure UUID but that's an added bonus of using the built-in Node function.

Packages *shouldn't* be depending on the exact format of this temp file/directory, but even if they were this should be a compatible as we're still generating a version 4 UUID

> Generates a random [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.txt) version 4 UUID. The UUID is generated using a cryptographic pseudorandom number generator.


There are a couple other packages within the toolkit that have an indirect dependency on `uuid` through `@actions/core`, those can be updated as well once we release this new version of `@actions/core`.