### PR TITLE
Allow passing non-async function to group

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -324,7 +324,7 @@ export function endGroup(): void {
  * @param name The name of the group
  * @param fn The function to wrap in the group
  */
-export async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
+export async function group<T>(name: string, fn: () => T | Promise<T>): Promise<T> {
   startGroup(name)
 
   let result: T


### PR DESCRIPTION
The current version would give a `@typescript-eslint/require-await` error when there is no await inside and wouldn't accept a non-async block. This allows passing a non-async block (although still leaving the group function async, I don't know if it's possible to tie those together in TypeScript)