### PR TITLE
Prepare @actions/attest 2.0.0 release

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,12 @@
 # @actions/attest Releases
 
+### 2.0.0
+
+- Add support for Node 24 [#2110](https://github.com/actions/toolkit/pull/2110)
+- Bump @sigstore/bundle from 3.0.0 to 3.1.0
+- Bump @sigstore/sign from 3.0.0 to 3.1.0
+- Bump jose from 5.2.3 to 5.10.0
+
 ### 1.6.0
 
 - Update `buildSLSAProvenancePredicate` to populate `workflow.ref` field from the `ref` claim in the OIDC token [#1969](https://github.com/actions/toolkit/pull/1969)

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/attest",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "1.6.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",


### PR DESCRIPTION
This PR prepares the @actions/attest package for a 2.0.0 release.

## Changes
- Bump version from 1.6.0 to 2.0.0
- Add release notes for 2.0.0 in RELEASES.md

## Release Notes
- Add support for Node 24 #2110
- Bump @sigstore/bundle from 3.0.0 to 3.1.0
- Bump @sigstore/sign from 3.0.0 to 3.1.0
- Bump jose from 5.2.3 to 5.10.0

This is a major version bump to ensure compatibility with Node 24.