### PR TITLE
Change hash to digest for consistent terminology across runner logs

### DIFF
--- a/packages/artifact/src/internal/upload/blob-upload.ts
+++ b/packages/artifact/src/internal/upload/blob-upload.ts
@@ -98,7 +98,7 @@ export async function uploadZipToBlobStorage(
 
   hashStream.end()
   sha256Hash = hashStream.read() as string
-  core.info(`SHA256 hash of uploaded artifact zip is ${sha256Hash}`)
+  core.info(`SHA256 digest of uploaded artifact zip is ${sha256Hash}`)
 
   if (uploadByteCount === 0) {
     core.warning(


### PR DESCRIPTION
With the introduction of digest validation on artifact download, taking this opportunity to change the message printed during upload to use the same terminology.