### PR TITLE
Support pigz

### DIFF
--- a/packages/cache/src/internal/constants.ts
+++ b/packages/cache/src/internal/constants.ts
@@ -5,6 +5,7 @@ export enum CacheFilename {
 
 export enum CompressionMethod {
   Gzip = 'gzip',
+  Pigz = 'pigz',
   // Long range mode was added to zstd in v1.3.2.
   // This enum is for earlier version of zstd that does not have --long support
   ZstdWithoutLong = 'zstd-without-long',

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -65,6 +65,7 @@ async function getTarArgs(
   const BSD_TAR_ZSTD =
     tarPath.type === ArchiveToolType.BSD &&
     compressionMethod !== CompressionMethod.Gzip &&
+    compressionMethod !== CompressionMethod.Pigz &&
     IS_WINDOWS
 
   // Method specific args
@@ -146,6 +147,7 @@ async function getCommands(
   const BSD_TAR_ZSTD =
     tarPath.type === ArchiveToolType.BSD &&
     compressionMethod !== CompressionMethod.Gzip &&
+    compressionMethod !== CompressionMethod.Pigz &&
     IS_WINDOWS
 
   if (BSD_TAR_ZSTD && type !== 'create') {
@@ -171,14 +173,12 @@ async function getDecompressionProgram(
   compressionMethod: CompressionMethod,
   archivePath: string
 ): Promise<string[]> {
-  // -d: Decompress.
-  // unzstd is equivalent to 'zstd -d'
-  // --long=#: Enables long distance matching with # bits. Maximum is 30 (1GB) on 32-bit OS and 31 (2GB) on 64-bit.
-  // Using 30 here because we also support 32-bit self-hosted runners.
   const BSD_TAR_ZSTD =
     tarPath.type === ArchiveToolType.BSD &&
     compressionMethod !== CompressionMethod.Gzip &&
+    compressionMethod !== CompressionMethod.Pigz &&
     IS_WINDOWS
+
   switch (compressionMethod) {
     case CompressionMethod.Zstd:
       return BSD_TAR_ZSTD
@@ -199,6 +199,8 @@ async function getDecompressionProgram(
             archivePath.replace(new RegExp(`\\${path.sep}`, 'g'), '/')
           ]
         : ['--use-compress-program', IS_WINDOWS ? '"zstd -d"' : 'unzstd']
+    case CompressionMethod.Pigz:
+      return ['--use-compress-program', IS_WINDOWS ? '"pigz -d"' : 'pigz -d']
     default:
       return ['-z']
   }
@@ -218,7 +220,9 @@ async function getCompressionProgram(
   const BSD_TAR_ZSTD =
     tarPath.type === ArchiveToolType.BSD &&
     compressionMethod !== CompressionMethod.Gzip &&
+    compressionMethod !== CompressionMethod.Pigz &&
     IS_WINDOWS
+
   switch (compressionMethod) {
     case CompressionMethod.Zstd:
       return BSD_TAR_ZSTD
@@ -239,6 +243,8 @@ async function getCompressionProgram(
             TarFilename
           ]
         : ['--use-compress-program', IS_WINDOWS ? '"zstd -T0"' : 'zstdmt']
+    case CompressionMethod.Pigz:
+      return ['--use-compress-program', 'pigz']
     default:
       return ['-z']
   }


### PR DESCRIPTION
Adds support for `pigz` as a compression method.

`pigz` stands for "**P**arallel **I**mplementation of **Gz**ip". As the name suggests, it tries to do the work in parallel and so it's usually faster than plain Gzip.

Right now it'll just pick `pigz` over `gzip` when it's available. Usually you'll need to manually install `pigz` on the system and then this action can pick that up.

I think I'll need to write some tests? Can someone point out how?
Considering the implementation relies on gzip being installed before-hand.

#### I'm not a js/ts developer please point out any sub-optimalities. Not to mention first contribution to this repo.

## Why though?

For the Swift Package Manager (SwiftPM for short), we cache the `.build` directory for faster build times.
This helps a ton and can make things easily 2.5x faster. The bigger the project, the bigger the impact.
Swift also has a pretty slow build system, so the difference between build times on a real project is at least 3 mins. I've seen 20+ minutes of saved build time too.

The problem is, SwiftPM's `.build` directory is relatively big. Starts from like 500 MB for a non-insignificant project, and can easily climb up to 2 GB+.
The cache action needs to compress / decompress all this data, and that means it can take a few minutes just for caching stuff. The decompression is usually fast enough though, not reaching a minute even for 2 GB+ files.

## Numbers?

I've done some tests manually on some projects.

| Cache Size (GB) | Save Cache Time | Time Ratio | Machine Size     | Project         |
|-----------------|-----------------|------------|------------------|-----------------|
| 0.6             | 57s -> 46s      | 1.24x        | GitHub's Default | Private 1       |
| 1               | [76s](https://github.com/vapor/penny-bot/actions/runs/12547587263/job/34985338526) -> [37s](https://github.com/vapor/penny-bot/actions/runs/12557099546/job/35009211708)      | 2.05x        | GitHub's Default | vapor/penny-bot |
| 1.8             | 153s -> 43s     | 3.56x       | EC2 32 core      | Private 2       |
| 2.1             | 210s -> 53s     | 3.96x       | EC2 32 core      | Private 2       |

