### PR TITLE
`@actions/attest`: Support multi-subject attestations

### DIFF
--- a/packages/attest/README.md
+++ b/packages/attest/README.md
@@ -32,8 +32,7 @@ async function run() {
     const ghToken = core.getInput('gh-token');
 
     const attestation = await attest({
-        subjectName: 'my-artifact-name',
-        subjectDigest: { 'sha256': '36ab4667...'},
+        subjects: [{name: 'my-artifact-name', digest: { 'sha256': '36ab4667...'}}],
         predicateType: 'https://in-toto.io/attestation/release',
         predicate: { . . . },
         token: ghToken
@@ -49,11 +48,12 @@ The `attest` function supports the following options:
 
 ```typescript
 export type AttestOptions = {
-  // The name of the subject to be attested.
-  subjectName: string
-  // The digest of the subject to be attested. Should be a map of digest
-  // algorithms to their hex-encoded values.
-  subjectDigest: Record<string, string>
+  // Deprecated. Use 'subjects' instead.
+  subjectName?: string
+  // Deprecated. Use 'subjects' instead.
+  subjectDigest?: Record<string, string>
+  // Collection of subjects to be attested
+  subjects?: Subject[]
   // URI identifying the content type of the predicate being attested.
   predicateType: string
   // Predicate to be attested.
@@ -67,6 +67,13 @@ export type AttestOptions = {
   headers?: {[header: string]: string | number | undefined}
   // Whether to skip writing the attestation to the GH attestations API.
   skipWrite?: boolean
+}
+
+export type Subject = {
+   // Name of the subject.
+  name: string
+   // Digests of the subject. Should be a map of digest algorithms to their hex-encoded values.
+  digest: Record<string, string>
 }
 ```
 
@@ -105,12 +112,13 @@ The `attestProvenance` function supports the following options:
 
 ```typescript
 export type AttestProvenanceOptions = {
-  // The name of the subject to be attested.
-  subjectName: string
-  // The digest of the subject to be attested. Should be a map of digest
-  // algorithms to their hex-encoded values.
-  subjectDigest: Record<string, string>
-  // GitHub token for writing attestations.
+  // Deprecated. Use 'subjects' instead.
+  subjectName?: string
+  // Deprecated. Use 'subjects' instead.
+  subjectDigest?: Record<string, string>
+  // Collection of subjects to be attested
+  subjects?: Subject[]
+  // URI identifying the content type of the predicate being attested.
   token: string
   // Sigstore instance to use for signing. Must be one of "public-good" or
   // "github".

--- a/packages/attest/__tests__/attest.test.ts
+++ b/packages/attest/__tests__/attest.test.ts
@@ -1,0 +1,16 @@
+import {attest} from '../src/attest'
+
+describe('attest', () => {
+  describe('when no subject information is provided', () => {
+    it('throws an error', async () => {
+      const options = {
+        predicateType: 'foo',
+        predicate: {bar: 'baz'},
+        token: 'token'
+      }
+      expect(attest(options)).rejects.toThrowError(
+        'Must provide either subjectName and subjectDigest or subjects'
+      )
+    })
+  })
+})

--- a/packages/attest/__tests__/intoto.test.ts
+++ b/packages/attest/__tests__/intoto.test.ts
@@ -17,7 +17,7 @@ describe('buildIntotoStatement', () => {
   }
 
   it('returns an intoto statement', () => {
-    const statement = buildIntotoStatement(subject, predicate)
+    const statement = buildIntotoStatement([subject], predicate)
     expect(statement).toMatchSnapshot()
   })
 })

--- a/packages/attest/__tests__/provenance.test.ts
+++ b/packages/attest/__tests__/provenance.test.ts
@@ -115,8 +115,7 @@ describe('provenance functions', () => {
       describe('when the sigstore instance is explicitly set', () => {
         it('attests provenance', async () => {
           const attestation = await attestProvenance({
-            subjectName,
-            subjectDigest,
+            subjects: [{name: subjectName, digest: subjectDigest}],
             token: 'token',
             sigstore: 'github'
           })
@@ -143,8 +142,7 @@ describe('provenance functions', () => {
 
         it('attests provenance', async () => {
           const attestation = await attestProvenance({
-            subjectName,
-            subjectDigest,
+            subjects: [{name: subjectName, digest: subjectDigest}],
             token: 'token'
           })
 
@@ -178,8 +176,7 @@ describe('provenance functions', () => {
       describe('when the sigstore instance is explicitly set', () => {
         it('attests provenance', async () => {
           const attestation = await attestProvenance({
-            subjectName,
-            subjectDigest,
+            subjects: [{name: subjectName, digest: subjectDigest}],
             token: 'token',
             sigstore: 'public-good'
           })
@@ -206,8 +203,7 @@ describe('provenance functions', () => {
 
         it('attests provenance', async () => {
           const attestation = await attestProvenance({
-            subjectName,
-            subjectDigest,
+            subjects: [{name: subjectName, digest: subjectDigest}],
             token: 'token'
           })
 

--- a/packages/attest/src/intoto.ts
+++ b/packages/attest/src/intoto.ts
@@ -20,12 +20,12 @@ export type InTotoStatement = {
  * @returns The constructed in-toto statement.
  */
 export const buildIntotoStatement = (
-  subject: Subject,
+  subjects: Subject[],
   predicate: Predicate
 ): InTotoStatement => {
   return {
     _type: INTOTO_STATEMENT_V1_TYPE,
-    subject: [subject],
+    subject: subjects,
     predicateType: predicate.type,
     predicate: predicate.params
   }


### PR DESCRIPTION
Updates the `attest` and `attestProvenance` functions to accept an array of subjects which can be added to a single attestation.

Previously, these functions accepted a single subject name and digest -- allowing the consumer to create an attested intoto statement for just a single subject. This change deprecates the `subjectName`/`subjectDigest` params in favor of a new `subjects` option which accepts an array of subjects.