### PR TITLE
fix(tool-cache): enable keepAlive for HTTP client to improve download reliability

### DIFF
--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -90,7 +90,8 @@ async function downloadToolAttempt(
 
   // Get the response headers
   const http = new httpm.HttpClient(userAgent, [], {
-    allowRetries: false
+    allowRetries: false,
+    keepAlive: true
   })
 
   if (auth) {


### PR DESCRIPTION
This PR updates the `httpm.HttpClient` initialization in the `tool-cache` package to explicitly set `keepAlive: true` when downloading tools.

The HTTP client is being created without specifying the `keepAlive` option, which defaults to `false`. 

https://github.com/actions/toolkit/blob/main/packages/http-client/src/index.ts#L142
https://github.com/actions/toolkit/blob/main/packages/http-client/src/index.ts#L172

This causes the client to open a new TCP connection for every request and close it immediately after. In some environments, especially those involving network proxies or service meshes, this pattern can lead to unreliable downloads, connection resets, or timeouts, as these systems often expect clients to reuse connections. 

Eg:
![Screenshot 2025-06-20 at 09 50 37](https://github.com/user-attachments/assets/3b90e749-1463-48f5-96ae-2b3459444f66)

By setting `keepAlive: true`, the HTTP client will reuse TCP connections for multiple requests. 