### PR TITLE
Removes unneeded spaces at the end of lines

### DIFF
--- a/packages/core/src/oidc-utils.ts
+++ b/packages/core/src/oidc-utils.ts
@@ -50,8 +50,8 @@ export class OidcClient {
       .getJson<TokenResponse>(id_token_url)
       .catch(error => {
         throw new Error(
-          `Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+          `Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.message}`
         )
       })


### PR DESCRIPTION
When compiling this module into a webpack build, our pre-commit failed for extra spacing at the end of lines.  This simply removes those spaces.