### PR TITLE
Test: add a timeout test for downloading chunks from the stream

### DIFF
--- a/packages/artifact/__tests__/download-artifact.test.ts
+++ b/packages/artifact/__tests__/download-artifact.test.ts
@@ -3,7 +3,7 @@ import * as http from 'http'
 import * as net from 'net'
 import * as path from 'path'
 import * as github from '@actions/github'
-import {HttpClient, HttpClientResponse} from '@actions/http-client'
+import {HttpClient} from '@actions/http-client'
 import type {RestEndpointMethods} from '@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types'
 import archiver from 'archiver'
 
@@ -621,12 +621,10 @@ describe('download-artifact', () => {
       })
     })
   })
-  
+
   describe('streamExtractExternal', () => {
     it('should fail if the timeout is exceeded', async () => {
-
-      const mockSlowGetArtifact = jest
-        .fn(mockGetArtifactHung)
+      const mockSlowGetArtifact = jest.fn(mockGetArtifactHung)
 
       const mockHttpClient = (HttpClient as jest.Mock).mockImplementation(
         () => {
@@ -640,10 +638,10 @@ describe('download-artifact', () => {
         await streamExtractExternal(
           fixtures.blobStorageUrl,
           fixtures.workspaceDir,
-          { timeout: 2 }
+          {timeout: 2}
         )
         expect(true).toBe(false) // should not be called
-      } catch (e: any) {
+      } catch (e) {
         expect(e).toBeInstanceOf(Error)
         expect(e.message).toContain('did not respond in 2ms')
         expect(mockHttpClient).toHaveBeenCalledWith(getUserAgentString())

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -65,7 +65,7 @@ async function streamExtract(
 export async function streamExtractExternal(
   url: string,
   directory: string,
-  opts: { timeout: number } = { timeout: 30 * 1000 }
+  opts: {timeout: number} = {timeout: 30 * 1000}
 ): Promise<StreamExtractResponse> {
   const client = new httpClient.HttpClient(getUserAgentString())
   const response = await client.get(url)

--- a/packages/artifact/src/internal/download/download-artifact.ts
+++ b/packages/artifact/src/internal/download/download-artifact.ts
@@ -64,7 +64,8 @@ async function streamExtract(
 
 export async function streamExtractExternal(
   url: string,
-  directory: string
+  directory: string,
+  opts: { timeout: number } = { timeout: 30 * 1000 }
 ): Promise<StreamExtractResponse> {
   const client = new httpClient.HttpClient(getUserAgentString())
   const response = await client.get(url)
@@ -74,18 +75,17 @@ export async function streamExtractExternal(
     )
   }
 
-  const timeout = 30 * 1000 // 30 seconds
   let sha256Digest: string | undefined = undefined
 
   return new Promise((resolve, reject) => {
     const timerFn = (): void => {
       const timeoutError = new Error(
-        `Blob storage chunk did not respond in ${timeout}ms`
+        `Blob storage chunk did not respond in ${opts.timeout}ms`
       )
       response.message.destroy(timeoutError)
       reject(timeoutError)
     }
-    const timer = setTimeout(timerFn, timeout)
+    const timer = setTimeout(timerFn, opts.timeout)
 
     const hashStream = crypto.createHash('sha256').setEncoding('hex')
     const passThrough = new stream.PassThrough()


### PR DESCRIPTION
## Description

This test will fail until we merge the changes in this [PR](https://github.com/actions/toolkit/pull/2124). I wanted to take the proposed changes there so I'm adding a test to be merged after the fact.

This should check that a hung stream will fail. I updated the code to make the timeout configurable so we're not waiting the full `30s`.