### PR TITLE
Prepare cache v5 release

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -2,9 +2,8 @@
 
 ### 5.0.0
 
-- Remove `@azure/ms-rest-js` dependency to fix Node.js 24+ punycode deprecation warning [#2197](https://github.com/actions/toolkit/pull/2197)
+- Remove `@azure/ms-rest-js` dependency [#2197](https://github.com/actions/toolkit/pull/2197)
   - The `TransferProgressEvent` type is now imported from `@azure/core-rest-pipeline` instead of `@azure/ms-rest-js`
-  - This fixes: `(node:2110) [DEP0040] DeprecationWarning: The punycode module is deprecated`
 - Bump `@actions/core` from `^1.11.1` to `^2.0.0` [#2198](https://github.com/actions/toolkit/pull/2198)
 - Bump `@actions/exec` from `^1.0.1` to `^2.0.0` [#2198](https://github.com/actions/toolkit/pull/2198)
 - Bump `@actions/glob` from `^0.1.0` to `^0.5.0` [#2198](https://github.com/actions/toolkit/pull/2198)


### PR DESCRIPTION
This pull request documents the release of version 5.0.0 for the `@actions/cache` package, highlighting several dependency updates, a dependency removal, and node 24 support.