### PR TITLE
Use node24 for publishing

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -69,6 +69,11 @@ jobs:
       id-token: write
     steps:
 
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+
       - name: download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Ensure we have node24 (and at least npm 11.5.1) when publishing