### PR TITLE
improve glob performance by not ignoring negate

### DIFF
--- a/packages/glob/__tests__/internal-pattern-helper.test.ts
+++ b/packages/glob/__tests__/internal-pattern-helper.test.ts
@@ -128,7 +128,7 @@ describe('pattern-helper', () => {
     ])
   })
 
-  it('partialMatch skips negate patterns', () => {
+  it('partialMatch avoids going deep by respecting negate patterns', () => {
     const root = IS_WINDOWS ? 'C:\\' : '/'
     const patterns = [
       `${root}search1/foo/**`,
@@ -143,7 +143,7 @@ describe('pattern-helper', () => {
     expect(patternHelper.partialMatch(patterns, `${root}search2`)).toBeTruthy()
     expect(
       patternHelper.partialMatch(patterns, `${root}search2/bar`)
-    ).toBeTruthy()
+    ).toBeFalsy()
     expect(patternHelper.partialMatch(patterns, `${root}search3`)).toBeFalsy()
     expect(
       patternHelper.partialMatch(patterns, `${root}search3/bar`)

--- a/packages/glob/src/internal-pattern-helper.ts
+++ b/packages/glob/src/internal-pattern-helper.ts
@@ -77,5 +77,8 @@ export function match(patterns: Pattern[], itemPath: string): MatchKind {
  * Checks whether to descend further into the directory
  */
 export function partialMatch(patterns: Pattern[], itemPath: string): boolean {
-  return patterns.some(x => !x.negate && x.partialMatch(itemPath))
+  return (
+    patterns.some(x => !x.negate && x.partialMatch(itemPath)) &&
+    !patterns.some(x => x.negate && x.match(itemPath))
+  )
 }


### PR DESCRIPTION
Fixes #657

In a pnpm monorepo, I have the following patterns to upload with `upload-artifact`:

```
apps
packages
!**/node_modules
```

However, because a deep `apps/app-a/node_modules/abc` is a partial match, the globber goes through files in a directory that will be filtered out later anyway.

This reduces the time to find all matches from **1m 8s** to **250ms** with identical result arrays.