### PR TITLE
Prepare artifact release 2.2.0

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/artifact Releases
 
+### 2.2.0
+
+- Return artifact digest on upload [#1896](https://github.com/actions/toolkit/pull/1896)
+
 ### 2.1.11
 
 - Fixed a bug with relative symlinks resolution [#1844](https://github.com/actions/toolkit/pull/1844)

--- a/packages/artifact/docs/generated/README.md
+++ b/packages/artifact/docs/generated/README.md
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[src/artifact.ts:7](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/artifact.ts#L7)
+[src/artifact.ts:7](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/artifact.ts#L7)

--- a/packages/artifact/docs/generated/classes/ArtifactNotFoundError.md
+++ b/packages/artifact/docs/generated/classes/ArtifactNotFoundError.md
@@ -48,7 +48,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:24](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L24)
+[src/internal/shared/errors.ts:24](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L24)
 
 ## Properties
 

--- a/packages/artifact/docs/generated/classes/DefaultArtifactClient.md
+++ b/packages/artifact/docs/generated/classes/DefaultArtifactClient.md
@@ -61,7 +61,7 @@ single DeleteArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:248](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L248)
+[src/internal/client.ts:248](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L248)
 
 ___
 
@@ -92,7 +92,7 @@ single DownloadArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:138](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L138)
+[src/internal/client.ts:138](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L138)
 
 ___
 
@@ -127,7 +127,7 @@ If there are multiple artifacts with the same name in the same workflow run this
 
 #### Defined in
 
-[src/internal/client.ts:212](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L212)
+[src/internal/client.ts:212](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L212)
 
 ___
 
@@ -159,7 +159,7 @@ ListArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:176](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L176)
+[src/internal/client.ts:176](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L176)
 
 ___
 
@@ -190,4 +190,4 @@ single UploadArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:113](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L113)
+[src/internal/client.ts:113](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L113)

--- a/packages/artifact/docs/generated/classes/FilesNotFoundError.md
+++ b/packages/artifact/docs/generated/classes/FilesNotFoundError.md
@@ -49,7 +49,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:4](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L4)
+[src/internal/shared/errors.ts:4](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L4)
 
 ## Properties
 
@@ -59,7 +59,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:2](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L2)
+[src/internal/shared/errors.ts:2](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L2)
 
 ___
 

--- a/packages/artifact/docs/generated/classes/GHESNotSupportedError.md
+++ b/packages/artifact/docs/generated/classes/GHESNotSupportedError.md
@@ -48,7 +48,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:31](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L31)
+[src/internal/shared/errors.ts:31](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L31)
 
 ## Properties
 

--- a/packages/artifact/docs/generated/classes/InvalidResponseError.md
+++ b/packages/artifact/docs/generated/classes/InvalidResponseError.md
@@ -48,7 +48,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:17](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L17)
+[src/internal/shared/errors.ts:17](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L17)
 
 ## Properties
 

--- a/packages/artifact/docs/generated/classes/NetworkError.md
+++ b/packages/artifact/docs/generated/classes/NetworkError.md
@@ -50,7 +50,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:42](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L42)
+[src/internal/shared/errors.ts:42](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L42)
 
 ## Properties
 
@@ -60,7 +60,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:40](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L40)
+[src/internal/shared/errors.ts:40](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L40)
 
 ___
 
@@ -198,4 +198,4 @@ ___
 
 #### Defined in
 
-[src/internal/shared/errors.ts:49](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L49)
+[src/internal/shared/errors.ts:49](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L49)

--- a/packages/artifact/docs/generated/classes/UsageError.md
+++ b/packages/artifact/docs/generated/classes/UsageError.md
@@ -43,7 +43,7 @@ Error.constructor
 
 #### Defined in
 
-[src/internal/shared/errors.ts:62](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L62)
+[src/internal/shared/errors.ts:62](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L62)
 
 ## Properties
 
@@ -181,4 +181,4 @@ ___
 
 #### Defined in
 
-[src/internal/shared/errors.ts:68](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/errors.ts#L68)
+[src/internal/shared/errors.ts:68](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/errors.ts#L68)

--- a/packages/artifact/docs/generated/interfaces/Artifact.md
+++ b/packages/artifact/docs/generated/interfaces/Artifact.md
@@ -23,7 +23,7 @@ The time when the artifact was created
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:123](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L123)
+[src/internal/shared/interfaces.ts:128](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L128)
 
 ___
 
@@ -35,7 +35,7 @@ The ID of the artifact
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:113](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L113)
+[src/internal/shared/interfaces.ts:118](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L118)
 
 ___
 
@@ -47,7 +47,7 @@ The name of the artifact
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:108](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L108)
+[src/internal/shared/interfaces.ts:113](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L113)
 
 ___
 
@@ -59,4 +59,4 @@ The size of the artifact in bytes
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:118](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L118)
+[src/internal/shared/interfaces.ts:123](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L123)

--- a/packages/artifact/docs/generated/interfaces/ArtifactClient.md
+++ b/packages/artifact/docs/generated/interfaces/ArtifactClient.md
@@ -43,7 +43,7 @@ single DeleteArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:103](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L103)
+[src/internal/client.ts:103](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L103)
 
 ___
 
@@ -70,7 +70,7 @@ single DownloadArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:89](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L89)
+[src/internal/client.ts:89](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L89)
 
 ___
 
