### PR TITLE
Prepare release `4.0.5`

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,6 +1,12 @@
 # @actions/cache Releases
 
+### 4.0.5
+
+- Reintroduce @protobuf-ts/runtime-rpc as a runtime dependency [#2113](https://github.com/actions/toolkit/pull/2113)
+
 ### 4.0.4
+
+⚠️ Faulty patch release. Upgrade to 4.0.5 instead.
 
 - Optimized cache dependencies by moving `@protobuf-ts/plugin` to dev dependencies [#2106](https://github.com/actions/toolkit/pull/2106)
 - Improved cache service availability determination for different cache service versions (v1 and v2) [#2100](https://github.com/actions/toolkit/pull/2100)

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
Updates the `@actions/cache` package to version `4.0.5` and addresses a runtime dependency issue. The main change is the reintroduction of the `@protobuf-ts/runtime-rpc` package as a runtime dependency, which resolves a faulty patch in the previous release.