### PR TITLE
Enable npm trusted publishing

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -74,11 +74,6 @@ jobs:
         with:
           name: ${{ github.event.inputs.package }}
 
-      - name: setup authentication
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.TOKEN }}
-
       - name: publish
         run: npm publish --provenance *.tgz
 


### PR DESCRIPTION
For each of the packages in this repo, I have configured a [trusted publisher](https://docs.npmjs.com/trusted-publishers) on npmjs:

<img width="788" height="228" alt="image" src="https://github.com/user-attachments/assets/d79f6864-365f-4394-8a8a-3c3d20c2c68f" />
 
We no longer need to use token-based auth with the npm registry.