### PR TITLE
Remove unnecessary Buffer to Uint8Array conversion

### DIFF
--- a/packages/attest/src/attest.ts
+++ b/packages/attest/src/attest.ts
@@ -102,8 +102,7 @@ function toAttestation(bundle: Bundle, attestationID?: string): Attestation {
       throw new Error('Bundle must contain an x509 certificate')
   }
 
-  // Convert Buffer to Uint8Array for Node.js 24 compatibility
-  const signingCert = new X509Certificate(new Uint8Array(certBytes))
+  const signingCert = new X509Certificate(certBytes)
 
   // Collect transparency log ID if available
   const tlogEntries = bundle.verificationMaterial.tlogEntries


### PR DESCRIPTION
Removed unnecessary conversion of Buffer to Uint8Array for compatibility.

based on https://nodejs.org/api/crypto.html#new-x509certificatebuffer `new X509Certificate(buffer)` should take buffer