### PR TITLE
Fix the job summary table example

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -451,17 +451,17 @@ For example
 ```typescript
 
 const tableData = [
-  {data: 'Header1', header: true},
-  {data: 'Header2', header: true},
-  {data: 'Header3', header: true},
-  {data: 'MyData1'},
-  {data: 'MyData2'},
-  {data: 'MyData3'}
+  [
+    {data: 'Header1', header: true},
+    {data: 'Header2', header: true},
+    {data: 'Header3', header: true}
+  ],
+  ['MyData1', 'MyData2', 'MyData3']
 ]
 
 // Add an HTML table
-core.summary.addTable([tableData])
-// Output: <table><tr><th>Header1</th><th>Header2</th><th>Header3</th></tr><tr></tr><td>MyData1</td><td>MyData2</td><td>MyData3</td></tr></table>
+core.summary.addTable(tableData)
+// Output: <table><tr><th>Header1</th><th>Header2</th><th>Header3</th></tr><tr><td>MyData1</td><td>MyData2</td><td>MyData3</td></tr></table>
 
 ```
 


### PR DESCRIPTION
The current example for using `core.summary.addTable()` shows passing the data as a single row and does not correctly represent the sample output. This updates the example to be accurate both in code and in example output. I also took the liberty of hcanging the data cell content to strings to show both ways of passing cell data. This mirrors the [blog post](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/) that announced job summaries.