@@ -101,7 +101,7 @@ If there are multiple artifacts with the same name in the same workflow run this
 
 #### Defined in
 
-[src/internal/client.ts:75](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L75)
+[src/internal/client.ts:75](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L75)
 
 ___
 
@@ -129,7 +129,7 @@ ListArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:57](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L57)
+[src/internal/client.ts:57](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L57)
 
 ___
 
@@ -156,4 +156,4 @@ single UploadArtifactResponse object
 
 #### Defined in
 
-[src/internal/client.ts:40](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/client.ts#L40)
+[src/internal/client.ts:40](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/client.ts#L40)

--- a/packages/artifact/docs/generated/interfaces/DeleteArtifactResponse.md
+++ b/packages/artifact/docs/generated/interfaces/DeleteArtifactResponse.md
@@ -20,4 +20,4 @@ The id of the artifact that was deleted
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:158](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L158)
+[src/internal/shared/interfaces.ts:163](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L163)

--- a/packages/artifact/docs/generated/interfaces/DownloadArtifactOptions.md
+++ b/packages/artifact/docs/generated/interfaces/DownloadArtifactOptions.md
@@ -20,4 +20,4 @@ Denotes where the artifact will be downloaded to. If not specified then the arti
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:98](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L98)
+[src/internal/shared/interfaces.ts:103](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L103)

--- a/packages/artifact/docs/generated/interfaces/DownloadArtifactResponse.md
+++ b/packages/artifact/docs/generated/interfaces/DownloadArtifactResponse.md
@@ -20,4 +20,4 @@ The path where the artifact was downloaded to
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:88](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L88)
+[src/internal/shared/interfaces.ts:93](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L93)

--- a/packages/artifact/docs/generated/interfaces/FindOptions.md
+++ b/packages/artifact/docs/generated/interfaces/FindOptions.md
@@ -27,4 +27,4 @@ The criteria for finding Artifact(s) out of the scope of the current run.
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:131](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L131)
+[src/internal/shared/interfaces.ts:136](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L136)

--- a/packages/artifact/docs/generated/interfaces/GetArtifactResponse.md
+++ b/packages/artifact/docs/generated/interfaces/GetArtifactResponse.md
@@ -20,4 +20,4 @@ Metadata about the artifact that was found
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:57](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L57)
+[src/internal/shared/interfaces.ts:62](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L62)

--- a/packages/artifact/docs/generated/interfaces/ListArtifactsOptions.md
+++ b/packages/artifact/docs/generated/interfaces/ListArtifactsOptions.md
@@ -21,4 +21,4 @@ In the case of reruns, this can be useful to avoid duplicates
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:68](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L68)
+[src/internal/shared/interfaces.ts:73](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L73)

--- a/packages/artifact/docs/generated/interfaces/ListArtifactsResponse.md
+++ b/packages/artifact/docs/generated/interfaces/ListArtifactsResponse.md
@@ -20,4 +20,4 @@ A list of artifacts that were found
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:78](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L78)
+[src/internal/shared/interfaces.ts:83](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L83)

--- a/packages/artifact/docs/generated/interfaces/UploadArtifactOptions.md
+++ b/packages/artifact/docs/generated/interfaces/UploadArtifactOptions.md
@@ -28,7 +28,7 @@ For large files that are not easily compressed, a value of 0 is recommended for 
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:47](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L47)
+[src/internal/shared/interfaces.ts:52](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L52)
 
 ___
 
@@ -52,4 +52,4 @@ input of 0 assumes default retention setting.
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:36](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L36)
+[src/internal/shared/interfaces.ts:41](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L41)

--- a/packages/artifact/docs/generated/interfaces/UploadArtifactResponse.md
+++ b/packages/artifact/docs/generated/interfaces/UploadArtifactResponse.md
@@ -8,10 +8,23 @@ Response from the server when an artifact is uploaded
 
 ### Properties
 
+- [digest](UploadArtifactResponse.md#digest)
 - [id](UploadArtifactResponse.md#id)
 - [size](UploadArtifactResponse.md#size)
 
 ## Properties
+
+### digest
+
+• `Optional` **digest**: `string`
+
+The SHA256 digest of the artifact that was created. Not provided if no artifact was uploaded
+
+#### Defined in
+
+[src/internal/shared/interfaces.ts:19](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L19)
+
+___
 
 ### id
 
@@ -22,7 +35,7 @@ This ID can be used as input to other APIs to download, delete or get more infor
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:14](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L14)
+[src/internal/shared/interfaces.ts:14](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L14)
 
 ___
 
@@ -34,4 +47,4 @@ Total size of the artifact in bytes. Not provided if no artifact was uploaded
 
 #### Defined in
 
-[src/internal/shared/interfaces.ts:8](https://github.com/actions/toolkit/blob/daf23ba/packages/artifact/src/internal/shared/interfaces.ts#L8)
+[src/internal/shared/interfaces.ts:8](https://github.com/actions/toolkit/blob/f522fdf/packages/artifact/src/internal/shared/interfaces.ts#L8)

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.1.11",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [


### PR DESCRIPTION
Prepare v2.2.0 release of `@actions/artifact` package:

* Bump version string in `package.json`
* Update `RELEASES.md`
* Regenerate docs (necessary to capture new `digest` field in `UploadArtifactResponse.md` interface)