### PR TITLE
set workflow.ref provenance field from ref claim

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+### 1.6.0
+
+- Update `buildSLSAProvenancePredicate` to populate `workflow.ref` field from the `ref` claim in the OIDC token [#1969](https://github.com/actions/toolkit/pull/1969)
+
 ### 1.5.0
 
 - Bump @actions/core from 1.10.1 to 1.11.1 [#1847](https://github.com/actions/toolkit/pull/1847)

--- a/packages/attest/__tests__/__snapshots__/provenance.test.ts.snap
+++ b/packages/attest/__tests__/__snapshots__/provenance.test.ts.snap
@@ -1,47 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`provenance functions buildSLSAProvenancePredicate handle tags including "@" character 1`] = `
-{
-  "params": {
-    "buildDefinition": {
-      "buildType": "https://actions.github.io/buildtypes/workflow/v1",
-      "externalParameters": {
-        "workflow": {
-          "path": ".github/workflows/main.yml",
-          "ref": "foo@1.0.0",
-          "repository": "https://foo.ghe.com/owner/repo",
-        },
-      },
-      "internalParameters": {
-        "github": {
-          "event_name": "push",
-          "repository_id": "repo-id",
-          "repository_owner_id": "owner-id",
-          "runner_environment": "github-hosted",
-        },
-      },
-      "resolvedDependencies": [
-        {
-          "digest": {
-            "gitCommit": "babca52ab0c93ae16539e5923cb0d7403b9a093b",
-          },
-          "uri": "git+https://foo.ghe.com/owner/repo@refs/heads/main",
-        },
-      ],
-    },
-    "runDetails": {
-      "builder": {
-        "id": "https://foo.ghe.com/owner/workflows/.github/workflows/publish.yml@main",
-      },
-      "metadata": {
-        "invocationId": "https://foo.ghe.com/owner/repo/actions/runs/run-id/attempts/run-attempt",
-      },
-    },
-  },
-  "type": "https://slsa.dev/provenance/v1",
-}
-`;
-
 exports[`provenance functions buildSLSAProvenancePredicate returns a provenance hydrated from an OIDC token 1`] = `
 {
   "params": {
@@ -50,7 +8,7 @@ exports[`provenance functions buildSLSAProvenancePredicate returns a provenance 
       "externalParameters": {
         "workflow": {
           "path": ".github/workflows/main.yml",
-          "ref": "main",
+          "ref": "refs/heads/main",
           "repository": "https://foo.ghe.com/owner/repo",
         },
       },

--- a/packages/attest/__tests__/provenance.test.ts
+++ b/packages/attest/__tests__/provenance.test.ts
@@ -75,16 +75,6 @@ describe('provenance functions', () => {
       const predicate = await buildSLSAProvenancePredicate()
       expect(predicate).toMatchSnapshot()
     })
-
-    it('handle tags including "@" character', async () => {
-      nock.cleanAll()
-      await mockIssuer({
-        ...claims,
-        workflow_ref: 'owner/repo/.github/workflows/main.yml@foo@1.0.0'
-      })
-      const predicate = await buildSLSAProvenancePredicate()
-      expect(predicate).toMatchSnapshot()
-    })
   })
 
   describe('attestProvenance', () => {

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/attest",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",

--- a/packages/attest/src/provenance.ts
+++ b/packages/attest/src/provenance.ts
@@ -30,11 +30,9 @@ export const buildSLSAProvenancePredicate = async (
   // Split just the path and ref from the workflow string.
   // owner/repo/.github/workflows/main.yml@main =>
   //   .github/workflows/main.yml, main
-  const [workflowPath, ...workflowRefChunks] = claims.workflow_ref
+  const [workflowPath] = claims.workflow_ref
     .replace(`${claims.repository}/`, '')
     .split('@')
-  // Handle case where tag contains `@` (e.g: when using changesets in a monorepo context),
-  const workflowRef = workflowRefChunks.join('@')
 
   return {
     type: SLSA_PREDICATE_V1_TYPE,
@@ -43,7 +41,7 @@ export const buildSLSAProvenancePredicate = async (
         buildType: GITHUB_BUILD_TYPE,
         externalParameters: {
           workflow: {
-            ref: workflowRef,
+            ref: claims.ref,
             repository: `${serverURL}/${claims.repository}`,
             path: workflowPath
           }


### PR DESCRIPTION
Updates the `buildSLSAProvenancePredicate` function in the `@actions/attest` package to populate the `workflow.ref` field from the `ref` claim in the OIDC token.

For most events which trigger a workflow run (`push`, `release`, `workflow_dispatch`, etc) this will have no impact on generated predicate statement. For other events which may be triggered from ref-less commits, this will ensure that the populated value more accurately reflects the state of the workflow run.