### PR TITLE
`@actions/io`: export `lib/io-util`

### DIFF
--- a/packages/io/RELEASES.md
+++ b/packages/io/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/io Releases
 
+## 3.0.1
+
+- Fix: export `@actions/io/lib/io-util`
+
 ## 3.0.0
 
 - **Breaking change**: Package is now ESM-only
@@ -16,7 +20,7 @@
 
 ## 1.1.2
 
-- Update `lockfileVersion` to `v2` in `package-lock.json [#1020](https://github.com/actions/toolkit/pull/1020) 
+- Update `lockfileVersion` to `v2` in `package-lock.json [#1020](https://github.com/actions/toolkit/pull/1020)
 
 ## 1.1.1
 

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/io",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Actions io lib",
   "keywords": [
     "github",
@@ -16,6 +16,10 @@
     ".": {
       "types": "./lib/io.d.ts",
       "import": "./lib/io.js"
+    },
+    "./lib/io-util": {
+      "types": "./lib/io-util.d.ts",
+      "import": "./lib/io-util.js"
     }
   },
   "directories": {


### PR DESCRIPTION
## Description

I missed exporting `lib/io-util` when converting the package to modules. This adds the export back so we can import it in the `@actions/exec` conversion.