### PR TITLE
Add option to overwrite the files on cache extraction

### DIFF
--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -111,6 +111,9 @@ async function getTarArgs(
 
   // Platform specific args
   if (tarPath.type === ArchiveToolType.GNU) {
+    // Make sure any existing files are overwritten
+    args.push('--overwrite')
+
     switch (process.platform) {
       case 'win32':
         args.push('--force-local')


### PR DESCRIPTION
When using GNU tar, if a file already exists, from a previous run or another cached action, it results in a slew of warning messages.

This change adds the use of --overwrite when using GNU tar so that any existing file will just be overwritten.

Similar issue was fixed in the @actions/tool-cache package, but not in @actions/cache: https://github.com/actions/toolkit/pull/807/files#diff-725a5ef102ee3762738a5500c3d7c5b6afef874a1cb67c55085ad5e4615b1a6f

This PR supersedes https://github.com/actions/toolkit/pull/1704