### PR TITLE
Bump `@actions/glob` to `0.5.1` in `@actions/cache`

### DIFF
--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/cache Releases
 
+### 5.0.5
+
+- Bump `@actions/glob` to `0.5.1`
+
 ### 5.0.4
 
 - Bump `@actions/http-client` to `3.0.2`

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@actions/cache",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/cache",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.0",
         "@actions/exec": "^2.0.0",
-        "@actions/glob": "^0.5.0",
+        "@actions/glob": "^0.5.1",
         "@actions/http-client": "^3.0.2",
         "@actions/io": "^2.0.0",
         "@azure/abort-controller": "^1.1.0",
@@ -28,13 +28,13 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-oBfqT3GwkvLlo1fjvhQLQxuwZCGTarTE5OuZ2Wg10hvhBj7LRIlF611WT4aZS6fDhO5ZKlY7lCAZTlpmyaHaeg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.0"
+        "@actions/http-client": "^3.0.2"
       }
     },
     "node_modules/@actions/exec": {
@@ -47,49 +47,14 @@
       }
     },
     "node_modules/@actions/glob": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.5.0.tgz",
-      "integrity": "sha512-tST2rjPvJLRZLuT9NMUtyBjvj9Yo0MiJS3ow004slMvm8GFM+Zv9HvMJ7HWzfUyJnGrJvDsYkWBaaG3YKXRtCw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.5.1.tgz",
+      "integrity": "sha512-+dv/t2aKQdKp9WWSp+1yIXVJzH5Q38M0Mta26pzIbeec14EcIleMB7UU6N7sNgbEuYfyuVGpE5pOKjl6j1WXkA==",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.9.1",
+        "@actions/core": "^2.0.3",
         "minimatch": "^3.0.4"
       }
-    },
-    "node_modules/@actions/glob/node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
-      }
-    },
-    "node_modules/@actions/glob/node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/io": "^1.0.1"
-      }
-    },
-    "node_modules/@actions/glob/node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      }
-    },
-    "node_modules/@actions/glob/node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-      "license": "MIT"
     },
     "node_modules/@actions/http-client": {
       "version": "3.0.2",
@@ -445,15 +410,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@protobuf-ts/plugin": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.11.1.tgz",
@@ -723,18 +679,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/cache",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "preview": true,
   "description": "Actions cache lib",
   "keywords": [
@@ -39,7 +39,7 @@
   "dependencies": {
     "@actions/core": "^2.0.0",
     "@actions/exec": "^2.0.0",
-    "@actions/glob": "^0.5.0",
+    "@actions/glob": "^0.5.1",
     "@protobuf-ts/runtime-rpc": "^2.11.1",
     "@actions/http-client": "^3.0.2",
     "@actions/io": "^2.0.0",


### PR DESCRIPTION
## Description

I missed that `@actions/cache` takes a dependency on `@actions/glob`. This updates that version and bumps `@actions/cache` to `5.0.5`