### PR TITLE
`@actions/io`: update lock file version

### DIFF
--- a/packages/io/RELEASES.md
+++ b/packages/io/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/io Releases
 
+## 3.0.2
+
+- Fix: update lock file version
+
 ## 3.0.1
 
 - Fix: export `@actions/io/lib/io-util`

--- a/packages/io/package-lock.json
+++ b/packages/io/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/io",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/io",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT"
     }
   }

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/io",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Actions io lib",
   "keywords": [
     "github",


### PR DESCRIPTION
## Description

The previous version's lock file wasn't updated so it's not discoverable on npm. This fixes it and burns that old version.