### PR TITLE
Log ignored files when using the Globber option

### DIFF
--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/glob Releases
 
+### 0.5.1
+- When using the `excludeHiddenFiles` option, log any ignored files with `core.info()` [#2040](https://github.com/actions/toolkit/pull/2040)
+
 ### 0.5.0
 - Added `excludeHiddenFiles` option, which is disabled by default to preserve existing behavior [#1791: Add glob option to ignore hidden files](https://github.com/actions/toolkit/pull/1791)
 

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "description": "Actions glob lib",
@@ -21,7 +21,7 @@
   "packages": {
     "": {
       "name": "@actions/glob",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -104,6 +104,7 @@ export class DefaultGlobber implements Globber {
 
     // Search
     const traversalChain: string[] = [] // used to detect cycles
+    let loggedFirstHiddenMessage: boolean = false // if printing hidden, is this the first one
     while (stack.length) {
       // Pop
       const item = stack.pop() as SearchState
@@ -130,6 +131,11 @@ export class DefaultGlobber implements Globber {
 
       // Hidden file or directory?
       if (options.excludeHiddenFiles && path.basename(item.path).match(/^\./)) {
+        if(!loggedFirstHiddenMessage) {
+          core.info(`Ignoring the following hidden files and directories`)
+          loggedFirstHiddenMessage = true
+        }
+        core.info(`- ${item.path}`)
         continue
       }
 

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -104,7 +104,7 @@ export class DefaultGlobber implements Globber {
 
     // Search
     const traversalChain: string[] = [] // used to detect cycles
-    let loggedFirstHiddenMessage: boolean = false // if printing hidden, is this the first one
+    let loggedFirstHiddenMessage = false // if printing hidden, is this the first one
     while (stack.length) {
       // Pop
       const item = stack.pop() as SearchState
@@ -131,7 +131,7 @@ export class DefaultGlobber implements Globber {
 
       // Hidden file or directory?
       if (options.excludeHiddenFiles && path.basename(item.path).match(/^\./)) {
-        if(!loggedFirstHiddenMessage) {
+        if (!loggedFirstHiddenMessage) {
           core.info(`Ignoring the following hidden files and directories`)
           loggedFirstHiddenMessage = true
         }


### PR DESCRIPTION
As above, when the Globber is set to ignore hidden files, log the files being ignored with `core.info()` so that users are quietly made aware.