### PR TITLE
Release `@actions/core v1.11.0`

### DIFF
--- a/packages/core/RELEASES.md
+++ b/packages/core/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/core Releases
 
+### 1.11.0
+- Remove dependency on `uuid` package [#1824](https://github.com/actions/toolkit/pull/1824)
+
 ### 1.10.1
 - Fix error message reference in oidc utils [#1511](https://github.com/actions/toolkit/pull/1511)
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/core",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/core",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^1.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Actions core lib",
   "keywords": [
     "github",


### PR DESCRIPTION
Releasing the changes from #1824 for `@actions/core`.

Once this is released, `@actions/cache` and `@actions/tool-cache` can be updated to point to this new version of `@actions/core` and fully remove their indirect dependency on `uuid`.

Supports #925 