### PR TITLE
Fix cache tests

### DIFF
--- a/packages/cache/__tests__/__fixtures__/index.js
+++ b/packages/cache/__tests__/__fixtures__/index.js
@@ -6,12 +6,12 @@ const filePath = process.env[`GITHUB_ENV`]
 fs.appendFileSync(filePath, `ACTIONS_RUNTIME_TOKEN=${process.env.ACTIONS_RUNTIME_TOKEN}${os.EOL}`, {
     encoding: 'utf8'
 })
-fs.appendFileSync(filePath, `ACTIONS_CACHE_URL=${process.env.ACTIONS_CACHE_URL}${os.EOL}`, {
+fs.appendFileSync(filePath, `ACTIONS_CACHE_URL=${process.env.ACTIONS_RESULTS_URL}${os.EOL}`, {
     encoding: 'utf8'
 })
 fs.appendFileSync(filePath, `GITHUB_RUN_ID=${process.env.GITHUB_RUN_ID}${os.EOL}`, {
     encoding: 'utf8'
 })
-fs.appendFileSync(filePath, `ACTIONS_CACHE_SERVICE_V2=true`, {
+fs.appendFileSync(filePath, `ACTIONS_CACHE_SERVICE_V2=true${os.EOL}`, {
     encoding: 'utf8'
 })

--- a/packages/cache/__tests__/__fixtures__/index.js
+++ b/packages/cache/__tests__/__fixtures__/index.js
@@ -3,15 +3,15 @@
 const fs = require('fs');
 const os = require('os');
 const filePath = process.env[`GITHUB_ENV`]
-fs.appendFileSync(filePath, `ACTIONS_RUNTIME_TOKEN=${process.env.ACTIONS_RUNTIME_TOKEN}${os.EOL}`, {
-    encoding: 'utf8'
-})
-fs.appendFileSync(filePath, `GITHUB_RUN_ID=${process.env.GITHUB_RUN_ID}${os.EOL}`, {
-    encoding: 'utf8'
-})
 fs.appendFileSync(filePath, `ACTIONS_CACHE_SERVICE_V2=true${os.EOL}`, {
     encoding: 'utf8'
 })
 fs.appendFileSync(filePath, `ACTIONS_RESULTS_URL=${process.env.ACTIONS_RESULTS_URL}${os.EOL}`, {
+    encoding: 'utf8'
+})
+fs.appendFileSync(filePath, `ACTIONS_RUNTIME_TOKEN=${process.env.ACTIONS_RUNTIME_TOKEN}${os.EOL}`, {
+    encoding: 'utf8'
+})
+fs.appendFileSync(filePath, `GITHUB_RUN_ID=${process.env.GITHUB_RUN_ID}${os.EOL}`, {
     encoding: 'utf8'
 })

--- a/packages/cache/__tests__/__fixtures__/index.js
+++ b/packages/cache/__tests__/__fixtures__/index.js
@@ -12,3 +12,6 @@ fs.appendFileSync(filePath, `GITHUB_RUN_ID=${process.env.GITHUB_RUN_ID}${os.EOL}
 fs.appendFileSync(filePath, `ACTIONS_CACHE_SERVICE_V2=true${os.EOL}`, {
     encoding: 'utf8'
 })
+fs.appendFileSync(filePath, `ACTIONS_RESULTS_URL=${process.env.ACTIONS_RESULTS_URL}${os.EOL}`, {
+    encoding: 'utf8'
+})

--- a/packages/cache/__tests__/__fixtures__/index.js
+++ b/packages/cache/__tests__/__fixtures__/index.js
@@ -6,9 +6,6 @@ const filePath = process.env[`GITHUB_ENV`]
 fs.appendFileSync(filePath, `ACTIONS_RUNTIME_TOKEN=${process.env.ACTIONS_RUNTIME_TOKEN}${os.EOL}`, {
     encoding: 'utf8'
 })
-fs.appendFileSync(filePath, `ACTIONS_CACHE_URL=${process.env.ACTIONS_RESULTS_URL}${os.EOL}`, {
-    encoding: 'utf8'
-})
 fs.appendFileSync(filePath, `GITHUB_RUN_ID=${process.env.GITHUB_RUN_ID}${os.EOL}`, {
     encoding: 'utf8'
 })

--- a/packages/cache/__tests__/__fixtures__/index.js
+++ b/packages/cache/__tests__/__fixtures__/index.js
@@ -12,3 +12,6 @@ fs.appendFileSync(filePath, `ACTIONS_CACHE_URL=${process.env.ACTIONS_CACHE_URL}$
 fs.appendFileSync(filePath, `GITHUB_RUN_ID=${process.env.GITHUB_RUN_ID}${os.EOL}`, {
     encoding: 'utf8'
 })
+fs.appendFileSync(filePath, `ACTIONS_CACHE_SERVICE_V2=true`, {
+    encoding: 'utf8'
+})


### PR DESCRIPTION
Closes https://github.com/actions/toolkit/issues/2042

Due to deprecation of ArtifactCache service, saveCacheV1 fails in production, and so the cache tests that use it fail. This addresses that.