### PR TITLE
Remove 10GB Cache Size Limit for Cache Service V2

### DIFF
--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -237,7 +237,8 @@ test('save with server error should fail', async () => {
     .mockReturnValue(
       Promise.resolve({
         ok: true,
-        signedUploadUrl: 'https://blob-storage.local?signed=true'
+        signedUploadUrl: 'https://blob-storage.local?signed=true',
+        message: ""
       })
     )
 

--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -238,7 +238,7 @@ test('save with server error should fail', async () => {
       Promise.resolve({
         ok: true,
         signedUploadUrl: 'https://blob-storage.local?signed=true',
-        message: ""
+        message: ''
       })
     )
 

--- a/packages/cache/__tests__/saveCacheV2.test.ts
+++ b/packages/cache/__tests__/saveCacheV2.test.ts
@@ -458,7 +458,7 @@ test('save with finalize cache entry failure and specific error message', async 
   const createTarMock = jest.spyOn(tar, 'createTar')
   const saveCacheMock = jest
     .spyOn(cacheHttpClient, 'saveCache')
-    .mockResolvedValue(Promise.resolve())
+    .mockResolvedValue()
 
   const compression = CompressionMethod.Zstd
   const getCompressionMock = jest

--- a/packages/cache/__tests__/saveCacheV2.test.ts
+++ b/packages/cache/__tests__/saveCacheV2.test.ts
@@ -59,39 +59,6 @@ test('save with missing input should fail', async () => {
   )
 })
 
-test('save with large cache outputs should fail using', async () => {
-  const paths = 'node_modules'
-  const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
-  const cachePaths = [path.resolve(paths)]
-
-  const createTarMock = jest.spyOn(tar, 'createTar')
-  const logWarningMock = jest.spyOn(core, 'warning')
-
-  const cacheSize = 11 * 1024 * 1024 * 1024 //~11GB, over the 10GB limit
-  jest
-    .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
-    .mockReturnValueOnce(cacheSize)
-  const compression = CompressionMethod.Gzip
-  const getCompressionMock = jest
-    .spyOn(cacheUtils, 'getCompressionMethod')
-    .mockReturnValueOnce(Promise.resolve(compression))
-
-  const cacheId = await saveCache([paths], key)
-  expect(cacheId).toBe(-1)
-  expect(logWarningMock).toHaveBeenCalledWith(
-    'Failed to save: Cache size of ~11264 MB (11811160064 B) is over the 10GB limit, not saving cache.'
-  )
-
-  const archiveFolder = '/foo/bar'
-
-  expect(createTarMock).toHaveBeenCalledWith(
-    archiveFolder,
-    cachePaths,
-    compression
-  )
-  expect(getCompressionMock).toHaveBeenCalledTimes(1)
-})
-
 test('create cache entry failure on non-ok response', async () => {
   const paths = ['node_modules']
   const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'

--- a/packages/cache/__tests__/saveCacheV2.test.ts
+++ b/packages/cache/__tests__/saveCacheV2.test.ts
@@ -66,7 +66,7 @@ test('create cache entry failure on non-ok response', async () => {
 
   const createCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
-    .mockResolvedValue({ok: false, signedUploadUrl: ''})
+    .mockResolvedValue({ok: false, signedUploadUrl: '', message: ''})
 
   const createTarMock = jest.spyOn(tar, 'createTar')
   const finalizeCacheEntryMock = jest.spyOn(
@@ -149,7 +149,7 @@ test('save cache fails if a signedUploadURL was not passed', async () => {
   const createCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
     .mockReturnValue(
-      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL})
+      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL, message: ''})
     )
 
   const createTarMock = jest.spyOn(tar, 'createTar')
@@ -207,7 +207,7 @@ test('finalize save cache failure', async () => {
   const createCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
     .mockReturnValue(
-      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL})
+      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL, message: ''})
     )
 
   const createTarMock = jest.spyOn(tar, 'createTar')
@@ -227,7 +227,7 @@ test('finalize save cache failure', async () => {
 
   const finalizeCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
-    .mockReturnValue(Promise.resolve({ok: false, entryId: ''}))
+    .mockReturnValue(Promise.resolve({ok: false, entryId: '', message: ''}))
 
   const cacheId = await saveCache([paths], key, options)
 
@@ -286,7 +286,7 @@ test('save with valid inputs uploads a cache', async () => {
   jest
     .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
     .mockReturnValue(
-      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL})
+      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL, message: ''})
     )
 
   const saveCacheMock = jest.spyOn(cacheHttpClient, 'saveCache')
@@ -299,9 +299,251 @@ test('save with valid inputs uploads a cache', async () => {
 
   const finalizeCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
-    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString()}))
+    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''}))
 
   const expectedCacheId = await saveCache([paths], key)
