### PR TITLE
Log cache version requested on debugging message

### DIFF
--- a/packages/cache/__tests__/restoreCacheV2.test.ts
+++ b/packages/cache/__tests__/restoreCacheV2.test.ts
@@ -115,6 +115,10 @@ test('restore with restore keys and no cache found', async () => {
   const paths = ['node_modules']
   const key = 'node-test'
   const restoreKeys = ['node-']
+  const cacheVersion =
+    'd90f107aaeb22920dba0c637a23c37b5bc497b4dfa3b07fe3f79bf88a273c11b'
+  const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
+  getCacheVersionMock.mockReturnValue(cacheVersion)
 
   jest
     .spyOn(CacheServiceClientJSON.prototype, 'GetCacheEntryDownloadURL')
@@ -130,7 +134,10 @@ test('restore with restore keys and no cache found', async () => {
 
   expect(cacheKey).toBe(undefined)
   expect(logDebugMock).toHaveBeenCalledWith(
-    `Cache not found for keys: ${[key, ...restoreKeys].join(', ')}`
+    `Cache not found for version ${cacheVersion} of keys: ${[
+      key,
+      ...restoreKeys
+    ].join(', ')}`
   )
 })
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -256,7 +256,11 @@ async function restoreCacheV2(
     const response = await twirpClient.GetCacheEntryDownloadURL(request)
 
     if (!response.ok) {
-      core.debug(`Cache not found for keys: ${keys.join(', ')}`)
+      core.debug(
+        `Cache not found for version ${request.version} of keys: ${keys.join(
+          ', '
+        )}`
+      )
       return undefined
     }
 


### PR DESCRIPTION
This changes adds additional logging information to the debug message returned when a cache restore request fails to find a matching key.

It adds the cache version requested as not only keys but also version must match for a cache restore to be successfully.

Logging the version will assist in troubleshooting cache restore failures.