### PR TITLE
[ARTIFACT] Reject download promise if timeout was reached

### DIFF
--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -79,7 +79,9 @@ export async function streamExtractExternal(
 
   return new Promise((resolve, reject) => {
     const timerFn = (): void => {
-      const timeoutError = new Error(`Blob storage chunk did not respond in ${timeout}ms`)
+      const timeoutError = new Error(
+        `Blob storage chunk did not respond in ${timeout}ms`
+      )
       response.message.destroy(timeoutError)
       reject(timeoutError)
     }

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -79,10 +79,9 @@ export async function streamExtractExternal(
 
   return new Promise((resolve, reject) => {
     const timerFn = (): void => {
-      response.message.destroy(
-        new Error(`Blob storage chunk did not respond in ${timeout}ms`)
-      )
-      reject(`Blob storage chunk did not respond in ${timeout}ms`)
+      const timeoutError = new Error(`Blob storage chunk did not respond in ${timeout}ms`)
+      response.message.destroy(timeoutError)
+      reject(timeoutError)
     }
     const timer = setTimeout(timerFn, timeout)
 

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -82,6 +82,7 @@ export async function streamExtractExternal(
       response.message.destroy(
         new Error(`Blob storage chunk did not respond in ${timeout}ms`)
       )
+      reject(`Blob storage chunk did not respond in ${timeout}ms`)
     }
     const timer = setTimeout(timerFn, timeout)
 


### PR DESCRIPTION
Hi. There is a bug in the `actions/download-artifact` repository: https://github.com/actions/download-artifact/issues/396. The gist is that the artefact downloading is reported as successful on the download step, but further down, it is revealed that the artefact is corrupt/not present/not fully downloaded. And the downloading step does not report any logs/issues, the only logs are: 
```
Downloading single artifact
Preparing to download the following artifacts:
- fmod-project-build-16795056208 [redacted]
Redirecting to blob download url: [redacted]
Starting download of artifact to: /Users/effortstarbuild/runner/_work/[redacted]
(node:19985) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

We have faced this bug in the openvinotoolkit/openvino repository multiple times, just a couple recent ones: 
* https://github.com/openvinotoolkit/openvino/actions/runs/17227024908/job/48879391034
* https://github.com/openvinotoolkit/openvino/actions/runs/17227024908/job/48879391034

To investigate, we have added logs to `actions/download-artifact` and `actions/toolkit` (specifically, `actions/artifact`) and found out that the problem might lie in the retry logic of the `actions/artifact`.

Check the following pipeline:
* https://github.com/openvinotoolkit/openvino/actions/runs/17152024763/job/48663990948, step `Download OpenVINO artifacts (tests)`
This pipeline utilises a custom action with more verbose logging, and the logs are:
```
Attempt 1/5 to download and extract artifact
Initializing HTTP client for artifact download
Making HTTP GET request to blob storage
HTTP response received with status: 200
Creating hash stream for SHA256 verification
Setting up stream pipeline for download and extraction
Piping response message to passThrough stream
Piping passThrough stream to unzip.Extract
(node:17804) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Received 10 data chunks (chunk size: 16384 bytes)
Received 20 data chunks (chunk size: 16384 bytes)
Received 30 data chunks (chunk size: 16384 bytes)
Received 40 data chunks (chunk size: 16384 bytes)
Received 50 data chunks (chunk size: 16384 bytes)
Received 60 data chunks (chunk size: 16384 bytes)
Received 70 data chunks (chunk size: 16384 bytes)
Received 80 data chunks (chunk size: 16384 bytes)
Received 90 data chunks (chunk size: 16384 bytes)
Received 100 data chunks (chunk size: 16384 bytes)
Received 110 data chunks (chunk size: 16384 bytes)
Received 120 data chunks (chunk size: 16384 bytes)
Received 130 data chunks (chunk size: 16384 bytes)
Received 140 data chunks (chunk size: 16384 bytes)
Received 150 data chunks (chunk size: 16384 bytes)
Received 160 data chunks (chunk size: 16384 bytes)
Received 170 data chunks (chunk size: 16384 bytes)
Received 180 data chunks (chunk size: 16384 bytes)
Received 190 data chunks (chunk size: 16384 bytes)
Received 200 data chunks (chunk size: 16384 bytes)
Received 210 data chunks (chunk size: 16384 bytes)
Received 220 data chunks (chunk size: 16384 bytes)
Received 230 data chunks (chunk size: 16384 bytes)
Received 240 data chunks (chunk size: 16384 bytes)
Received 250 data chunks (chunk size: 16384 bytes)
Timeout reached: Blob storage chunk did not respond in 30000ms
```
So it silently fails after the first attempt without retrying for the second/third/etc. time. The timeout logic is defined in https://github.com/actions/toolkit/blob/f58042f9cc16bcaa87afaa86c2974a8c771ce1ea/packages/artifact/src/internal/download/download-artifact.ts#L82 and it seems like an error from `message.destroy` is not properly propagated up meaning the retry logic from https://github.com/actions/toolkit/blob/f58042f9cc16bcaa87afaa86c2974a8c771ce1ea/packages/artifact/src/internal/download/download-artifact.ts#L49 is not used.

After further investigation, we tried to add `reject` to the timeout logic suggested in this PR and it seems to be correctly retrying the download if it fails, check the following job and step:
* https://github.com/openvinotoolkit/openvino/actions/runs/17206828551/job/48813115664#step:3:1273

The first attempt fails but the download retries and completes successfully. 

The problem is that the first download is running in the background https://github.com/openvinotoolkit/openvino/actions/runs/17206828551/job/48813115664#step:3:2512, so it seems to be the problem with the `message.destroy`/the download `pipe`.

This PR is not the final solution but a highlight of the problem and a suggestion for the maintainer to take a look.
