### PR TITLE
fix: bumping max list artifact to 2k

### DIFF
--- a/packages/artifact/src/internal/find/list-artifacts.ts
+++ b/packages/artifact/src/internal/find/list-artifacts.ts
@@ -59,7 +59,7 @@ export async function listArtifactsPublic(
   const totalArtifactCount = listArtifactResponse.total_count
   if (totalArtifactCount > maximumArtifactCount) {
     warning(
-      `Workflow run ${workflowRunId} has more than ${maximumArtifactCount} artifacts. Results will be incomplete as only the first ${maximumArtifactCount} artifacts will be returned`
+      `Workflow run ${workflowRunId} has ${totalArtifactCount} artifacts, exceeding the limit of ${maximumArtifactCount}. Results will be incomplete as only the first ${maximumArtifactCount} artifacts will be returned`
     )
     numberOfPages = maxNumberOfPages
   }


### PR DESCRIPTION
running into use cases where each workflow has more than 1k artifacts that i need to download