### PR TITLE
`@actions/core`: convert to ESM module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,13 @@ module.exports = {
   testMatch: ['**/__tests__/*.test.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@actions/core$': '<rootDir>/packages/core/lib/core.js',
+    '^@actions/exec$': '<rootDir>/packages/exec/lib/exec.js',
     '^@actions/io$': '<rootDir>/packages/io/lib/io.js',
     '^@actions/io/lib/io-util$': '<rootDir>/packages/io/lib/io-util.js',
     '^@actions/http-client$': '<rootDir>/packages/http-client/lib/index.js',
     '^@actions/http-client/lib/auth$': '<rootDir>/packages/http-client/lib/auth.js',
+    '^@actions/http-client/lib/interfaces$': '<rootDir>/packages/http-client/lib/interfaces.js',
     '^@actions/github$': '<rootDir>/packages/github/lib/github.js',
     '^@actions/github/lib/utils$': '<rootDir>/packages/github/lib/utils.js'
   },
@@ -26,7 +29,7 @@ module.exports = {
     }]
   },
   transformIgnorePatterns: [
-    '/node_modules/(?!(@octokit|@actions/github|@actions/http-client|@actions/io|universal-user-agent|before-after-hook)/)'
+    '/node_modules/(?!(@octokit|@actions/github|@actions/http-client|@actions/io|@actions/exec|@actions/core|universal-user-agent|before-after-hook)/)'
   ],
   verbose: true
 }

--- a/packages/core/RELEASES.md
+++ b/packages/core/RELEASES.md
@@ -1,74 +1,99 @@
 # @actions/core Releases
 
+## 3.0.0
+
+- **Breaking change**: Package is now ESM-only
+  - CommonJS consumers must use dynamic `import()` instead of `require()`
+
 ## 2.0.3
 
 - Bump `@actions/http-client` to `3.0.2`
 
 ## 2.0.1
