### PR TITLE
Prepare cache `v4.1.0` release

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/cache Releases
 
+### 4.1.0
+
+- Remove client side 10GiB cache size limit check & update twirp client [#2118](https://github.com/actions/toolkit/pull/2118)
+
 ### 4.0.5
 
 - Reintroduce @protobuf-ts/runtime-rpc as a runtime dependency [#2113](https://github.com/actions/toolkit/pull/2113)

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "4.0.5",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [


### PR DESCRIPTION
Release version 4.1.0 of the `@actions/cache` package. The main update removes the client-side 10GiB cache size limit check and updates the twirp client.