### PR TITLE
fix(http-client): fix relative redirects

### DIFF
--- a/packages/http-client/__tests__/basics.test.ts
+++ b/packages/http-client/__tests__/basics.test.ts
@@ -159,6 +159,18 @@ describe('basics', () => {
     expect(obj.url).toBe('https://postman-echo.com/get')
   })
 
+  it('does basic get request with hostname and relative redirects', async () => {
+    const res: httpm.HttpClientResponse = await _http.get(
+      `https://postman-echo.com/redirect-to?url=${encodeURIComponent(
+        'https://www.postman-echo.com/redirect-to?url=get'
+      )}`
+    )
+    expect(res.message.statusCode).toBe(200)
+    const body: string = await res.readBody()
+    const obj = JSON.parse(body)
+    expect(obj.url).toBe('https://www.postman-echo.com/get')
+  })
+
   it('does basic get request with redirects (303)', async () => {
     const res: httpm.HttpClientResponse = await _http.get(
       `https://postman-echo.com/redirect-to?url=${encodeURIComponent(

--- a/packages/http-client/__tests__/basics.test.ts
+++ b/packages/http-client/__tests__/basics.test.ts
@@ -149,6 +149,16 @@ describe('basics', () => {
     expect(obj.url).toBe('https://postman-echo.com/get')
   })
 
+  it('does basic get request with relative redirects', async () => {
+    const res: httpm.HttpClientResponse = await _http.get(
+      'https://postman-echo.com/redirect-to?url=get'
+    )
+    expect(res.message.statusCode).toBe(200)
+    const body: string = await res.readBody()
+    const obj = JSON.parse(body)
+    expect(obj.url).toBe('https://postman-echo.com/get')
+  })
+
   it('does basic get request with redirects (303)', async () => {
     const res: httpm.HttpClientResponse = await _http.get(
       `https://postman-echo.com/redirect-to?url=${encodeURIComponent(

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -402,7 +402,7 @@ export class HttpClient {
           // if there's no location to redirect to, we won't
           break
         }
-        const parsedRedirectUrl = new URL(redirectUrl)
+        const parsedRedirectUrl = new URL(redirectUrl, info.parsedUrl)
         if (
           parsedUrl.protocol === 'https:' &&
           parsedUrl.protocol !== parsedRedirectUrl.protocol &&


### PR DESCRIPTION
See: #2226

This solves the root cause of the bug, but for tool-cache to work correctly, the tool-cache's http-client version needs to be updated with this patch.

URL constructor parameter documentation can be found here:
https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#parameters