### PR TITLE
prepare @actions/exec 2.0.1 relesae + chore(core): bump @actions/exec from ^1.1.1 to ^2.0.0

### DIFF
--- a/packages/core/RELEASES.md
+++ b/packages/core/RELEASES.md
@@ -1,5 +1,8 @@
 # @actions/core Releases
 
+## 2.0.1
+- Bump @actions/exec from 1.1.1 to 2.0.0 [#2199](https://github.com/actions/toolkit/pull/2199)
+
 ## 2.0.0
 - Add support for Node 24 [#2110](https://github.com/actions/toolkit/pull/2110)
 - Bump @actions/http-client from 2.0.1 to 3.0.0

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@actions/core",
-  "version": "2.0.0",
-  "lockfileVersion": 2,
+  "version": "2.0.1",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/core",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
+        "@actions/exec": "^2.0.0",
         "@actions/http-client": "^3.0.0"
       },
       "devDependencies": {
@@ -17,11 +17,12 @@
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
+      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^2.0.0"
       }
     },
     "node_modules/@actions/http-client": {
@@ -35,9 +36,10 @@
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
+      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+      "license": "MIT"
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
@@ -49,15 +51,17 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.112.tgz",
-      "integrity": "sha512-EKrbKUGJROm17+dY/gMi31aJlGLJ75e1IkTojt9n6u+hnaTBDs+M1bIdOawpk2m6YUAXq/R2W0SxCng1tndHCg==",
-      "dev": true
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -72,54 +76,6 @@
       },
       "engines": {
         "node": ">=14.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "requires": {
-        "@actions/io": "^1.0.1"
-      }
-    },
-    "@actions/http-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.0.tgz",
-      "integrity": "sha512-1s3tXAfVMSz9a4ZEBkXXRQD4QhY3+GAsWSbaYpeknPOKEeyRiU3lH+bHiLMZdo2x/fIeQ/hscL1wCkDLVM2DZQ==",
-      "requires": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.28.5"
-      }
-    },
-    "@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
-    },
-    "@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
-    },
-    "@types/node": {
-      "version": "16.18.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.112.tgz",
-      "integrity": "sha512-EKrbKUGJROm17+dY/gMi31aJlGLJ75e1IkTojt9n6u+hnaTBDs+M1bIdOawpk2m6YUAXq/R2W0SxCng1tndHCg==",
-      "dev": true
-    },
-    "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
-    "undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Actions core lib",
   "keywords": [
     "github",
@@ -36,7 +36,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/exec": "^1.1.1",
+    "@actions/exec": "^2.0.0",
     "@actions/http-client": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `@actions/exec` dependency in `@actions/core` from `^1.1.1` to `^2.0.0`.

## Why

- Aligns with the cache package which already uses `exec@2.0.0`
- Avoids nested duplicate dependencies in consuming projects
- exec v2 has no breaking API changes (only bumped its `@actions/io` dependency from v1 to v2)

## Changes

- `packages/core/package.json`: Bump `@actions/exec` to `^2.0.0`, version to `2.0.1`
- `packages/core/RELEASES.md`: Added release notes for 2.0.1
- Regenerated `package-lock.json`