### PR TITLE
Explicit logging of cache key and restore key matches

### DIFF
--- a/packages/cache/__tests__/restoreCacheV2.test.ts
+++ b/packages/cache/__tests__/restoreCacheV2.test.ts
@@ -4,10 +4,10 @@ import * as tar from '../src/internal/tar'
 import * as config from '../src/internal/config'
 import * as cacheUtils from '../src/internal/cacheUtils'
 import * as cacheHttpClient from '../src/internal/cacheHttpClient'
-import { restoreCache } from '../src/cache'
-import { CacheFilename, CompressionMethod } from '../src/internal/constants'
-import { CacheServiceClientJSON } from '../src/generated/results/api/v1/cache.twirp-client'
-import { DownloadOptions } from '../src/options'
+import {restoreCache} from '../src/cache'
+import {CacheFilename, CompressionMethod} from '../src/internal/constants'
+import {CacheServiceClientJSON} from '../src/generated/results/api/v1/cache.twirp-client'
+import {DownloadOptions} from '../src/options'
 
 jest.mock('../src/internal/cacheHttpClient')
 jest.mock('../src/internal/cacheUtils')
@@ -18,11 +18,11 @@ let logDebugMock: jest.SpyInstance
 let logInfoMock: jest.SpyInstance
 
 beforeAll(() => {
-  jest.spyOn(console, 'log').mockImplementation(() => { })
-  jest.spyOn(core, 'debug').mockImplementation(() => { })
-  jest.spyOn(core, 'info').mockImplementation(() => { })
-  jest.spyOn(core, 'warning').mockImplementation(() => { })
-  jest.spyOn(core, 'error').mockImplementation(() => { })
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.spyOn(core, 'debug').mockImplementation(() => {})
+  jest.spyOn(core, 'info').mockImplementation(() => {})
+  jest.spyOn(core, 'warning').mockImplementation(() => {})
+  jest.spyOn(core, 'error').mockImplementation(() => {})
 
   jest.spyOn(cacheUtils, 'getCacheFileName').mockImplementation(cm => {
     const actualUtils = jest.requireActual('../src/internal/cacheUtils')
@@ -148,7 +148,7 @@ test('restore with gzip compressed cache found', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     'd90f107aaeb22920dba0c637a23c37b5bc497b4dfa3b07fe3f79bf88a273c11b'
-  const options = { useAzureSdk: true } as DownloadOptions
+  const options = {useAzureSdk: true} as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)
@@ -224,7 +224,7 @@ test('restore with zstd compressed cache found', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     '8e2e96a184cb0cd6b48285b176c06a418f3d7fce14c29d9886fd1bb4f05c513d'
-  const options = { useAzureSdk: true } as DownloadOptions
+  const options = {useAzureSdk: true} as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)
@@ -302,7 +302,7 @@ test('restore with cache found for restore key', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     'b8b58e9bd7b1e8f83d9f05c7e06ea865ba44a0330e07a14db74ac74386677bed'
-  const options = { useAzureSdk: true } as DownloadOptions
+  const options = {useAzureSdk: true} as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)
@@ -343,7 +343,9 @@ test('restore with cache found for restore key', async () => {
   const cacheKey = await restoreCache(paths, key, restoreKeys, options)
 
   expect(cacheKey).toBe(restoreKeys[0])
-  expect(logInfoMock).toHaveBeenCalledWith(`Cache hit for restore-key: ${restoreKeys[0]}`)
+  expect(logInfoMock).toHaveBeenCalledWith(
+    `Cache hit for restore-key: ${restoreKeys[0]}`
+  )
   expect(getCacheVersionMock).toHaveBeenCalledWith(
     paths,
     compressionMethod,
@@ -379,7 +381,7 @@ test('restore with lookup only enabled', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     'd90f107aaeb22920dba0c637a23c37b5bc497b4dfa3b07fe3f79bf88a273c11b'
-  const options = { lookupOnly: true, useAzureSdk: true } as DownloadOptions
+  const options = {lookupOnly: true, useAzureSdk: true} as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)

--- a/packages/cache/__tests__/restoreCacheV2.test.ts
+++ b/packages/cache/__tests__/restoreCacheV2.test.ts
@@ -4,10 +4,10 @@ import * as tar from '../src/internal/tar'
 import * as config from '../src/internal/config'
 import * as cacheUtils from '../src/internal/cacheUtils'
 import * as cacheHttpClient from '../src/internal/cacheHttpClient'
-import {restoreCache} from '../src/cache'
-import {CacheFilename, CompressionMethod} from '../src/internal/constants'
-import {CacheServiceClientJSON} from '../src/generated/results/api/v1/cache.twirp-client'
-import {DownloadOptions} from '../src/options'
+import { restoreCache } from '../src/cache'
+import { CacheFilename, CompressionMethod } from '../src/internal/constants'
+import { CacheServiceClientJSON } from '../src/generated/results/api/v1/cache.twirp-client'
+import { DownloadOptions } from '../src/options'
 
 jest.mock('../src/internal/cacheHttpClient')
 jest.mock('../src/internal/cacheUtils')
@@ -18,11 +18,11 @@ let logDebugMock: jest.SpyInstance
 let logInfoMock: jest.SpyInstance
 
 beforeAll(() => {
-  jest.spyOn(console, 'log').mockImplementation(() => {})
-  jest.spyOn(core, 'debug').mockImplementation(() => {})
-  jest.spyOn(core, 'info').mockImplementation(() => {})
-  jest.spyOn(core, 'warning').mockImplementation(() => {})
-  jest.spyOn(core, 'error').mockImplementation(() => {})
+  jest.spyOn(console, 'log').mockImplementation(() => { })
+  jest.spyOn(core, 'debug').mockImplementation(() => { })
+  jest.spyOn(core, 'info').mockImplementation(() => { })
+  jest.spyOn(core, 'warning').mockImplementation(() => { })
+  jest.spyOn(core, 'error').mockImplementation(() => { })
 
   jest.spyOn(cacheUtils, 'getCacheFileName').mockImplementation(cm => {
     const actualUtils = jest.requireActual('../src/internal/cacheUtils')
@@ -148,7 +148,7 @@ test('restore with gzip compressed cache found', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     'd90f107aaeb22920dba0c637a23c37b5bc497b4dfa3b07fe3f79bf88a273c11b'
-  const options = {useAzureSdk: true} as DownloadOptions
+  const options = { useAzureSdk: true } as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)
@@ -224,7 +224,7 @@ test('restore with zstd compressed cache found', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     '8e2e96a184cb0cd6b48285b176c06a418f3d7fce14c29d9886fd1bb4f05c513d'
-  const options = {useAzureSdk: true} as DownloadOptions
+  const options = { useAzureSdk: true } as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)
@@ -265,6 +265,7 @@ test('restore with zstd compressed cache found', async () => {
   const cacheKey = await restoreCache(paths, key, [], options)
 
   expect(cacheKey).toBe(key)
+  expect(logInfoMock).toHaveBeenCalledWith(`Cache hit for: ${key}`)
   expect(getCacheVersionMock).toHaveBeenCalledWith(
     paths,
     compressionMethod,
@@ -301,7 +302,7 @@ test('restore with cache found for restore key', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     'b8b58e9bd7b1e8f83d9f05c7e06ea865ba44a0330e07a14db74ac74386677bed'
-  const options = {useAzureSdk: true} as DownloadOptions
+  const options = { useAzureSdk: true } as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)
@@ -342,6 +343,7 @@ test('restore with cache found for restore key', async () => {
   const cacheKey = await restoreCache(paths, key, restoreKeys, options)
 
   expect(cacheKey).toBe(restoreKeys[0])
+  expect(logInfoMock).toHaveBeenCalledWith(`Cache hit for restore-key: ${restoreKeys[0]}`)
   expect(getCacheVersionMock).toHaveBeenCalledWith(
     paths,
     compressionMethod,
@@ -377,7 +379,7 @@ test('restore with lookup only enabled', async () => {
   const signedDownloadUrl = 'https://blob-storage.local?signed=true'
   const cacheVersion =
     'd90f107aaeb22920dba0c637a23c37b5bc497b4dfa3b07fe3f79bf88a273c11b'
-  const options = {lookupOnly: true, useAzureSdk: true} as DownloadOptions
+  const options = { lookupOnly: true, useAzureSdk: true } as DownloadOptions
 
   const getCacheVersionMock = jest.spyOn(cacheUtils, 'getCacheVersion')
   getCacheVersionMock.mockReturnValue(cacheVersion)

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -3,16 +3,16 @@ import * as path from 'path'
 import * as utils from './internal/cacheUtils'
 import * as cacheHttpClient from './internal/cacheHttpClient'
 import * as cacheTwirpClient from './internal/shared/cacheTwirpClient'
-import {getCacheServiceVersion, isGhes} from './internal/config'
-import {DownloadOptions, UploadOptions} from './options'
-import {createTar, extractTar, listTar} from './internal/tar'
+import { getCacheServiceVersion, isGhes } from './internal/config'
+import { DownloadOptions, UploadOptions } from './options'
+import { createTar, extractTar, listTar } from './internal/tar'
 import {
   CreateCacheEntryRequest,
   FinalizeCacheEntryUploadRequest,
   FinalizeCacheEntryUploadResponse,
   GetCacheEntryDownloadURLRequest
 } from './generated/results/api/v1/cache'
-import {CacheFileSizeLimit} from './internal/constants'
+import { CacheFileSizeLimit } from './internal/constants'
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message)
@@ -264,7 +264,12 @@ async function restoreCacheV2(
       return undefined
     }
 
-    core.info(`Cache hit for: ${request.key}`)
+    const isRestoreKeyMatch = request.key !== response.matchedKey
+    if (isRestoreKeyMatch) {
+      core.info(`Cache hit for restore-key: ${response.matchedKey}`)
+    } else {
+      core.info(`Cache hit for: ${response.matchedKey}`)
+    }
 
     if (options?.lookupOnly) {
       core.info('Lookup only - skipping download')
@@ -418,9 +423,9 @@ async function saveCacheV1(
     } else if (reserveCacheResponse?.statusCode === 400) {
       throw new Error(
         reserveCacheResponse?.error?.message ??
-          `Cache size of ~${Math.round(
-            archiveFileSize / (1024 * 1024)
-          )} MB (${archiveFileSize} B) is over the data cap limit, not saving cache.`
+        `Cache size of ~${Math.round(
+          archiveFileSize / (1024 * 1024)
+        )} MB (${archiveFileSize} B) is over the data cap limit, not saving cache.`
       )
     } else {
       throw new ReserveCacheError(

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -3,16 +3,16 @@ import * as path from 'path'
 import * as utils from './internal/cacheUtils'
 import * as cacheHttpClient from './internal/cacheHttpClient'
 import * as cacheTwirpClient from './internal/shared/cacheTwirpClient'
-import { getCacheServiceVersion, isGhes } from './internal/config'
-import { DownloadOptions, UploadOptions } from './options'
-import { createTar, extractTar, listTar } from './internal/tar'
+import {getCacheServiceVersion, isGhes} from './internal/config'
+import {DownloadOptions, UploadOptions} from './options'
+import {createTar, extractTar, listTar} from './internal/tar'
 import {
   CreateCacheEntryRequest,
   FinalizeCacheEntryUploadRequest,
   FinalizeCacheEntryUploadResponse,
   GetCacheEntryDownloadURLRequest
 } from './generated/results/api/v1/cache'
-import { CacheFileSizeLimit } from './internal/constants'
+import {CacheFileSizeLimit} from './internal/constants'
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message)
@@ -423,9 +423,9 @@ async function saveCacheV1(
     } else if (reserveCacheResponse?.statusCode === 400) {
       throw new Error(
         reserveCacheResponse?.error?.message ??
-        `Cache size of ~${Math.round(
-          archiveFileSize / (1024 * 1024)
-        )} MB (${archiveFileSize} B) is over the data cap limit, not saving cache.`
+          `Cache size of ~${Math.round(
+            archiveFileSize / (1024 * 1024)
+          )} MB (${archiveFileSize} B) is over the data cap limit, not saving cache.`
       )
     } else {
       throw new ReserveCacheError(


### PR DESCRIPTION
Fixes: https://github.com/actions/cache/issues/1626

Improve logging for cache restoration in the `restoreCacheV2` functionality. It adds more specific log messages to differentiate between cache hits for exact keys and restore keys, enhancing debugging and traceability.