### PR TITLE
Properly resolve relative symlinks

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/artifact Releases
 
+### 2.1.11
+
+- Fixed a bug with relative symlinks resolution [#????](https://github.com/actions/toolkit/pull/????)
+
 ### 2.1.10
 
 - Fixed a regression with symlinks not being automatically resolved [#1830](https://github.com/actions/toolkit/pull/1830)

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -2,7 +2,7 @@
 
 ### 2.1.11
 
-- Fixed a bug with relative symlinks resolution [#????](https://github.com/actions/toolkit/pull/????)
+- Fixed a bug with relative symlinks resolution [#1844](https://github.com/actions/toolkit/pull/1844)
 
 ### 2.1.10
 

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/src/internal/upload/zip.ts
+++ b/packages/artifact/src/internal/upload/zip.ts
@@ -1,5 +1,5 @@
 import * as stream from 'stream'
-import {readlink} from 'fs/promises'
+import {realpath} from 'fs/promises'
 import * as archiver from 'archiver'
 import * as core from '@actions/core'
 import {UploadZipSpecification} from './upload-zip-specification'
@@ -46,7 +46,7 @@ export async function createZipUploadStream(
       // Check if symlink and resolve the source path
       let sourcePath = file.sourcePath
       if (file.stats.isSymbolicLink()) {
-        sourcePath = await readlink(file.sourcePath)
+        sourcePath = await realpath(file.sourcePath)
       }
 
       // Add the file to the zip


### PR DESCRIPTION
After adding custom symlink logic in:
- https://github.com/actions/toolkit/pull/1830

We did not resolve relative symlinks properly with `readlink`, we should have been using `realpath` to resolve. Also updated tests to better capture this case.

Reported in:
- https://github.com/actions/upload-artifact/issues/590#issuecomment-2399714918