### PR TITLE
Prepare @actions/http-client 3.0.0 release

### DIFF
--- a/packages/http-client/RELEASES.md
+++ b/packages/http-client/RELEASES.md
@@ -2,7 +2,6 @@
 
 ## 3.0.0
 - Add support for Node 24 [#2110](https://github.com/actions/toolkit/pull/2110)
-- Bump undici from 5.28.5 to 5.28.5
 
 ## 2.2.3
 - Fixed an issue where proxy username and password were not handled correctly [#1799](https://github.com/actions/toolkit/pull/1799)


### PR DESCRIPTION
This PR prepares the @actions/http-client package for a 3.0.0 release.

## Changes
- Add release notes for 3.0.0 in RELEASES.md

## Release Notes
- Add support for Node 24 #2110

This is a major version bump to ensure compatibility with Node 24. The README already documents Node 24 support.