### PR TITLE
Limit files extracted by restoreCache to those in paths option.

### DIFF
--- a/packages/cache/__tests__/restoreCache.test.ts
+++ b/packages/cache/__tests__/restoreCache.test.ts
@@ -154,7 +154,7 @@ test('restore with gzip compressed cache found', async () => {
   expect(getArchiveFileSizeInBytesMock).toHaveBeenCalledWith(archivePath)
 
   expect(extractTarMock).toHaveBeenCalledTimes(1)
-  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compression)
+  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compression, paths)
 
   expect(unlinkFileMock).toHaveBeenCalledTimes(1)
   expect(unlinkFileMock).toHaveBeenCalledWith(archivePath)
@@ -215,7 +215,7 @@ test('restore with zstd compressed cache found', async () => {
   expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~60 MB (62915000 B)`)
 
   expect(extractTarMock).toHaveBeenCalledTimes(1)
-  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compression)
+  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compression, paths)
   expect(getCompressionMock).toHaveBeenCalledTimes(1)
 })
 
@@ -273,7 +273,7 @@ test('restore with cache found for restore key', async () => {
   expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~0 MB (142 B)`)
 
   expect(extractTarMock).toHaveBeenCalledTimes(1)
-  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compression)
+  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compression, paths)
   expect(getCompressionMock).toHaveBeenCalledTimes(1)
 })
 

--- a/packages/cache/__tests__/restoreCacheV2.test.ts
+++ b/packages/cache/__tests__/restoreCacheV2.test.ts
@@ -203,7 +203,7 @@ test('restore with gzip compressed cache found', async () => {
   expect(logInfoMock).toHaveBeenCalledWith(`Cache Size: ~0 MB (142 B)`)
 
   expect(extractTarMock).toHaveBeenCalledTimes(1)
-  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compressionMethod)
+  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compressionMethod, paths)
 
   expect(unlinkFileMock).toHaveBeenCalledTimes(1)
   expect(unlinkFileMock).toHaveBeenCalledWith(archivePath)
@@ -279,7 +279,7 @@ test('restore with zstd compressed cache found', async () => {
   expect(logInfoMock).toHaveBeenCalledWith(`Cache Size: ~60 MB (62915000 B)`)
 
   expect(extractTarMock).toHaveBeenCalledTimes(1)
-  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compressionMethod)
+  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compressionMethod, paths)
 
   expect(unlinkFileMock).toHaveBeenCalledTimes(1)
   expect(unlinkFileMock).toHaveBeenCalledWith(archivePath)
@@ -356,7 +356,7 @@ test('restore with cache found for restore key', async () => {
   expect(logInfoMock).toHaveBeenCalledWith(`Cache Size: ~0 MB (142 B)`)
 
   expect(extractTarMock).toHaveBeenCalledTimes(1)
-  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compressionMethod)
+  expect(extractTarMock).toHaveBeenCalledWith(archivePath, compressionMethod, paths)
 
   expect(unlinkFileMock).toHaveBeenCalledTimes(1)
   expect(unlinkFileMock).toHaveBeenCalledWith(archivePath)

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -177,7 +177,7 @@ async function restoreCacheV1(
       )} MB (${archiveFileSize} B)`
     )
 
-    await extractTar(archivePath, compressionMethod)
+    await extractTar(archivePath, compressionMethod, paths)
     core.info('Cache restored successfully')
 
     return cacheEntry.cacheKey
@@ -291,7 +291,7 @@ async function restoreCacheV2(
       await listTar(archivePath, compressionMethod)
     }
 
-    await extractTar(archivePath, compressionMethod)
+    await extractTar(archivePath, compressionMethod, paths)
     core.info('Cache restored successfully')
 
     return response.matchedKey

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -55,7 +55,8 @@ async function getTarArgs(
   tarPath: ArchiveTool,
   compressionMethod: CompressionMethod,
   type: string,
-  archivePath = ''
+  archivePath = '',
+  paths: string[] = [],
 ): Promise<string[]> {
   const args = [`"${tarPath.path}"`]
   const cacheFileName = utils.getCacheFileName(compressionMethod)
@@ -95,7 +96,8 @@ async function getTarArgs(
           : archivePath.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
         '-P',
         '-C',
-        workingDirectory.replace(new RegExp(`\\${path.sep}`, 'g'), '/')
+        workingDirectory.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
+        ...paths,
       )
       break
     case 'list':
@@ -128,7 +130,8 @@ async function getTarArgs(
 async function getCommands(
   compressionMethod: CompressionMethod,
   type: string,
-  archivePath = ''
+  archivePath = '',
+  paths: string[] = [],
 ): Promise<string[]> {
   let args
 
@@ -137,7 +140,8 @@ async function getCommands(
     tarPath,
     compressionMethod,
     type,
-    archivePath
+    archivePath,
+    paths,
   )
   const compressionArgs =
     type !== 'create'
@@ -272,12 +276,13 @@ export async function listTar(
 // Extract a tar
 export async function extractTar(
   archivePath: string,
-  compressionMethod: CompressionMethod
+  compressionMethod: CompressionMethod,
+  paths?: string[],
 ): Promise<void> {
   // Create directory to extract tar into
   const workingDirectory = getWorkingDirectory()
   await io.mkdirP(workingDirectory)
-  const commands = await getCommands(compressionMethod, 'extract', archivePath)
+  const commands = await getCommands(compressionMethod, 'extract', archivePath, paths)
   await execCommands(commands)
 }
 


### PR DESCRIPTION
Not doing this facilitates cache poisoning attack in which attacker can clobber pretty much any file they want. This was exploited in https://github.com/ultralytics/ultralytics/issues/18027.