### PR TITLE
fix(github): import from core directly

### DIFF
--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -2,7 +2,7 @@ import * as Context from './context'
 import {GitHub, getOctokitOptions} from './utils'
 
 // octokit + plugins
-import {OctokitOptions, OctokitPlugin} from '@octokit/core/dist-types/types'
+import {OctokitOptions, OctokitPlugin} from '@octokit/core/types'
 
 export const context = new Context.Context()
 

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import * as httpClient from '@actions/http-client'
-import {OctokitOptions} from '@octokit/core/dist-types/types'
+import {OctokitOptions} from '@octokit/core'
 import {ProxyAgent, fetch} from 'undici'
 
 export function getAuthString(

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -2,8 +2,7 @@ import * as Context from './context'
 import * as Utils from './internal/utils'
 
 // octokit + plugins
-import {Octokit} from '@octokit/core'
-import {OctokitOptions} from '@octokit/core/dist-types/types'
+import {Octokit, type OctokitOptions} from '@octokit/core'
 import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
 import {paginateRest} from '@octokit/plugin-paginate-rest'
 


### PR DESCRIPTION
The core `package.json` doesn't export `dist-types`, so typescript can
no longer resolve this path. That means it also can't resolve anything
that depends on it so they all become `any`.

It seems we can just import from core directly.

Fixes #2254.

EDIT:

there's actually all sorts of places importing `dist-types`, but its certainly not in the export map. so what's the expectation here? do you want to export it or do you want to stop importing from `dist-types`?