### PR TITLE
core.setFailed and core.error to include stack trace to make debugging and triaging easier

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -244,7 +244,7 @@ export function debug(message: string): void {
 
 /**
  * Adds an error issue
- * @param message error issue message. Errors will be converted to string via toString()
+ * @param message error issue message. error.stack will be used for Errors
  * @param properties optional properties to add to the annotation.
  */
 export function error(
@@ -254,7 +254,7 @@ export function error(
   issueCommand(
     'error',
     toCommandProperties(properties),
-    message instanceof Error ? message.toString() : message
+    message instanceof Error ? message.stack : message
   )
 }
 


### PR DESCRIPTION
currently its impossible to know which place in the code caused an error if you have simple syntax errors like `replace is not a function`.

and if I get an report of an error with my action, report won't have anything meaningful to mention, which makes triaging process few steps longer than needed