### PR TITLE
Prepare Cache v4.0.3 & Artifact v2.3.2 releases

### DIFF
--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,5 +1,10 @@
 # @actions/artifact Releases
 
+### 2.3.2
+
+- Added masking for Secure Access Signatures (SAS) artifact URLs [#1982](https://github.com/actions/toolkit/pull/1982)
+- Change hash to digest for consistent terminology across runner logs [#1991](https://github.com/actions/toolkit/pull/1991) 
+
 ### 2.3.1
 
 - Fix comment typo on expectedHash. [#1986](https://github.com/actions/toolkit/pull/1986)

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,6 +1,6 @@
 # @actions/artifact Releases
 
-### 2.4.0
+### 2.3.2
 
 - Added masking for Shared Access Signature (SAS) artifact URLs [#1982](https://github.com/actions/toolkit/pull/1982)
 - Change hash to digest for consistent terminology across runner logs [#1991](https://github.com/actions/toolkit/pull/1991) 

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -2,7 +2,7 @@
 
 ### 2.4.0
 
-- Added masking for Secure Access Signatures (SAS) artifact URLs [#1982](https://github.com/actions/toolkit/pull/1982)
+- Added masking for Shared Access Signature (SAS) artifact URLs [#1982](https://github.com/actions/toolkit/pull/1982)
 - Change hash to digest for consistent terminology across runner logs [#1991](https://github.com/actions/toolkit/pull/1991) 
 
 ### 2.3.1

--- a/packages/artifact/RELEASES.md
+++ b/packages/artifact/RELEASES.md
@@ -1,6 +1,6 @@
 # @actions/artifact Releases
 
-### 2.3.2
+### 2.4.0
 
 - Added masking for Secure Access Signatures (SAS) artifact URLs [#1982](https://github.com/actions/toolkit/pull/1982)
 - Change hash to digest for consistent terminology across runner logs [#1991](https://github.com/actions/toolkit/pull/1991) 

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.4.0",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.4.0",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/artifact",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/artifact",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.4.0",
+  "version": "2.3.2",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/artifact",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "preview": true,
   "description": "Actions artifact lib",
   "keywords": [

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,6 +1,6 @@
 # @actions/cache Releases
 
-### 4.0.3
+### 4.1.0
 
 - Added masking for Secure Access Signatures (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
 

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -3,6 +3,7 @@
 ### 4.0.3
 
 - Added masking for Shared Access Signature (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
+- Improved debugging by logging both the cache version alongside the keys requested when a cache restore fails [#1994]](https://github.com/actions/toolkit/pull/1994)
 
 ### 4.0.2
 

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/cache Releases
 
+### 4.0.3
+
+- Added masking for Secure Access Signatures (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
+
 ### 4.0.2
 
 - Wrap create failures in ReserveCacheError [#1966](https://github.com/actions/toolkit/pull/1966)

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -3,7 +3,7 @@
 ### 4.0.3
 
 - Added masking for Shared Access Signature (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
-- Improved debugging by logging both the cache version alongside the keys requested when a cache restore fails [#1994]](https://github.com/actions/toolkit/pull/1994)
+- Improved debugging by logging both the cache version alongside the keys requested when a cache restore fails [#1994](https://github.com/actions/toolkit/pull/1994)
 
 ### 4.0.2
 

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,6 +1,6 @@
 # @actions/cache Releases
 
-### 4.1.0
+### 4.0.3
 
 - Added masking for Shared Access Signature (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
 

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -2,7 +2,7 @@
 
 ### 4.1.0
 
-- Added masking for Secure Access Signatures (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
+- Added masking for Shared Access Signature (SAS) cache entry URLs [#1982](https://github.com/actions/toolkit/pull/1982)
 
 ### 4.0.2
 

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "4.1.0",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "4.1.0",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "4.1.0",
+  "version": "4.0.3",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
This pull request includes bumps to the `@actions/artifact` and `@actions/cache` packages. The changes primarily focus on version updates and adding masking for Secure Access Signatures (SAS) URLs.

### Updates to `@actions/artifact` package:

* Added masking for Secure Access Signatures (SAS) artifact URLs to enhance security.
* Changed hash terminology to digest for consistent terminology across runner logs.
* Updated version number to `2.3.2` in `package.json`.

### Updates to `@actions/cache` package:

* Added masking for Secure Access Signatures (SAS) cache entry URLs to enhance security.
* Updated version number to `4.0.3` in `package.json`.
* Improved debugging by logging both the cache version and keys requested when a cache restore fails 