### PR TITLE
catching error message from github that's in Json format

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -627,8 +627,11 @@ export async function getManifestFromRepo(
       core.debug('Invalid json')
     }
   }
-
-  return releases
+  if (!releases.hasOwnProperty('documentation_url')) {
+    return releases
+  } else {
+    throw new Error('github API rate limiting response in JSON format')
+  }
 }
 
 export async function findFromManifest(


### PR DESCRIPTION
Description:

Updates fail condition for getManifestFromRepo function to include instances when github responds with JSON body for API rate limiting, that is incorrectly handled.
Related issue:

https://github.com/actions/setup-python/issues/903