### PR TITLE
chore: bump undici to ^7.16.0

### DIFF
--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -22,7 +22,7 @@
         "@sigstore/rekor-types": "^3.0.0",
         "@types/jsonwebtoken": "^9.0.6",
         "nock": "^13.5.1",
-        "undici": "^6.20.0"
+        "undici": "^7.16.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1625,13 +1625,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -39,7 +39,7 @@
     "@sigstore/rekor-types": "^3.0.0",
     "@types/jsonwebtoken": "^9.0.6",
     "nock": "^13.5.1",
-    "undici": "^6.20.0"
+    "undici": "^7.16.0"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
         "@octokit/request": "^8.4.1",
         "@octokit/request-error": "^5.1.1",
-        "undici": "^5.28.5"
+        "undici": "^7.16.0"
       },
       "devDependencies": {
         "proxy": "^2.1.1"
@@ -29,6 +29,18 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -402,15 +414,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/universal-user-agent": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -44,7 +44,7 @@
     "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
     "@octokit/request": "^8.4.1",
     "@octokit/request-error": "^5.1.1",
-    "undici": "^5.28.5"
+    "undici": "^7.16.0"
   },
   "devDependencies": {
     "proxy": "^2.1.1"

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -10,22 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.28.5"
+        "undici": "^7.16.0"
       },
       "devDependencies": {
         "@types/node": "24.1.0",
         "@types/proxy": "^1.0.1",
         "@types/tunnel": "0.0.3",
         "proxy": "^2.1.1"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@types/node": {
@@ -241,15 +232,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "tunnel": "^0.0.6",
-    "undici": "^5.28.5"
+    "undici": "^7.16.0"
   },
   "overrides": {
     "uri-js": "npm:uri-js-replace@^1.0.1"


### PR DESCRIPTION
- @actions/http-client: ^5.28.5 → ^7.16.0
- @actions/github: ^5.28.5 → ^7.16.0
- @actions/attest: ^6.20.0 → ^7.16.0

Note: undici v7 requires Node.js 20+