### PR TITLE
Fix regression, auto readlink on symlinks again

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/artifact Releases
 
+### 2.1.10
+
+- Fixed a bug with symlinks not being automatically resolved.
+
 ### 2.1.9
 
 - Fixed artifact upload chunk timeout logic [#1774](https://github.com/actions/toolkit/pull/1774)

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -2,7 +2,8 @@
 
 ### 2.1.10
 
-- Fixed a bug with symlinks not being automatically resolved.
+- Fixed a regression with symlinks not being automatically resolved [#1830](https://github.com/actions/toolkit/pull/1830)
+- Fixed a regression with chunk timeout [#1786](https://github.com/actions/toolkit/pull/1786)
 
 ### 2.1.9
 

--- a/packages/artifact/__tests__/upload-zip-specification.test.ts
+++ b/packages/artifact/__tests__/upload-zip-specification.test.ts
@@ -305,4 +305,20 @@ describe('Search', () => {
       }
     }
   })
+
+  it('Upload Specification - Includes symlinks', async () => {
+    const targetPath = path.join(root, 'link-dir', 'symlink-me.txt')
+    await fs.mkdir(path.dirname(targetPath), {recursive: true})
+    await fs.writeFile(targetPath, 'symlink file content')
+
+    const uploadPath = path.join(root, 'upload-dir', 'symlink.txt')
+    await fs.mkdir(path.dirname(uploadPath), {recursive: true})
+    await fs.symlink(targetPath, uploadPath, 'file')
+
+    const specifications = getUploadZipSpecification([uploadPath], root)
+    expect(specifications.length).toEqual(1)
+    expect(specifications[0].sourcePath).toEqual(uploadPath)
+    expect(specifications[0].destinationPath).toEqual('/upload-dir/symlink.txt')
+    expect(specifications[0].stats.isSymbolicLink()).toBe(true)
+  })
 })

--- a/packages/artifact/__tests__/upload-zip-specification.test.ts
+++ b/packages/artifact/__tests__/upload-zip-specification.test.ts
@@ -318,7 +318,9 @@ describe('Search', () => {
     const specifications = getUploadZipSpecification([uploadPath], root)
     expect(specifications.length).toEqual(1)
     expect(specifications[0].sourcePath).toEqual(uploadPath)
-    expect(specifications[0].destinationPath).toEqual('/upload-dir/symlink.txt')
+    expect(specifications[0].destinationPath).toEqual(
+      path.join('upload-dir', 'symlink.txt')
+    )
     expect(specifications[0].stats.isSymbolicLink()).toBe(true)
   })
 })

--- a/packages/artifact/__tests__/upload-zip-specification.test.ts
+++ b/packages/artifact/__tests__/upload-zip-specification.test.ts
@@ -319,7 +319,7 @@ describe('Search', () => {
     expect(specifications.length).toEqual(1)
     expect(specifications[0].sourcePath).toEqual(uploadPath)
     expect(specifications[0].destinationPath).toEqual(
-      path.join('upload-dir', 'symlink.txt')
+      path.join('/upload-dir', 'symlink.txt')
     )
     expect(specifications[0].stats.isSymbolicLink()).toBe(true)
   })

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1315,9 +1315,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "node_modules/prettier": {
       "version": "2.8.8",

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/upload/upload-zip-specification.ts
+++ b/packages/artifact/src/internal/upload/upload-zip-specification.ts
@@ -13,6 +13,12 @@ export interface UploadZipSpecification {
    * The destination path in a zip for a file
    */
   destinationPath: string
+
+  /**
+   * Information about the file
+   * https://nodejs.org/api/fs.html#class-fsstats
+   */
+  stats: fs.Stats
 }
 
 /**
@@ -75,10 +81,11 @@ export function getUploadZipSpecification(
           - file3.txt
   */
   for (let file of filesToZip) {
-    if (!fs.existsSync(file)) {
+    const stats = fs.lstatSync(file, {throwIfNoEntry: false})
+    if (!stats) {
       throw new Error(`File ${file} does not exist`)
     }
-    if (!fs.statSync(file).isDirectory()) {
+    if (!stats.isDirectory()) {
       // Normalize and resolve, this allows for either absolute or relative paths to be used
       file = normalize(file)
       file = resolve(file)
@@ -94,7 +101,8 @@ export function getUploadZipSpecification(
 
       specification.push({
         sourcePath: file,
-        destinationPath: uploadPath
+        destinationPath: uploadPath,
+        stats
       })
     } else {
       // Empty directory
@@ -103,7 +111,8 @@ export function getUploadZipSpecification(
 
       specification.push({
         sourcePath: null,
-        destinationPath: directoryPath
+        destinationPath: directoryPath,
+        stats
       })
     }
   }

--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -1,4 +1,5 @@
 import * as stream from 'stream'
+import {readlink} from 'fs/promises'
 import * as archiver from 'archiver'
 import * as core from '@actions/core'
 import {UploadZipSpecification} from './upload-zip-specification'
@@ -42,8 +43,14 @@ export async function createZipUploadStream(
 
   for (const file of uploadSpecification) {
     if (file.sourcePath !== null) {
-      // Add a normal file to the zip
-      zip.file(file.sourcePath, {
+      // Check if symlink and resolve the source path
+      let sourcePath = file.sourcePath
+      if (file.stats.isSymbolicLink()) {
+        sourcePath = await readlink(file.sourcePath)
+      }
+
+      // Add the file to the zip
+      zip.file(sourcePath, {
         name: file.destinationPath
       })
     } else {


### PR DESCRIPTION
With the changes introduced in:
- https://github.com/actions/toolkit/pull/1771

Which was meant to resolve:
- https://github.com/actions/upload-artifact/issues/485

We introduced a new bug:
- https://github.com/actions/upload-artifact/issues/590

We had a slight regression with symlinks. The typical behavior is that they are auto-resolved and the contents of the zip are added at the link's location. With the lazy-stream wrapper being used, it did not resolve the symlinks.

This PR switches our `stat` to an `lstat`, and we can check for a symbolic link, then resolve it, when we add the file to the zip archive.