+
+  const archiveFolder = '/foo/bar'
+  const archiveFile = path.join(archiveFolder, CacheFilename.Zstd)
+  expect(saveCacheMock).toHaveBeenCalledWith(
+    -1,
+    archiveFile,
+    signedUploadURL,
+    options
+  )
+  expect(createTarMock).toHaveBeenCalledWith(
+    archiveFolder,
+    cachePaths,
+    compression
+  )
+
+  expect(finalizeCacheEntryMock).toHaveBeenCalledWith({
+    key,
+    version: cacheVersion,
+    sizeBytes: archiveFileSize.toString()
+  })
+
+  expect(getCompressionMock).toHaveBeenCalledTimes(1)
+  expect(expectedCacheId).toBe(cacheId)
+})
+
+test('save with extremely large cache should succeed in v2 (no size limit)', async () => {
+  const paths = 'node_modules'
+  const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  const cachePaths = [path.resolve(paths)]
+  const signedUploadURL = 'https://blob-storage.local?signed=true'
+  const createTarMock = jest.spyOn(tar, 'createTar')
+  
+  // Simulate a very large cache (20GB)
+  const archiveFileSize = 20 * 1024 * 1024 * 1024 // 20GB
+  const options: UploadOptions = {
+    archiveSizeBytes: archiveFileSize,
+    useAzureSdk: true,
+    uploadChunkSize: 64 * 1024 * 1024,
+    uploadConcurrency: 8
+  }
+
+  jest
+    .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
+    .mockReturnValueOnce(archiveFileSize)
+
+  const cacheId = 4
+  jest
+    .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
+    .mockReturnValue(
+      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL, message: ''})
+    )
+
+  const saveCacheMock = jest.spyOn(cacheHttpClient, 'saveCache')
+
+  const compression = CompressionMethod.Zstd
+  const getCompressionMock = jest
+    .spyOn(cacheUtils, 'getCompressionMethod')
+    .mockReturnValue(Promise.resolve(compression))
+  const cacheVersion = cacheUtils.getCacheVersion([paths], compression)
+
+  const finalizeCacheEntryMock = jest
+    .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
+    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''}))
+
+  const expectedCacheId = await saveCache([paths], key)
+
+  const archiveFolder = '/foo/bar'
+  const archiveFile = path.join(archiveFolder, CacheFilename.Zstd)
+  expect(saveCacheMock).toHaveBeenCalledWith(
+    -1,
+    archiveFile,
+    signedUploadURL,
+    options
+  )
+  expect(createTarMock).toHaveBeenCalledWith(
+    archiveFolder,
+    cachePaths,
+    compression
+  )
+
+  expect(finalizeCacheEntryMock).toHaveBeenCalledWith({
+    key,
+    version: cacheVersion,
+    sizeBytes: archiveFileSize.toString()
+  })
+
+  expect(getCompressionMock).toHaveBeenCalledTimes(1)
+  expect(expectedCacheId).toBe(cacheId)
+})
+
+test('save with create cache entry failure and specific error message', async () => {
+  const paths = ['node_modules']
+  const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  const infoLogMock = jest.spyOn(core, 'info')
+  const warningLogMock = jest.spyOn(core, 'warning')
+  const errorMessage = 'Cache storage quota exceeded for repository'
+
+  const createCacheEntryMock = jest
+    .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
+    .mockResolvedValue({ok: false, signedUploadUrl: '', message: errorMessage})
+
+  const createTarMock = jest.spyOn(tar, 'createTar')
+  const compression = CompressionMethod.Zstd
+  const getCompressionMock = jest
+    .spyOn(cacheUtils, 'getCompressionMethod')
+    .mockResolvedValueOnce(compression)
+  const archiveFileSize = 1024
+  jest
+    .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
+    .mockReturnValueOnce(archiveFileSize)
+
+  const cacheId = await saveCache(paths, key)
+  expect(cacheId).toBe(-1)
+  
+  expect(warningLogMock).toHaveBeenCalledWith(
+    `Cache reservation failed: ${errorMessage}`
+  )
+  expect(infoLogMock).toHaveBeenCalledWith(
+    `Failed to save: Unable to reserve cache with key ${key}, another job may be creating this cache.`
+  )
+
+  expect(createCacheEntryMock).toHaveBeenCalledWith({
+    key,
+    version: cacheUtils.getCacheVersion(paths, compression)
+  })
+  expect(createTarMock).toHaveBeenCalledTimes(1)
+  expect(getCompressionMock).toHaveBeenCalledTimes(1)
+})
+
+test('save with finalize cache entry failure and specific error message', async () => {
+  const paths = 'node_modules'
+  const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  const cachePaths = [path.resolve(paths)]
+  const logWarningMock = jest.spyOn(core, 'warning')
+  const signedUploadURL = 'https://blob-storage.local?signed=true'
+  const archiveFileSize = 1024
+  const errorMessage = 'Cache entry finalization failed due to concurrent access'
+  const options: UploadOptions = {
+    archiveSizeBytes: archiveFileSize,
+    useAzureSdk: true,
+    uploadChunkSize: 64 * 1024 * 1024,
+    uploadConcurrency: 8
+  }
+
+  const createCacheEntryMock = jest
+    .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
+    .mockReturnValue(
+      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL, message: ''})
+    )
+
+  const createTarMock = jest.spyOn(tar, 'createTar')
+  const saveCacheMock = jest
+    .spyOn(cacheHttpClient, 'saveCache')
+    .mockResolvedValue(Promise.resolve())
+
+  const compression = CompressionMethod.Zstd
+  const getCompressionMock = jest
+    .spyOn(cacheUtils, 'getCompressionMethod')
+    .mockReturnValueOnce(Promise.resolve(compression))
+
+  const cacheVersion = cacheUtils.getCacheVersion([paths], compression)
+  jest
+    .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
+    .mockReturnValueOnce(archiveFileSize)
+
+  const finalizeCacheEntryMock = jest
+    .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
+    .mockReturnValue(Promise.resolve({ok: false, entryId: '', message: errorMessage}))
+
+  const cacheId = await saveCache([paths], key, options)
+
+  expect(createCacheEntryMock).toHaveBeenCalledWith({
+    key,
+    version: cacheVersion
+  })
+
+  const archiveFolder = '/foo/bar'
+  const archiveFile = path.join(archiveFolder, CacheFilename.Zstd)
+  expect(createTarMock).toHaveBeenCalledWith(
+    archiveFolder,
+    cachePaths,
+    compression
+  )
+
+  expect(saveCacheMock).toHaveBeenCalledWith(
+    -1,
+    archiveFile,
+    signedUploadURL,
+    options
+  )
+  expect(getCompressionMock).toHaveBeenCalledTimes(1)
+
+  expect(finalizeCacheEntryMock).toHaveBeenCalledWith({
+    key,
+    version: cacheVersion,
+    sizeBytes: archiveFileSize.toString()
+  })
+
+  expect(cacheId).toBe(-1)
+  expect(logWarningMock).toHaveBeenCalledWith(errorMessage)
+})
+
+test('save with multiple large caches should succeed in v2 (testing 50GB)', async () => {
+  const paths = ['large-dataset', 'node_modules', 'build-artifacts']
+  const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  const cachePaths = paths.map(p => path.resolve(p))
+  const signedUploadURL = 'https://blob-storage.local?signed=true'
+  const createTarMock = jest.spyOn(tar, 'createTar')
+  
+  // Simulate an extremely large cache (50GB)
+  const archiveFileSize = 50 * 1024 * 1024 * 1024 // 50GB
+  const options: UploadOptions = {
+    archiveSizeBytes: archiveFileSize,
+    useAzureSdk: true,
+    uploadChunkSize: 64 * 1024 * 1024,
+    uploadConcurrency: 8
+  }
+
+  jest
+    .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
+    .mockReturnValueOnce(archiveFileSize)
+
+  const cacheId = 7
+  jest
+    .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
+    .mockReturnValue(
+      Promise.resolve({ok: true, signedUploadUrl: signedUploadURL, message: ''})
+    )
+
+  const saveCacheMock = jest.spyOn(cacheHttpClient, 'saveCache')
+
+  const compression = CompressionMethod.Zstd
+  const getCompressionMock = jest
+    .spyOn(cacheUtils, 'getCompressionMethod')
+    .mockReturnValue(Promise.resolve(compression))
+  const cacheVersion = cacheUtils.getCacheVersion(paths, compression)
+
+  const finalizeCacheEntryMock = jest
+    .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
+    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''}))
+
+  const expectedCacheId = await saveCache(paths, key)
 
   const archiveFolder = '/foo/bar'
   const archiveFile = path.join(archiveFolder, CacheFilename.Zstd)

