### PR TITLE
Dependabot: add support for `/packages/artifact` and `/packages/cache`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "daily"
     groups:
       # Group minor and patch updates together but keep major separate
-      npm-minor-patch-updates:
+      artifact-minor-patch:
         update-types:
           - "minor"
           - "patch"
@@ -21,7 +21,7 @@ updates:
       interval: "daily"
     groups:
       # Group minor and patch updates together but keep major separate
-      npm-minor-patch-updates:
+      cache-minor-patch:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Description

We've let a lot of dependencies get stale and are now getting blocked by the audit CI checks. This'll allow `artifact`/`cache` to keep up to date without much toil. I didn't turn this on everywhere since this repo is crosscutting across several teams internally.