### PR TITLE
ESM-only with updated @octokit dependencies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   roots: ['<rootDir>/packages'],
   testEnvironment: 'node',
   testMatch: ['**/__tests__/*.test.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
   transform: {
     '^.+\\.(ts|js)$': ['ts-jest', {
       isolatedModules: true,

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -6,9 +6,20 @@
 
 Returns an authenticated Octokit client that follows the machine [proxy settings](https://help.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners) and correctly sets GHES base urls. See https://octokit.github.io/rest.js for the API.
 
+**Note:** This package is ESM-only starting from v9.0.0. For CommonJS projects, use dynamic import:
 ```js
-const github = require('@actions/github');
-const core = require('@actions/core');
+async function main() {
+    const { getOctokit, context } = await import('@actions/github');
+    // ... your code here
+}
+main();
+```
+
+For bundled actions (recommended), most bundlers like esbuild, webpack, and rollup handle ESM imports automatically.
+
+```js
+import * as github from '@actions/github';
+import * as core from '@actions/core';
 
 async function run() {
     // This should be a token with access to your repository scoped in as a secret.
@@ -46,7 +57,7 @@ const result = await octokit.graphql(query, variables);
 Finally, you can get the context of the current action:
 
 ```js
-const github = require('@actions/github');
+import * as github from '@actions/github';
 
 const context = github.context;
 

--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,5 +1,12 @@
 # @actions/github Releases
 
+### 9.0.0
+
+- **Breaking change**: Package is now ESM-only
+  - CommonJS consumers must use dynamic `import()` instead of `require()`
+  - Example: `const { getOctokit, context } = await import('@actions/github')`
+- Fix TypeScript compilation by migrating to ESM, enabling proper imports from `@octokit/core/types`
+
 ### 8.0.1
 
 - Update `undici` to `6.23.0`

--- a/packages/github/__tests__/lib.test.ts
+++ b/packages/github/__tests__/lib.test.ts
@@ -1,8 +1,6 @@
 import * as path from 'path'
-import {Context} from '../src/context'
-
-/* eslint-disable @typescript-eslint/no-require-imports */
-/* eslint-disable @typescript-eslint/no-var-requires */
+import {readFileSync} from 'fs'
+import {Context} from '../src/context.js'
 
 describe('@actions/context', () => {
   let context: Context
@@ -14,7 +12,10 @@ describe('@actions/context', () => {
   })
 
   it('returns the payload object', () => {
-    expect(context.payload).toEqual(require('./payload.json'))
+    const payload = JSON.parse(
+      readFileSync(path.join(__dirname, 'payload.json'), 'utf8')
+    )
+    expect(context.payload).toEqual(payload)
   })
 
   it('returns an empty payload if the GITHUB_EVENT_PATH environment variable is falsey', () => {

--- a/packages/github/jest.config.cjs
+++ b/packages/github/jest.config.cjs
@@ -1,14 +1,19 @@
+/** @type {import('jest').Config} */
 module.exports = {
   clearMocks: true,
   moduleFileExtensions: ['js', 'ts'],
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
   transform: {
     '^.+\\.(ts|js)$': ['ts-jest', {
-      useESM: false,
       tsconfig: {
         allowJs: true,
-        esModuleInterop: true
+        esModuleInterop: true,
+        module: 'node16',
+        moduleResolution: 'node16'
       }
     }]
   },

--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/github",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/github",
-      "version": "8.0.1",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^3.0.2",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/github",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "description": "Actions github lib",
   "keywords": [
     "github",
@@ -8,8 +8,19 @@
   ],
   "homepage": "https://github.com/actions/toolkit/tree/main/packages/github",
   "license": "MIT",
+  "type": "module",
   "main": "lib/github.js",
   "types": "lib/github.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/github.d.ts",
+      "import": "./lib/github.js"
+    },
+    "./lib/utils": {
+      "types": "./lib/utils.d.ts",
+      "import": "./lib/utils.js"
+    }
+  },
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -1,5 +1,5 @@
 // Originally pulled from https://github.com/JasonEtco/actions-toolkit/blob/main/src/context.ts
-import {WebhookPayload} from './interfaces'
+import {WebhookPayload} from './interfaces.js'
 import {readFileSync, existsSync} from 'fs'
 import {EOL} from 'os'
 

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -1,8 +1,7 @@
-import * as Context from './context'
-import {GitHub, getOctokitOptions} from './utils'
-
+import * as Context from './context.js'
+import {GitHub, getOctokitOptions} from './utils.js'
 // octokit + plugins
-import {OctokitOptions, OctokitPlugin} from '@octokit/core/dist-types/types'
+import type {OctokitOptions, OctokitPlugin} from '@octokit/core/types'
 
 export const context = new Context.Context()
 

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -1,6 +1,6 @@
 import * as http from 'http'
 import * as httpClient from '@actions/http-client'
-import {OctokitOptions} from '@octokit/core/dist-types/types'
+import type {OctokitOptions} from '@octokit/core/types'
 import {ProxyAgent, fetch} from 'undici'
 
 export function getAuthString(

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -1,9 +1,9 @@
-import * as Context from './context'
-import * as Utils from './internal/utils'
+import * as Context from './context.js'
+import * as Utils from './internal/utils.js'
+import type {OctokitOptions} from '@octokit/core/types'
 
 // octokit + plugins
 import {Octokit} from '@octokit/core'
-import {OctokitOptions} from '@octokit/core/dist-types/types'
 import {restEndpointMethods} from '@octokit/plugin-rest-endpoint-methods'
 import {paginateRest} from '@octokit/plugin-paginate-rest'
 

--- a/packages/github/tsconfig.json
+++ b/packages/github/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "include": [
     "./src"


### PR DESCRIPTION
## Summary

Migrate `@actions/github` to ESM-only (v9.0.0) to properly support `@octokit/core` v7's type exports and resolve TypeScript compilation issues.

## Motivation

The v8.0.0 release upgraded `@octokit` dependencies but had broken TypeScript types because `@octokit/core` v7 is ESM-only and its type exports (`OctokitOptions`, `OctokitPlugin`) can only be properly imported using `moduleResolution: "node16"`. Converting `@actions/github` to ESM resolves this.

## Breaking Changes

- **ESM-only**: `@actions/github` v9.0.0 is now ESM-only
  - CommonJS consumers must use dynamic `import()`:
    ```js
    async function main() {
        const { getOctokit, context } = await import('@actions/github');
    }
    main();
    ```
    
Fixes: https://github.com/actions/toolkit/issues/2254