### PR TITLE
Reintroduce `@protobuf-ts/runtime-rpc` as a runtime dependency

### DIFF
--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
@@ -17,6 +17,7 @@
         "@azure/abort-controller": "^1.1.0",
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/storage-blob": "^12.13.0",
+        "@protobuf-ts/runtime": "^2.11.1",
         "semver": "^6.3.1"
       },
       "devDependencies": {
@@ -318,10 +319,9 @@
       }
     },
     "node_modules/@protobuf-ts/runtime": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
-      "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==",
-      "dev": true,
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@protobuf-ts/runtime-rpc": {
@@ -1045,10 +1045,9 @@
       "dev": true
     },
     "@protobuf-ts/runtime": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
-      "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==",
-      "dev": true
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ=="
     },
     "@protobuf-ts/runtime-rpc": {
       "version": "2.9.4",

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -17,7 +17,7 @@
         "@azure/abort-controller": "^1.1.0",
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/storage-blob": "^12.13.0",
-        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1",
         "semver": "^6.3.1"
       },
       "devDependencies": {
@@ -325,13 +325,12 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@protobuf-ts/runtime-rpc": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
-      "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
-      "dev": true,
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.9.4"
+        "@protobuf-ts/runtime": "^2.11.1"
       }
     },
     "node_modules/@types/node": {
@@ -1050,12 +1049,11 @@
       "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ=="
     },
     "@protobuf-ts/runtime-rpc": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
-      "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
-      "dev": true,
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
       "requires": {
-        "@protobuf-ts/runtime": "^2.9.4"
+        "@protobuf-ts/runtime": "^2.11.1"
       }
     },
     "@types/node": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -40,6 +40,7 @@
     "@actions/core": "^1.11.1",
     "@actions/exec": "^1.0.1",
     "@actions/glob": "^0.1.0",
+    "@protobuf-ts/runtime": "^2.11.1",
     "@actions/http-client": "^2.1.1",
     "@actions/io": "^1.0.1",
     "@azure/abort-controller": "^1.1.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -40,7 +40,7 @@
     "@actions/core": "^1.11.1",
     "@actions/exec": "^1.0.1",
     "@actions/glob": "^0.1.0",
-    "@protobuf-ts/runtime": "^2.11.1",
+    "@protobuf-ts/runtime-rpc": "^2.11.1",
     "@actions/http-client": "^2.1.1",
     "@actions/io": "^1.0.1",
     "@azure/abort-controller": "^1.1.0",


### PR DESCRIPTION
Fixes: https://github.com/actions/toolkit/issues/2112
Related to: https://github.com/actions/toolkit/pull/2106

By moving `@protobuf-ts/plugin` from dependencies to devDependencies, `@protobuf-ts/runtime-rpc` which is a runtime dependency was lost.

This change reintroduced `@protobuf-ts/runtime-rpc` only and not the entire `@protobuf-ts/plugin` package which has 6 other dependencies not needed during runtime.