### PR TITLE
Bump `@actions/http-client@3.0.2`, `undici@6.23.0` and release `@actions/github@8.0.1`

### DIFF
--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,5 +1,10 @@
 # @actions/github Releases
 
+### 8.0.1
+
+- Update `undici` to `6.23.0`
+- Update `@actions/http-client` to `3.0.2`
+
 ### 8.0.0
 
 - Update @octokit dependencies 

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/github",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/github",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^3.0.2",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Actions github lib",
   "keywords": [
     "github",


### PR DESCRIPTION
## Description

Bumps `undici` and `@actions/http-client`. They need to go together so their versions match during `npm run build`.