### PR TITLE
use macos-latest-large in test/release workflows

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
 
     steps:
       - name: setup repo
@@ -48,7 +48,7 @@ jobs:
           path: packages/${{ github.event.inputs.package }}/*.tgz
 
   publish:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     needs: test
     environment: npm-publish
     permissions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-latest-large, windows-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION

For the workflows which execute unit tests, bumps the macOS runner from `macos-latest` to `macos-latest-large` to work-around some test failures which are occurring in the `@actions/exec` package (see #1859)