### PR TITLE
Cache miss as debug, not warning annotation

### DIFF
--- a/packages/cache/__tests__/restoreCacheV2.test.ts
+++ b/packages/cache/__tests__/restoreCacheV2.test.ts
@@ -115,7 +115,6 @@ test('restore with restore keys and no cache found', async () => {
   const paths = ['node_modules']
   const key = 'node-test'
   const restoreKeys = ['node-']
-  const logWarningMock = jest.spyOn(core, 'warning')
 
   jest
     .spyOn(CacheServiceClientJSON.prototype, 'GetCacheEntryDownloadURL')
@@ -130,7 +129,7 @@ test('restore with restore keys and no cache found', async () => {
   const cacheKey = await restoreCache(paths, key, restoreKeys)
 
   expect(cacheKey).toBe(undefined)
-  expect(logWarningMock).toHaveBeenCalledWith(
+  expect(logDebugMock).toHaveBeenCalledWith(
     `Cache not found for keys: ${[key, ...restoreKeys].join(', ')}`
   )
 })

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -256,7 +256,7 @@ async function restoreCacheV2(
     const response = await twirpClient.GetCacheEntryDownloadURL(request)
 
     if (!response.ok) {
-      core.warning(`Cache not found for keys: ${keys.join(', ')}`)
+      core.debug(`Cache not found for keys: ${keys.join(', ')}`)
       return undefined
     }
 


### PR DESCRIPTION
Fixes:
- https://github.com/actions/cache/issues/1552

In `restoreCacheV2`, we have an additional warning on miss which is not the same behavior we had in `restoreCacheV1`. This changes the warning message & annotation to a debug (in V1 [we didn't have anything](https://github.com/actions/toolkit/blob/340a6b15b5879eefe1412ee6c8606978b091d3e8/packages/cache/src/cache.ts#L148)).