--- a/packages/cache/__tests__/saveCacheV2.test.ts
+++ b/packages/cache/__tests__/saveCacheV2.test.ts
@@ -299,7 +299,9 @@ test('save with valid inputs uploads a cache', async () => {
 
   const finalizeCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
-    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''}))
+    .mockReturnValue(
+      Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''})
+    )
 
   const expectedCacheId = await saveCache([paths], key)
 
@@ -333,7 +335,6 @@ test('save with extremely large cache should succeed in v2 (no size limit)', asy
   const cachePaths = [path.resolve(paths)]
   const signedUploadURL = 'https://blob-storage.local?signed=true'
   const createTarMock = jest.spyOn(tar, 'createTar')
-  
   // Simulate a very large cache (20GB)
   const archiveFileSize = 20 * 1024 * 1024 * 1024 // 20GB
   const options: UploadOptions = {
@@ -364,7 +365,9 @@ test('save with extremely large cache should succeed in v2 (no size limit)', asy
 
   const finalizeCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
-    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''}))
+    .mockReturnValue(
+      Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''})
+    )
 
   const expectedCacheId = await saveCache([paths], key)
 
@@ -415,7 +418,6 @@ test('save with create cache entry failure and specific error message', async ()
 
   const cacheId = await saveCache(paths, key)
   expect(cacheId).toBe(-1)
-  
   expect(warningLogMock).toHaveBeenCalledWith(
     `Cache reservation failed: ${errorMessage}`
   )
@@ -438,7 +440,8 @@ test('save with finalize cache entry failure and specific error message', async 
   const logWarningMock = jest.spyOn(core, 'warning')
   const signedUploadURL = 'https://blob-storage.local?signed=true'
   const archiveFileSize = 1024
-  const errorMessage = 'Cache entry finalization failed due to concurrent access'
+  const errorMessage =
+    'Cache entry finalization failed due to concurrent access'
   const options: UploadOptions = {
     archiveSizeBytes: archiveFileSize,
     useAzureSdk: true,
@@ -469,7 +472,9 @@ test('save with finalize cache entry failure and specific error message', async 
 
   const finalizeCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
-    .mockReturnValue(Promise.resolve({ok: false, entryId: '', message: errorMessage}))
+    .mockReturnValue(
+      Promise.resolve({ok: false, entryId: '', message: errorMessage})
+    )
 
   const cacheId = await saveCache([paths], key, options)
 
@@ -510,7 +515,6 @@ test('save with multiple large caches should succeed in v2 (testing 50GB)', asyn
   const cachePaths = paths.map(p => path.resolve(p))
   const signedUploadURL = 'https://blob-storage.local?signed=true'
   const createTarMock = jest.spyOn(tar, 'createTar')
-  
   // Simulate an extremely large cache (50GB)
   const archiveFileSize = 50 * 1024 * 1024 * 1024 // 50GB
   const options: UploadOptions = {
@@ -541,7 +545,9 @@ test('save with multiple large caches should succeed in v2 (testing 50GB)', asyn
 
   const finalizeCacheEntryMock = jest
     .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
-    .mockReturnValue(Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''}))
+    .mockReturnValue(
+      Promise.resolve({ok: true, entryId: cacheId.toString(), message: ''})
+    )
 
   const expectedCacheId = await saveCache(paths, key)
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -12,7 +12,6 @@ import {
   FinalizeCacheEntryUploadResponse,
   GetCacheEntryDownloadURLRequest
 } from './generated/results/api/v1/cache'
-import {CacheFileSizeLimit} from './internal/constants'
 import {HttpClientError} from '@actions/http-client'
 export class ValidationError extends Error {
   constructor(message: string) {
@@ -549,15 +548,6 @@ async function saveCacheV2(
 
     const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath)
     core.debug(`File Size: ${archiveFileSize}`)
-
-    // For GHES, this check will take place in ReserveCache API with enterprise file size limit
-    if (archiveFileSize > CacheFileSizeLimit && !isGhes()) {
-      throw new Error(
-        `Cache size of ~${Math.round(
-          archiveFileSize / (1024 * 1024)
-        )} MB (${archiveFileSize} B) is over the 10GB limit, not saving cache.`
-      )
-    }
 
     // Set the archive size in the options, will be used to display the upload progress
     options.archiveSizeBytes = archiveFileSize

--- a/packages/cache/src/generated/results/api/v1/cache.ts
+++ b/packages/cache/src/generated/results/api/v1/cache.ts
@@ -50,6 +50,12 @@ export interface CreateCacheEntryResponse {
      * @generated from protobuf field: string signed_upload_url = 2;
      */
     signedUploadUrl: string;
+    /**
+     * When !ok, this field may contain a human-readable error message used to create an annotation
+     *
+     * @generated from protobuf field: string message = 3;
+     */
+    message: string;
 }
 /**
  * @generated from protobuf message github.actions.results.api.v1.FinalizeCacheEntryUploadRequest
@@ -94,6 +100,12 @@ export interface FinalizeCacheEntryUploadResponse {
      * @generated from protobuf field: int64 entry_id = 2;
      */
     entryId: string;
+    /**
+     * When !ok, this field may contain a human-readable error message used to create an annotation
+     *
+     * @generated from protobuf field: string message = 3;
+     */
+    message: string;
 }
 /**
  * @generated from protobuf message github.actions.results.api.v1.GetCacheEntryDownloadURLRequest
@@ -211,11 +223,12 @@ class CreateCacheEntryResponse$Type extends MessageType<CreateCacheEntryResponse
     constructor() {
         super("github.actions.results.api.v1.CreateCacheEntryResponse", [
             { no: 1, name: "ok", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 2, name: "signed_upload_url", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "signed_upload_url", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<CreateCacheEntryResponse>): CreateCacheEntryResponse {
-        const message = { ok: false, signedUploadUrl: "" };
+        const message = { ok: false, signedUploadUrl: "", message: "" };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<CreateCacheEntryResponse>(this, message, value);
@@ -231,6 +244,9 @@ class CreateCacheEntryResponse$Type extends MessageType<CreateCacheEntryResponse
                     break;
                 case /* string signed_upload_url */ 2:
                     message.signedUploadUrl = reader.string();
+                    break;
+                case /* string message */ 3:
+                    message.message = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -250,6 +266,9 @@ class CreateCacheEntryResponse$Type extends MessageType<CreateCacheEntryResponse
         /* string signed_upload_url = 2; */
         if (message.signedUploadUrl !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.signedUploadUrl);
+        /* string message = 3; */
+        if (message.message !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.message);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -333,11 +352,12 @@ class FinalizeCacheEntryUploadResponse$Type extends MessageType<FinalizeCacheEnt
     constructor() {
         super("github.actions.results.api.v1.FinalizeCacheEntryUploadResponse", [
             { no: 1, name: "ok", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 2, name: "entry_id", kind: "scalar", T: 3 /*ScalarType.INT64*/ }
+            { no: 2, name: "entry_id", kind: "scalar", T: 3 /*ScalarType.INT64*/ },
+            { no: 3, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<FinalizeCacheEntryUploadResponse>): FinalizeCacheEntryUploadResponse {
-        const message = { ok: false, entryId: "0" };
+        const message = { ok: false, entryId: "0", message: "" };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<FinalizeCacheEntryUploadResponse>(this, message, value);
@@ -353,6 +373,9 @@ class FinalizeCacheEntryUploadResponse$Type extends MessageType<FinalizeCacheEnt
                     break;
                 case /* int64 entry_id */ 2:
                     message.entryId = reader.int64().toString();
+                    break;
+                case /* string message */ 3:
+                    message.message = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -372,6 +395,9 @@ class FinalizeCacheEntryUploadResponse$Type extends MessageType<FinalizeCacheEnt
         /* int64 entry_id = 2; */
         if (message.entryId !== "0")
             writer.tag(2, WireType.Varint).int64(message.entryId);
+        /* string message = 3; */
+        if (message.message !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.message);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);


### PR DESCRIPTION
Remove size limit for individual caches on upload, allow for more specific error codes from results backend.