### PR TITLE
Bump `undici` to `v6.23.0` in `@actions/http-client`

### DIFF
--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -10,22 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.28.5"
+        "undici": "^6.23.0"
       },
       "devDependencies": {
         "@types/node": "24.1.0",
         "@types/proxy": "^1.0.1",
         "@types/tunnel": "0.0.3",
         "proxy": "^2.1.1"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@types/node": {
@@ -241,15 +232,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "tunnel": "^0.0.6",
-    "undici": "^5.28.5"
+    "undici": "^6.23.0"
   },
   "overrides": {
     "uri-js": "npm:uri-js-replace@^1.0.1"


### PR DESCRIPTION
## Description

Because of the dependency graph between packages in this repo, we need to bump `undici` in order. `@actions/http-client` is the root package that uses that dependency so we're starting here.