### PR TITLE
Bump `@actions/core` to `2.0.3` on `@actions/glob`

### DIFF
--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/glob Releases
 
+### 0.5.1
+
+- Bump `@actions/core` to `2.0.3`
+
 ### 0.5.0
 - Added `excludeHiddenFiles` option, which is disabled by default to preserve existing behavior [#1791: Add glob option to ignore hidden files](https://github.com/actions/toolkit/pull/1791)
 

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/glob",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/glob",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [


### PR DESCRIPTION
## Description

- Bumps `@actions/core` to `2.0.3` on `@actions/glob`

Fixes https://github.com/actions/toolkit/issues/2217