### PR TITLE
Fix maximum call stack size error

### DIFF
--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -50,6 +50,22 @@ describe('globber', () => {
     }
   })
 
+  it('captures large number of files', async () => {
+    const root = path.join(getTestTemp(), 'large-number-of-files')
+    await fs.mkdir(root, {recursive: true})
+
+    const promises: Promise<void>[] = []
+    for (let i = 0; i < 150000; i++) {
+      promises.push(
+        fs.writeFile(path.join(root, `item-${i}.txt`), 'test file content')
+      )
+    }
+
+    await Promise.all(promises)
+    const itemPaths = await glob(`${root}${path.sep}*`)
+    expect(itemPaths.length).toEqual(150000)
+  })
+
   it('defaults to followSymbolicLinks=true', async () => {
     // Create the following layout:
     //   <root>

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -146,10 +146,13 @@ export class DefaultGlobber implements Globber {
 
         // Push the child items in reverse
         const childLevel = item.level + 1
-        const childItems = (await fs.promises.readdir(item.path)).map(
-          x => new SearchState(path.join(item.path, x), childLevel)
-        )
-        stack.push(...childItems.reverse())
+        const childItems = await fs.promises.readdir(item.path)
+
+        for (let i = childItems.length - 1; i >= 0; i--) {
+          stack.push(
+            new SearchState(path.join(item.path, childItems[i]), childLevel)
+          )
+        }
       }
       // File
       else if (match & MatchKind.File) {


### PR DESCRIPTION
When a great number of files matching a glob pattern, the line
```typescript
stack.push(...childItems.reverse())
```
raises `Error: Maximum call stack size exceeded`. This can be fixed by pushing items to the array manually.