### PR TITLE
feat: add support for unzip argument in downloadArtifact

### DIFF
--- a/packages/artifact/__tests__/download-artifact.test.ts
+++ b/packages/artifact/__tests__/download-artifact.test.ts
@@ -169,8 +169,7 @@ describe('download-artifact', () => {
         fixtures.artifactID,
         fixtures.repositoryOwner,
         fixtures.repositoryName,
-        fixtures.token,
-        {unzip: true}
+        fixtures.token
       )
 
       expect(downloadArtifactMock).toHaveBeenCalledWith({
@@ -214,8 +213,7 @@ describe('download-artifact', () => {
         fixtures.artifactID,
         fixtures.repositoryOwner,
         fixtures.repositoryName,
-        fixtures.token,
-        {unzip: true}
+        fixtures.token
       )
 
       expect(downloadArtifactMock).toHaveBeenCalledWith({
@@ -272,8 +270,7 @@ describe('download-artifact', () => {
         fixtures.repositoryName,
         fixtures.token,
         {
-          path: customPath,
-          unzip: true
+          path: customPath
         }
       )
 
@@ -309,8 +306,7 @@ describe('download-artifact', () => {
           fixtures.artifactID,
           fixtures.repositoryOwner,
           fixtures.repositoryName,
-          fixtures.token,
-          {unzip: true}
+          fixtures.token
         )
       ).rejects.toBeInstanceOf(Error)
 
@@ -348,7 +344,7 @@ describe('download-artifact', () => {
       )
 
       await expect(
-        streamExtractExternal(fixtures.blobStorageUrl, fixtures.workspaceDir, {unzip: true})
+        streamExtractExternal(fixtures.blobStorageUrl, fixtures.workspaceDir)
       ).rejects.toBeInstanceOf(Error)
 
       expect(mockHttpClient).toHaveBeenCalledWith(getUserAgentString())
@@ -379,8 +375,7 @@ describe('download-artifact', () => {
           fixtures.artifactID,
           fixtures.repositoryOwner,
           fixtures.repositoryName,
-          fixtures.token,
-          {unzip: true}
+          fixtures.token
         )
       ).rejects.toBeInstanceOf(Error)
 
@@ -428,8 +423,7 @@ describe('download-artifact', () => {
         fixtures.artifactID,
         fixtures.repositoryOwner,
         fixtures.repositoryName,
-        fixtures.token,
-        {unzip: true}
+        fixtures.token
       )
 
       expect(downloadArtifactMock).toHaveBeenCalledWith({
@@ -547,7 +541,7 @@ describe('download-artifact', () => {
         }
       )
 
-      const response = await downloadArtifactInternal(fixtures.artifactID, {unzip: true})
+      const response = await downloadArtifactInternal(fixtures.artifactID)
 
       expectExtractedArchive(fixtures.workspaceDir)
       expect(response.downloadPath).toBe(fixtures.workspaceDir)
@@ -597,8 +591,7 @@ describe('download-artifact', () => {
       )
 
       const response = await downloadArtifactInternal(fixtures.artifactID, {
-        path: customPath,
-        unzip: true
+        path: customPath
       })
 
       expectExtractedArchive(customPath)
@@ -622,7 +615,7 @@ describe('download-artifact', () => {
         .mockRejectedValue(new Error('boom'))
 
       await expect(
-        downloadArtifactInternal(fixtures.artifactID, {unzip: true})
+        downloadArtifactInternal(fixtures.artifactID)
       ).rejects.toBeInstanceOf(Error)
     })
 
@@ -657,7 +650,7 @@ describe('download-artifact', () => {
       )
 
       await expect(
-        downloadArtifactInternal(fixtures.artifactID, {unzip: true})
+        downloadArtifactInternal(fixtures.artifactID)
       ).rejects.toBeInstanceOf(Error)
       expect(mockHttpClient).toHaveBeenCalledWith(getUserAgentString())
       expect(mockListArtifacts).toHaveBeenCalledWith({

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -100,7 +100,7 @@ export async function streamExtractExternal(
 
     let outputStream: NodeJS.WritableStream;
 
-    if (options?.unzip) {
+    if (options?.unzip ?? true) {
       outputStream = unzip.Extract({ path: directory });
     } else {
       const fileName = `${options?.artifactName}.zip`;

--- a/packages/artifact/src/internal/shared/interfaces.ts
+++ b/packages/artifact/src/internal/shared/interfaces.ts
@@ -115,7 +115,7 @@ export interface DownloadArtifactOptions {
   expectedHash?: string,
 
   /**
-   * Whenever to unzip the artifact after download.
+   * Whenever to unzip the artifact after download. Default to true.
    */
   unzip?: boolean
   /**
@@ -126,7 +126,7 @@ export interface DownloadArtifactOptions {
 
 export interface StreamExtractOptions {
   /**
-   * Whenever to unzip the artifact after download.
+   * Whenever to unzip the artifact after download. Default to true.
    */
   unzip?: boolean
   /**


### PR DESCRIPTION
This PR just add the possibility to filter what we want to unzip or not when downloading artifacts.

This feature was asked by so many people. I choose to focus on simplicity on this implementation and change almost nothing in the code, so it won't break any part of the existing toolkit.

Here a simple example that show how it work : https://github.com/shiipou/download-artifact/blob/main/.github/workflows/test.yml

You can also try it with this workflow : 

<details>

<summary>Workflow</summary>

```yml
name: Loop Over Artifact IDs

on: [push]

permissions:
  contents: write
  actions: write
  packages: write

jobs:
  create-artifacts:
    runs-on: ubuntu-latest
    steps:
      - name: Create and upload artifacts
        run: |
          mkdir -p artifact1 artifact2
          echo "Content1" > artifact1/file.txt
          echo "Content2.1" > artifact2/file1.txt
          echo "Content2.2" > artifact2/file2.txt
          echo "Content2.3" > artifact2/file3.txt
      - id: artifact-1
        name: Upload artifact 1
        uses: actions/upload-artifact@v4
        with:
          name: artifact1
          path: artifact1/*
      - id: artifact-2
        name: Upload artifact 2
        uses: actions/upload-artifact@v4
        with:
          name: artifact2
          path: artifact2/*
    outputs:
      artifact-1-id: ${{ steps.artifact-1.outputs.artifact-id }}
      artifact-2-id: ${{ steps.artifact-2.outputs.artifact-id }}

  process-artifacts:
    needs: create-artifacts
    runs-on: ubuntu-latest
    steps:
      - id: download-artifacts
        name: Download artifacts
        uses: shiipou/download-artifact@main
        with:
          artifact-ids: ${{ needs.create-artifacts.outputs.artifact-1-id }},${{ needs.create-artifacts.outputs.artifact-2-id }}
          path: artifacts/
          unzip: ${{ needs.create-artifacts.outputs.artifact-1-id }}
      - name: print artifacts
        run: ls -pAR artifacts/
      - name: unzip artifacts
        run: unzip artifacts/**/*.zip
```

![image](https://github.com/user-attachments/assets/7bf76499-0482-49bc-b9ab-6c1ffde44105)

</details>