+
 - Bump @actions/exec from 1.1.1 to 2.0.0 [#2199](https://github.com/actions/toolkit/pull/2199)
 
 ## 2.0.0
+
 - Add support for Node 24 [#2110](https://github.com/actions/toolkit/pull/2110)
 - Bump @actions/http-client from 2.0.1 to 3.0.0
 
 ## 1.11.1
+
 - Fix uses of `crypto.randomUUID` on Node 18 and earlier [#1842](https://github.com/actions/toolkit/pull/1842)
 
 ### 1.11.0
+
 - Add platform info utilities [#1551](https://github.com/actions/toolkit/pull/1551)
 - Remove dependency on `uuid` package [#1824](https://github.com/actions/toolkit/pull/1824)
 
 ### 1.10.1
+
 - Fix error message reference in oidc utils [#1511](https://github.com/actions/toolkit/pull/1511)
 
 ### 1.10.0
+
 - `saveState` and `setOutput` now use environment files if available [#1178](https://github.com/actions/toolkit/pull/1178)
 - `getMultilineInput` now correctly trims whitespace by default [#1185](https://github.com/actions/toolkit/pull/1185)
 
 ### 1.9.1
+
 - Randomize delimiter when calling `core.exportVariable`
 
 ### 1.9.0
+
 - Added `toPosixPath`, `toWin32Path` and `toPlatformPath` utilities [#1102](https://github.com/actions/toolkit/pull/1102)
 
 ### 1.8.2
+
 - Update to v2.0.1 of `@actions/http-client` [#1087](https://github.com/actions/toolkit/pull/1087)
 
 ### 1.8.1
+
 - Update to v2.0.0 of `@actions/http-client`
 
 ### 1.8.0
+
 - Deprecate `markdownSummary` extension export in favor of `summary`
-  - https://github.com/actions/toolkit/pull/1072
-  - https://github.com/actions/toolkit/pull/1073
+  - <https://github.com/actions/toolkit/pull/1072>
+  - <https://github.com/actions/toolkit/pull/1073>
 
 ### 1.7.0
+
 - [Added `markdownSummary` extension](https://github.com/actions/toolkit/pull/1014)
 
 ### 1.6.0
+
 - [Added OIDC Client function `getIDToken`](https://github.com/actions/toolkit/pull/919)
-- [Added `file` parameter to `AnnotationProperties`](https://github.com/actions/toolkit/pull/896) 
+- [Added `file` parameter to `AnnotationProperties`](https://github.com/actions/toolkit/pull/896)
 
 ### 1.5.0
+
 - [Added support for notice annotations and more annotation fields](https://github.com/actions/toolkit/pull/855)
 
 ### 1.4.0
+
 - [Added the `getMultilineInput` function](https://github.com/actions/toolkit/pull/829)
 
 ### 1.3.0
+
 - [Added the trimWhitespace option to getInput](https://github.com/actions/toolkit/pull/802)
 - [Added the getBooleanInput function](https://github.com/actions/toolkit/pull/725)
 
 ### 1.2.7
+
 - [Prepend newline for set-output](https://github.com/actions/toolkit/pull/772)
 
 ### 1.2.6
+
 - [Update `exportVariable` and `addPath` to use environment files](https://github.com/actions/toolkit/pull/571)
 
 ### 1.2.5
+
 - [Correctly bundle License File with package](https://github.com/actions/toolkit/pull/548)
 
 ### 1.2.4
+
 - [Be more lenient in accepting non-string command inputs](https://github.com/actions/toolkit/pull/405)
 - [Add Echo commands](https://github.com/actions/toolkit/pull/411)
 
@@ -89,7 +114,7 @@
 
 - saveState and getState functions for wrapper tasks (on finally entry points that run post job)
 
-### 1.1.3 
+### 1.1.3
 
 - setSecret added to register a secret with the runner to be masked from the logs
 - exportSecret which was not implemented and never worked was removed after clarification from product.

--- a/packages/core/__tests__/command.test.ts
+++ b/packages/core/__tests__/command.test.ts
@@ -1,4 +1,4 @@
-import * as command from '../src/command'
+import * as command from '../src/command.js'
 import * as os from 'os'
 
 /* eslint-disable @typescript-eslint/unbound-method */

--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import * as core from '../src/core'
+import * as core from '../src/core.js'
 import {HttpClient} from '@actions/http-client'
-import {toCommandProperties} from '../src/utils'
+import {toCommandProperties} from '../src/utils.js'
 
 /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/core/__tests__/path-utils.test.ts
+++ b/packages/core/__tests__/path-utils.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 
-import {toPlatformPath, toPosixPath, toWin32Path} from '../src/path-utils'
+import {toPlatformPath, toPosixPath, toWin32Path} from '../src/path-utils.js'
 
 describe('#toPosixPath', () => {
   const cases: {

--- a/packages/core/__tests__/platform.test.ts
+++ b/packages/core/__tests__/platform.test.ts
@@ -1,5 +1,5 @@
 import os from 'os'
-import {platform} from '../src/core'
+import {platform} from '../src/core.js'
 
 describe('getInfo', () => {
   it('returns the platform info', async () => {

--- a/packages/core/__tests__/summary.test.ts
+++ b/packages/core/__tests__/summary.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import path from 'path'
-import {summary, SUMMARY_ENV_VAR} from '../src/summary'
+import {summary, SUMMARY_ENV_VAR} from '../src/summary.js'
 
 const testDirectoryPath = path.join(__dirname, 'test')
 const testFilePath = path.join(testDirectoryPath, 'test-summary.md')

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,34 +1,34 @@
 {
   "name": "@actions/core",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/core",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.2"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       },
       "devDependencies": {
-        "@types/node": "^16.18.112"
+        "@types/node": "^25.1.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
-      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^2.0.0"
+        "@actions/io": "^3.0.2"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
-      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -36,17 +36,20 @@
       }
     },
     "node_modules/@actions/io": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
-      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
+      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -65,6 +68,13 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/core",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "Actions core lib",
   "keywords": [
     "github",
@@ -9,8 +9,15 @@
   ],
   "homepage": "https://github.com/actions/toolkit/tree/main/packages/core",
   "license": "MIT",
+  "type": "module",
   "main": "lib/core.js",
   "types": "lib/core.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/core.d.ts",
+      "import": "./lib/core.js"
+    }
+  },
   "directories": {
     "lib": "lib",
     "test": "__tests__"
@@ -36,10 +43,10 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/exec": "^2.0.0",
-    "@actions/http-client": "^3.0.2"
+    "@actions/exec": "^3.0.0",
+    "@actions/http-client": "^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^16.18.112"
+    "@types/node": "^25.1.0"
   }
 }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -1,5 +1,5 @@
 import * as os from 'os'
-import {toCommandValue} from './utils'
+import {toCommandValue} from './utils.js'
 
 // For internal use, subject to change.
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,11 +1,11 @@
-import {issue, issueCommand} from './command'
-import {issueFileCommand, prepareKeyValueMessage} from './file-command'
-import {toCommandProperties, toCommandValue} from './utils'
+import {issue, issueCommand} from './command.js'
+import {issueFileCommand, prepareKeyValueMessage} from './file-command.js'
+import {toCommandProperties, toCommandValue} from './utils.js'
 
 import * as os from 'os'
 import * as path from 'path'
 
-import {OidcClient} from './oidc-utils'
+import {OidcClient} from './oidc-utils.js'
 
 /**
  * Interface for getInput options
@@ -400,19 +400,19 @@ export async function getIDToken(aud?: string): Promise<string> {
 /**
  * Summary exports
  */
-export {summary} from './summary'
+export {summary} from './summary.js'
 
 /**
  * @deprecated use core.summary
  */
-export {markdownSummary} from './summary'
+export {markdownSummary} from './summary.js'
 
 /**
  * Path exports
  */
-export {toPosixPath, toWin32Path, toPlatformPath} from './path-utils'
+export {toPosixPath, toWin32Path, toPlatformPath} from './path-utils.js'
 
 /**
  * Platform utilities exports
  */
-export * as platform from './platform'
+export * as platform from './platform.js'

--- a/packages/core/src/file-command.ts
+++ b/packages/core/src/file-command.ts
@@ -6,7 +6,7 @@
 import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as os from 'os'
-import {toCommandValue} from './utils'
+import {toCommandValue} from './utils.js'
 
 export function issueFileCommand(command: string, message: any): void {
   const filePath = process.env[`GITHUB_${command}`]

--- a/packages/core/src/oidc-utils.ts
+++ b/packages/core/src/oidc-utils.ts
@@ -3,7 +3,7 @@ import * as actions_http_client from '@actions/http-client'
 import {RequestOptions} from '@actions/http-client/lib/interfaces'
 import {HttpClient} from '@actions/http-client'
 import {BearerCredentialHandler} from '@actions/http-client/lib/auth'
-import {debug, setSecret} from './core'
+import {debug, setSecret} from './core.js'
 interface TokenResponse {
   value?: string
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,8 +1,8 @@
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {AnnotationProperties} from './core'
-import {CommandProperties} from './command'
+import {AnnotationProperties} from './core.js'
+import {CommandProperties} from './command.js'
 
 /**
  * Sanitizes an input into a string so it can be passed into issueCommand safely

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,7 +4,9 @@
     "baseUrl": "./",
     "outDir": "./lib",
     "declaration": true,
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "include": [
     "./src"


### PR DESCRIPTION
## Description

We're upgrading all the packages in this repo to ESM modules. `@actions/core` can go next since `@actions/exec` and `@actions/http-client` are already modules.