### PR TITLE
chore(artifact): bump dependencies for Node.js 24 support

### DIFF
--- a/packages/artifact/package-lock.json
+++ b/packages/artifact/package-lock.json
@@ -9,9 +9,9 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.10.0",
+        "@actions/core": "^2.0.0",
         "@actions/github": "^6.0.1",
-        "@actions/http-client": "^2.1.0",
+        "@actions/http-client": "^3.0.0",
         "@azure/core-http": "^3.0.5",
         "@azure/storage-blob": "^12.15.0",
         "@octokit/core": "^5.2.1",
@@ -33,22 +33,22 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-oBfqT3GwkvLlo1fjvhQLQxuwZCGTarTE5OuZ2Wg10hvhBj7LRIlF611WT4aZS6fDhO5ZKlY7lCAZTlpmyaHaeg==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^2.0.0",
+        "@actions/http-client": "^3.0.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
+      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^2.0.0"
       }
     },
     "node_modules/@actions/github": {
@@ -66,7 +66,7 @@
         "undici": "^5.28.5"
       }
     },
-    "node_modules/@actions/http-client": {
+    "node_modules/@actions/github/node_modules/@actions/http-client": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
@@ -76,10 +76,20 @@
         "undici": "^5.25.4"
       }
     },
+    "node_modules/@actions/http-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.0.tgz",
+      "integrity": "sha512-1s3tXAfVMSz9a4ZEBkXXRQD4QhY3+GAsWSbaYpeknPOKEeyRiU3lH+bHiLMZdo2x/fIeQ/hscL1wCkDLVM2DZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.28.5"
+      }
+    },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
+      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
       "license": "MIT"
     },
     "node_modules/@azure/abort-controller": {
@@ -537,6 +547,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2350,6 +2361,7 @@
       "integrity": "sha512-dNWY8msnYB2a+7Audha+aTF1Pu3euiE7ySp53w8kEsXoYw7dMouV5A1UsTUY345aB152RHnmRMDiovuBi7BD+w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.12.0",
         "lunr": "^2.3.9",
@@ -2385,8 +2397,8 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -40,9 +40,9 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^1.10.0",
+    "@actions/core": "^2.0.0",
     "@actions/github": "^6.0.1",
-    "@actions/http-client": "^2.1.0",
+    "@actions/http-client": "^3.0.0",
     "@azure/core-http": "^3.0.5",
     "@azure/storage-blob": "^12.15.0",
     "@octokit/core": "^5.2.1",


### PR DESCRIPTION
## Summary

This PR updates the `@actions/artifact` package dependencies to support **Node.js 24** runtime.

## Changes

### Dependencies

| Package | Previous | New |
|---------|----------|-----|
| `@actions/core` | `^1.10.0` | `^2.0.0` |
| `@actions/http-client` | `^2.1.0` | `^3.0.0` |

## Why

Node.js 20 reaches end-of-life in April 2026. Upgrading dependencies ensures compatibility with Node.js 24 and enables:
- `upload-artifact@v5`
- `download-artifact@v5`

## Related

- Part of the Node.js 24 migration effort across the toolkit packages