### PR TITLE
fix(internal): vendor-aware GHES detection in isGhes() to support non-GitHub servers

### DIFF
--- a/packages/artifact/__tests__/config.test.ts
+++ b/packages/artifact/__tests__/config.test.ts
@@ -12,6 +12,9 @@ jest.mock('os', () => {
 
 beforeEach(() => {
   jest.resetModules()
+  delete process.env['FORGEJO_ACTIONS']
+  delete process.env['GITEA_ACTIONS']
+  delete process.env['ACTIONS_VENDOR']
 })
 
 describe('isGhes', () => {
@@ -35,8 +38,43 @@ describe('isGhes', () => {
     expect(config.isGhes()).toBe(false)
   })
 
-  it('should return false when the request domain is specific to an enterprise', () => {
+  it('should return true when the request domain is specific to an enterprise (GHES)', () => {
     process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+    expect(config.isGhes()).toBe(true)
+  })
+
+  it('should return false when FORGEJO_ACTIONS is set on a forge hostname', () => {
+    process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+    process.env.FORGEJO_ACTIONS = 'true'
+    expect(config.isGhes()).toBe(false)
+  })
+
+  it('should return false when GITEA_ACTIONS is set on a forge hostname', () => {
+    process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+    process.env.GITEA_ACTIONS = 'true'
+    expect(config.isGhes()).toBe(false)
+  })
+
+  it('should return false when ACTIONS_VENDOR is github on an enterprise hostname', () => {
+    process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+    process.env.ACTIONS_VENDOR = 'github'
+    expect(config.isGhes()).toBe(false)
+  })
+
+  it('should return true when ACTIONS_VENDOR is ghes on a forge hostname', () => {
+    process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+    process.env.ACTIONS_VENDOR = 'ghes'
+    expect(config.isGhes()).toBe(true)
+  })
+
+  it('should fall through to hostname when ACTIONS_VENDOR is an unknown value on an enterprise hostname', () => {
+    process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+    process.env.ACTIONS_VENDOR = 'unknownvalue'
+    expect(config.isGhes()).toBe(true)
+  })
+
+  it('should return true for a forge hostname with no forge flags or vendor set (pre-fix behavior)', () => {
+    process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
     expect(config.isGhes()).toBe(true)
   })
 })

--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -25,6 +25,20 @@ export function getResultsServiceUrl(): string {
 }
 
 export function isGhes(): boolean {
+  // Forge runners (Forgejo, Gitea) self-identify via these flags. They are not
+  // GitHub Enterprise Server and must not be misclassified as GHES.
+  if (process.env['FORGEJO_ACTIONS'] || process.env['GITEA_ACTIONS']) {
+    return false
+  }
+
+  // Optional operator-set vendor override. No runner emits this today; it is an
+  // explicit escape hatch for runners that set neither forge flag.
+  const vendor = (process.env['ACTIONS_VENDOR'] || '').trim().toLowerCase()
+  if (vendor === 'github') return false
+  if (vendor === 'ghes') return true
+  // Unknown/non-empty vendors fall through to the hostname heuristic; they do
+  // NOT auto-disable the GHES block (avoids a typo/spoof silently unblocking).
+
   const ghUrl = new URL(
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   )

--- a/packages/cache/__tests__/config.test.ts
+++ b/packages/cache/__tests__/config.test.ts
@@ -2,6 +2,9 @@ import * as config from '../src/internal/config'
 
 beforeEach(() => {
   jest.resetModules()
+  delete process.env['FORGEJO_ACTIONS']
+  delete process.env['GITEA_ACTIONS']
+  delete process.env['ACTIONS_VENDOR']
 })
 
 test('isGhes returns false for github.com', async () => {
@@ -22,6 +25,41 @@ test('isGhes returns true for enterprise URL', async () => {
 test('isGhes returns false for ghe.localhost', () => {
   process.env.GITHUB_SERVER_URL = 'https://my.domain.ghe.localhost'
   expect(config.isGhes()).toBe(false)
+})
+
+test('isGhes returns false when FORGEJO_ACTIONS is set on a forge hostname', () => {
+  process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+  process.env.FORGEJO_ACTIONS = 'true'
+  expect(config.isGhes()).toBe(false)
+})
+
+test('isGhes returns false when GITEA_ACTIONS is set on a forge hostname', () => {
+  process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+  process.env.GITEA_ACTIONS = 'true'
+  expect(config.isGhes()).toBe(false)
+})
+
+test('isGhes returns false when ACTIONS_VENDOR is github on an enterprise hostname', () => {
+  process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+  process.env.ACTIONS_VENDOR = 'github'
+  expect(config.isGhes()).toBe(false)
+})
+
+test('isGhes returns true when ACTIONS_VENDOR is ghes on a forge hostname', () => {
+  process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+  process.env.ACTIONS_VENDOR = 'ghes'
+  expect(config.isGhes()).toBe(true)
+})
+
+test('isGhes falls through to hostname for unknown ACTIONS_VENDOR on an enterprise hostname', () => {
+  process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+  process.env.ACTIONS_VENDOR = 'unknownvalue'
+  expect(config.isGhes()).toBe(true)
+})
+
+test('isGhes returns true for a forge hostname with no forge flags or vendor set (pre-fix behavior)', () => {
+  process.env.GITHUB_SERVER_URL = 'https://forge.example.com'
+  expect(config.isGhes()).toBe(true)
 })
 
 describe('cache-mode helpers', () => {

--- a/packages/cache/src/internal/config.ts
+++ b/packages/cache/src/internal/config.ts
@@ -1,4 +1,25 @@
+// NOTE: isGhes() here is intentionally identical to the artifact package's.
+// On forges this now returns false, so getCacheServiceVersion() honors
+// ACTIONS_CACHE_SERVICE_V2. Forges that set that flag without implementing
+// the cache v2 CacheService Twirp (see gitea#33393) will fail until they
+// implement it or stop setting the flag. The client-side 10GB cap in cache.ts
+// also becomes active on forges. These are accepted tradeoffs of making the
+// vendor flag authoritative.
 export function isGhes(): boolean {
+  // Forge runners (Forgejo, Gitea) self-identify via these flags. They are not
+  // GitHub Enterprise Server and must not be misclassified as GHES.
+  if (process.env['FORGEJO_ACTIONS'] || process.env['GITEA_ACTIONS']) {
+    return false
+  }
+
+  // Optional operator-set vendor override. No runner emits this today; it is an
+  // explicit escape hatch for runners that set neither forge flag.
+  const vendor = (process.env['ACTIONS_VENDOR'] || '').trim().toLowerCase()
+  if (vendor === 'github') return false
+  if (vendor === 'ghes') return true
+  // Unknown/non-empty vendors fall through to the hostname heuristic; they do
+  // NOT auto-disable the GHES block (avoids a typo/spoof silently unblocking).
+
   const ghUrl = new URL(
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   )


### PR DESCRIPTION
Introduce a minimal, explicit vendor switch to prevent `isGhes()` from misclassifying non GitHub platforms (e.g., Forgejo/Gitea) as GHES, This PR adds a positive allowlist for GHES aliases and preserves current behavior for github.

On self-hosted non-GitHub servers, the current heuristic (`GITHUB_SERVER_URL hostname`) often evaluates to `enterprise` sending actions down GHES specific code paths and causing failures. 
A tiny, explicit environment switch avoids this without changing default behavior on GitHub

for reference when this breaks other platforms please see:
https://github.com/actions/upload-artifact/issues/676
https://code.forgejo.org/actions/upload-artifact
https://code.forgejo.org/forgejo/runner/src/branch/main/RELEASE-NOTES.md#3-4-0

> Although this version is able to run [actions/upload-artifact@v4](https://code.forgejo.org/actions/upload-artifact/src/tag/v4) and [actions/download-artifact@v4](https://code.forgejo.org/actions/download-artifact/src/tag/v4), these actions will fail because it does not run against GitHub.com. A fork of those two actions with this check disabled is made available at:
> https://code.forgejo.org/forgejo/upload-artifact/src/tag/v4
> https://code.forgejo.org/forgejo/download-artifact/src/tag/v4

https://github.com/go-gitea/gitea/issues/31256


The workaround right now is:
https://gitea.com/actions/gitea-upload-artifact/commit/81f940d004763f986ba3582c007fd842dd5cb0d7
https://code.forgejo.org/forgejo/upload-artifact/commit/16871d9e8cfcf27ff31822cac382bbb5450f1e1e




---

Update (2026-07-31): reworked the approach. The current commit makes `isGhes()` forge-aware directly instead of relying on an `ACTIONS_VENDOR` allowlist.

1. If the runner sets `FORGEJO_ACTIONS` or `GITEA_ACTIONS`, `isGhes()` returns false. This is the forge-provided signal and fixes Forgejo and Gitea automatically.
2. `ACTIONS_VENDOR` is kept only as an optional, corrected escape hatch: `github` forces false, `ghes` forces true, unknown values fall through to the hostname heuristic (a typo or spoofed value cannot silently disable the GHES block). The buggy `ghe` / `github-enterprise` aliases are gone (they collided with `*.ghe.com`, which is GitHub Enterprise Cloud, not GHES).
3. The hostname heuristic (`github.com`, `*.ghe.com`, `*.localhost`) is unchanged, so real GHES with no forge flags still returns true and artifact v4 stays blocked there as before. `isGhes()` does not consult `ACTIONS_RESULTS_URL`.

Accepted tradeoffs, documented in `packages/cache/src/internal/config.ts`: on forges the cache client now honors `ACTIONS_CACHE_SERVICE_V2` (which can 404 until forges implement the v2 CacheService, see go-gitea/gitea#33393), and the client-side 10GB cache cap becomes active on forges.
