### PR TITLE
return artifact digest on upload

### DIFF
--- a/packages/artifact/__tests__/upload-artifact.test.ts
+++ b/packages/artifact/__tests__/upload-artifact.test.ts
@@ -281,7 +281,7 @@ describe('upload-artifact', () => {
       }
     )
 
-    const {id, size} = await uploadArtifact(
+    const {id, size, digest} = await uploadArtifact(
       fixtures.inputs.artifactName,
       fixtures.files.map(file =>
         path.join(fixtures.uploadDirectory, file.name)
@@ -291,6 +291,8 @@ describe('upload-artifact', () => {
 
     expect(id).toBe(1)
     expect(size).toBe(loadedBytes)
+    expect(digest).toBeDefined()
+    expect(digest).toHaveLength(64)
 
     const extractedDirectory = path.join(
       fixtures.uploadDirectory,

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -12,6 +12,11 @@ export interface UploadArtifactResponse {
    * This ID can be used as input to other APIs to download, delete or get more information about an artifact: https://docs.github.com/en/rest/actions/artifacts
    */
   id?: number
+
+  /**
+   * The SHA256 digest of the artifact that was created. Not provided if no artifact was uploaded
+   */
+  digest?: string
 }
 
 /**

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -110,6 +110,7 @@ export async function uploadArtifact(
 
   return {
     size: uploadResult.uploadSize,
+    digest: uploadResult.sha256Hash,
     id: Number(artifactId)
   }
 }


### PR DESCRIPTION
Updates the `UploadArtifactResponse` object to include the SHA-256 digest of the artifact that was created.

Returning the digest value will make it easy to integrate with things like the `attest-build-provenance` and `attest-sbom` actions -- allowing users to easily create attestations for artifacts created with the `upload-artifact` action.