### PR TITLE
Document `context.runAttempt` in @actions/github 6.0.1

### DIFF
--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -2,7 +2,8 @@
 
 ### 6.0.1
 
-- Dependency updates [#2043](https://github.com/actions/toolkit/pull/2043/)
+- Dependency updates [#2043](https://github.com/actions/toolkit/pull/2043)
+- Add `context.runAttempt` [#1588](https://github.com/actions/toolkit/pull/1588)
 
 ### 6.0.0 
 - Support the latest Octokit in @actions/github [#1553](https://github.com/actions/toolkit/pull/1553)


### PR DESCRIPTION
- #1754
- https://github.com/actions/github-script/issues/566

#1588 added `context.runAttempt` but we never published a new version until yesterday 😄 

