### PR TITLE
Document unreleased changes in `cache` and `tool-cache`

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,9 +1,12 @@
 # @actions/cache Releases
 
+### Unreleased
+- Remove dependency on `uuid` package [#1824](https://github.com/actions/toolkit/pull/1824), [#1842](https://github.com/actions/toolkit/pull/1842)
+
 ### 3.2.4
 
 - Updated `isGhes` check to include `.ghe.com` and `.ghe.localhost` as accepted hosts
-  
+
 ### 3.2.3
 
 - Fixed a bug that mutated path arguments to `getCacheVersion` [#1378](https://github.com/actions/toolkit/pull/1378)

--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/tool-cache Releases
 
+### Unreleased
+- Remove dependency on `uuid` package [#1824](https://github.com/actions/toolkit/pull/1824), [#1842](https://github.com/actions/toolkit/pull/1842)
+
 ### 2.0.1
 - Update to v2.0.1 of `@actions/http-client` [#1087](https://github.com/actions/toolkit/pull/1087)
 


### PR DESCRIPTION
- https://github.com/actions/toolkit/issues/925

Documenting the changes from #1824 and #1842, which have not been released yet.
Then ensures that when we cut a release soon, the removal of `uuid` will be documented.