### PR TITLE
Include #1551 in `@actions/core` 1.11.0 release notes

### DIFF
--- a/packages/core/RELEASES.md
+++ b/packages/core/RELEASES.md
@@ -1,6 +1,7 @@
 # @actions/core Releases
 
 ### 1.11.0
+- Add platform info utilities [#1551](https://github.com/actions/toolkit/pull/1551)
 - Remove dependency on `uuid` package [#1824](https://github.com/actions/toolkit/pull/1824)
 
 ### 1.10.1


### PR DESCRIPTION
I missed that #1551 was released as part of 1.11.0 when writing up the release notes in #1839