### PR TITLE
Default upload artifacts concurrency to 5

### DIFF
--- a/packages/artifact/__tests__/config.test.ts
+++ b/packages/artifact/__tests__/config.test.ts
@@ -56,22 +56,30 @@ describe('uploadChunkTimeoutEnv', () => {
 })
 
 describe('uploadConcurrencyEnv', () => {
-  it('should return default 32 when cpu num is <= 4', () => {
+  it('Concurrency default to 5', () => {
     ;(os.cpus as jest.Mock).mockReturnValue(new Array(4))
-    expect(config.getConcurrency()).toBe(32)
+    expect(config.getConcurrency()).toBe(5)
   })
 
-  it('should return 16 * num of cpu when cpu num is > 4', () => {
-    ;(os.cpus as jest.Mock).mockReturnValue(new Array(6))
-    expect(config.getConcurrency()).toBe(96)
-  })
-
-  it('should return up to 300 max value', () => {
+  it('Concurrency max out at 300 on systems with many CPUs', () => {
     ;(os.cpus as jest.Mock).mockReturnValue(new Array(32))
+    process.env.ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY = '301'
     expect(config.getConcurrency()).toBe(300)
   })
 
-  it('should return override value when ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY is set', () => {
+  it('Concurrency can be set to 32 when cpu num is <= 4', () => {
+    ;(os.cpus as jest.Mock).mockReturnValue(new Array(4))
+    process.env.ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY = '32'
+    expect(config.getConcurrency()).toBe(32)
+  })
+
+  it('Concurrency can be set 16 * num of cpu when cpu num is > 4', () => {
+    ;(os.cpus as jest.Mock).mockReturnValue(new Array(6))
+    process.env.ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY = '96'
+    expect(config.getConcurrency()).toBe(96)
+  })
+
+  it('Concurrency can be overridden by env var ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY', () => {
     ;(os.cpus as jest.Mock).mockReturnValue(new Array(4))
     process.env.ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY = '10'
     expect(config.getConcurrency()).toBe(10)
@@ -91,11 +99,5 @@ describe('uploadConcurrencyEnv', () => {
     expect(() => {
       config.getConcurrency()
     }).toThrow()
-  })
-
-  it('cannot go over currency cap when override value is greater', () => {
-    ;(os.cpus as jest.Mock).mockReturnValue(new Array(4))
-    process.env.ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY = '40'
-    expect(config.getConcurrency()).toBe(32)
   })
 })

--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -45,10 +45,8 @@ export function getGitHubWorkspaceDir(): string {
   return ghWorkspaceDir
 }
 
-// Mimics behavior of azcopy: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-optimize
-// If your machine has fewer than 5 CPUs, then the value of this variable is set to 32.
-// Otherwise, the default value is equal to 16 multiplied by the number of CPUs. The maximum value of this variable is 300.
-// This value can be lowered with ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY variable.
+// The maximum value of concurrency is 300.
+// This value can be changed with ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY variable.
 export function getConcurrency(): number {
   const numCPUs = os.cpus().length
   let concurrencyCap = 32
@@ -68,15 +66,20 @@ export function getConcurrency(): number {
     }
 
     if (concurrency < concurrencyCap) {
+      info(
+        `Set concurrency based on the value set in ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY.`
+      )
       return concurrency
     }
 
     info(
-      `ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY is higher than the cap of ${concurrencyCap} based on the number of cpus. Lowering it to the cap.`
+      `ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY is higher than the cap of ${concurrencyCap} based on the number of cpus. Set it to the maximum value allowed.`
     )
+    return concurrencyCap
   }
 
-  return concurrencyCap
+  // default concurrency to 5
+  return 5
 }
 
 export function getUploadChunkTimeout(): number {


### PR DESCRIPTION
Currently we set the default concurrency based on the number of CPUs in the system.  We have lowered it to 5 in some cases when `upload-artifact` action reported connectivity issues and we saw some improved stability, so making 5 the default.