### PR TITLE
Add CacheMetadata with repository_id to cache v2 requests

### DIFF
--- a/packages/cache/__tests__/saveCacheV2.test.ts
+++ b/packages/cache/__tests__/saveCacheV2.test.ts
@@ -27,6 +27,7 @@ jest.mock('@azure/storage-blob', () => ({
 
 beforeAll(() => {
   process.env['ACTIONS_RUNTIME_TOKEN'] = 'token'
+  process.env['GITHUB_REPOSITORY_ID'] = '123456789'
   jest.spyOn(console, 'log').mockImplementation(() => {})
   jest.spyOn(core, 'debug').mockImplementation(() => {})
   jest.spyOn(core, 'info').mockImplementation(() => {})
@@ -124,6 +125,10 @@ test('create cache entry failure on non-ok response', async () => {
   )
 
   expect(createCacheEntryMock).toHaveBeenCalledWith({
+    metadata: {
+      repositoryId: '123456789',
+      scope: []
+    },
     key,
     version: cacheVersion
   })
@@ -159,6 +164,10 @@ test('create cache entry fails on rejected promise', async () => {
   )
 
   expect(createCacheEntryMock).toHaveBeenCalledWith({
+    metadata: {
+      repositoryId: '123456789',
+      scope: []
+    },
     key,
     version: cacheUtils.getCacheVersion(paths, compression)
   })
@@ -202,6 +211,10 @@ test('save cache fails if a signedUploadURL was not passed', async () => {
 
   expect(cacheId).toBe(-1)
   expect(createCacheEntryMock).toHaveBeenCalledWith({
+    metadata: {
+      repositoryId: '123456789',
+      scope: []
+    },
     key,
     version: cacheVersion
   })
@@ -265,6 +278,10 @@ test('finalize save cache failure', async () => {
   const cacheId = await saveCache([paths], key, options)
 
   expect(createCacheEntryMock).toHaveBeenCalledWith({
+    metadata: {
+      repositoryId: '123456789',
+      scope: []
+    },
     key,
     version: cacheVersion
   })
@@ -286,6 +303,10 @@ test('finalize save cache failure', async () => {
   expect(getCompressionMock).toHaveBeenCalledTimes(1)
 
   expect(finalizeCacheEntryMock).toHaveBeenCalledWith({
+    metadata: {
+      repositoryId: '123456789',
+      scope: []
+    },
     key,
     version: cacheVersion,
     sizeBytes: archiveFileSize.toString()
@@ -351,6 +372,10 @@ test('save with valid inputs uploads a cache', async () => {
   )
 
   expect(finalizeCacheEntryMock).toHaveBeenCalledWith({
+    metadata: {
+      repositoryId: '123456789',
+      scope: []
+    },
     key,
     version: cacheVersion,
     sizeBytes: archiveFileSize.toString()

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -12,6 +12,7 @@ import {
   FinalizeCacheEntryUploadResponse,
   GetCacheEntryDownloadURLRequest
 } from './generated/results/api/v1/cache'
+import {CacheMetadata} from './generated/results/entities/v1/cachemetadata'
 import {CacheFileSizeLimit} from './internal/constants'
 export class ValidationError extends Error {
   constructor(message: string) {
@@ -48,6 +49,17 @@ function checkKey(key: string): void {
     throw new ValidationError(
       `Key Validation Error: ${key} cannot contain commas.`
     )
+  }
+}
+
+function getCacheMetadata(): CacheMetadata | undefined {
+  const repositoryId = process.env['GITHUB_REPOSITORY_ID']
+  if (!repositoryId) {
+    return undefined
+  }
+  return {
+    repositoryId,
+    scope: []
   }
 }
 
@@ -525,6 +537,7 @@ async function saveCacheV2(
       enableCrossOsArchive
     )
     const request: CreateCacheEntryRequest = {
+      metadata: getCacheMetadata(),
       key,
       version
     }
@@ -553,6 +566,7 @@ async function saveCacheV2(
     )
 
     const finalizeRequest: FinalizeCacheEntryUploadRequest = {
+      metadata: getCacheMetadata(),
       key,
       version,
       sizeBytes: `${archiveFileSize}`


### PR DESCRIPTION
The V2 cache supports passing `metadata` so let's pass it along.

Fixes #2094