### PR TITLE
[cache] Use Azure SDK to restore cache always if explicitly set to true

### DIFF
--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -150,26 +150,21 @@ export async function downloadCache(
   const archiveUrl = new URL(archiveLocation)
   const downloadOptions = getDownloadOptions(options)
 
-  if (archiveUrl.hostname.endsWith('.blob.core.windows.net')) {
-    if (downloadOptions.useAzureSdk) {
-      // Use Azure storage SDK to download caches hosted on Azure to improve speed and reliability.
-      await downloadCacheStorageSDK(
-        archiveLocation,
-        archivePath,
-        downloadOptions
-      )
-    } else if (downloadOptions.concurrentBlobDownloads) {
-      // Use concurrent implementation with HttpClient to work around blob SDK issue
-      await downloadCacheHttpClientConcurrent(
-        archiveLocation,
-        archivePath,
-        downloadOptions
-      )
-    } else {
-      // Otherwise, download using the Actions http-client.
-      await downloadCacheHttpClient(archiveLocation, archivePath)
-    }
+  if (downloadOptions.useAzureSdk) {
+    // Use Azure storage SDK to download caches hosted on Azure to improve speed and reliability.
+    await downloadCacheStorageSDK(archiveLocation, archivePath, downloadOptions)
+  } else if (
+    downloadOptions.concurrentBlobDownloads &&
+    archiveUrl.hostname.endsWith('.blob.core.windows.net')
+  ) {
+    // Use concurrent implementation with HttpClient to work around blob SDK issue
+    await downloadCacheHttpClientConcurrent(
+      archiveLocation,
+      archivePath,
+      downloadOptions
+    )
   } else {
+    // Otherwise, download using the Actions http-client.
     await downloadCacheHttpClient(archiveLocation, archivePath)
   }
 }


### PR DESCRIPTION
With the new cache service v2, "restoreCacheV2" [^1] and "saveCacheV2" [^2] now explicitly use the Azure SDK for blob operations.

The cacheHttpClient uses the Azure SDK to save the cache if the `useAzureSdk` option is set to true. [^3]

However, it may not use the Azure SDK to download the cache even if the `useAzureSdk` option is set to true. If the signed URL does not end with "blob.core.windows.net," it will not use the Azure SDK to restore the cache. [^4]

To ensure consistent behavior between saving and restoring the cache, the Azure SDK should be used to restore the cache if the `useAzureSdk` option is explicitly set to true.

This PR ensures that the Azure SDK is used to restore the cache whenever the `useAzureSdk` option is set to true.

[^1]: https://github.com/actions/toolkit/blob/1f7c2c79e034fe8a0d28006f52fc5b70f6dbb750/packages/cache/src/cache.ts#L224
[^2]: https://github.com/actions/toolkit/blob/1f7c2c79e034fe8a0d28006f52fc5b70f6dbb750/packages/cache/src/cache.ts#L472
[^3]: https://github.com/actions/toolkit/blob/1f7c2c79e034fe8a0d28006f52fc5b70f6dbb750/packages/cache/src/internal/cacheHttpClient.ts#L335-L343
[^4]: https://github.com/actions/toolkit/blob/1f7c2c79e034fe8a0d28006f52fc5b70f6dbb750/packages/cache/src/internal/cacheHttpClient.ts#L153