### PR TITLE
`@actions/glob`: convert to an ESM module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,8 @@ module.exports = {
     '^@actions/http-client/lib/auth$': '<rootDir>/packages/http-client/lib/auth.js',
     '^@actions/http-client/lib/interfaces$': '<rootDir>/packages/http-client/lib/interfaces.js',
     '^@actions/github$': '<rootDir>/packages/github/lib/github.js',
-    '^@actions/github/lib/utils$': '<rootDir>/packages/github/lib/utils.js'
+    '^@actions/github/lib/utils$': '<rootDir>/packages/github/lib/utils.js',
+    '^@actions/glob$': '<rootDir>/packages/glob/lib/glob.js'
   },
   transform: {
     '^.+\\.(ts|js)$': ['ts-jest', {
@@ -29,7 +30,7 @@ module.exports = {
     }]
   },
   transformIgnorePatterns: [
-    '/node_modules/(?!(@octokit|@actions/github|@actions/http-client|@actions/io|@actions/exec|@actions/core|universal-user-agent|before-after-hook)/)'
+    '/node_modules/(?!(@octokit|@actions/github|@actions/http-client|@actions/io|@actions/exec|@actions/core|@actions/glob|universal-user-agent|before-after-hook)/)'
   ],
   verbose: true
 }

--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -1,33 +1,43 @@
 # @actions/glob Releases
 
-### 0.5.1
+## 0.6.0
+
+- **Breaking change**: Package is now ESM-only
+  - CommonJS consumers must use dynamic `import()` instead of `require()`
+
+## 0.5.1
 
 - Bump `@actions/core` to `2.0.3`
 
-### 0.5.0
+## 0.5.0
+
 - Added `excludeHiddenFiles` option, which is disabled by default to preserve existing behavior [#1791: Add glob option to ignore hidden files](https://github.com/actions/toolkit/pull/1791)
 
-### 0.4.0
+## 0.4.0
+
 - Pass in the current workspace as a parameter to HashFiles [#1318](https://github.com/actions/toolkit/pull/1318)
 
-### 0.3.0
+## 0.3.0
+
 - Added a `verbose` option to HashFiles [#1052](https://github.com/actions/toolkit/pull/1052/files)
 
-### 0.2.1
-- Update `lockfileVersion` to `v2` in `package-lock.json [#1023](https://github.com/actions/toolkit/pull/1023) 
+## 0.2.1
 
-### 0.2.0
+- Update `lockfileVersion` to `v2` in `package-lock.json [#1023](https://github.com/actions/toolkit/pull/1023)
+
+## 0.2.0
+
 - [Added the hashFiles function to Glob](https://github.com/actions/toolkit/pull/830)
 - [Added an option to filter out directories](https://github.com/actions/toolkit/pull/728)
 
-### 0.1.2
+## 0.1.2
 
 - [Fix bug where files were matched incorrectly](https://github.com/actions/toolkit/pull/805)
 
-### 0.1.1
+## 0.1.1
 
 - Update @actions/core version
-### 0.1.0
+
+## 0.1.0
 
 - Initial release
-

--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -23,7 +23,7 @@
 
 ## 0.2.1
 
-- Update `lockfileVersion` to `v2` in `package-lock.json [#1023](https://github.com/actions/toolkit/pull/1023)
+- Update `lockfileVersion` to `v2` in `package-lock.json` [#1023](https://github.com/actions/toolkit/pull/1023)
 
 ## 0.2.0
 

--- a/packages/glob/__tests__/hash-files.test.ts
+++ b/packages/glob/__tests__/hash-files.test.ts
@@ -1,6 +1,6 @@
-import * as io from '../../io/src/io'
+import * as io from '../../io/src/io.js'
 import * as path from 'path'
-import {hashFiles} from '../src/glob'
+import {hashFiles} from '../src/glob.js'
 import {promises as fs} from 'fs'
 
 const IS_WINDOWS = process.platform === 'win32'

--- a/packages/glob/__tests__/internal-globber.test.ts
+++ b/packages/glob/__tests__/internal-globber.test.ts
@@ -1,9 +1,9 @@
 import * as child from 'child_process'
-import * as io from '../../io/src/io'
+import * as io from '../../io/src/io.js'
 import * as os from 'os'
 import * as path from 'path'
-import {Globber, DefaultGlobber} from '../src/internal-globber'
-import {GlobOptions} from '../src/internal-glob-options'
+import {Globber, DefaultGlobber} from '../src/internal-globber.js'
+import {GlobOptions} from '../src/internal-glob-options.js'
 import {promises as fs} from 'fs'
 
 const IS_WINDOWS = process.platform === 'win32'

--- a/packages/glob/__tests__/internal-path-helper.test.ts
+++ b/packages/glob/__tests__/internal-path-helper.test.ts
@@ -1,4 +1,4 @@
-import * as pathHelper from '../src/internal-path-helper'
+import * as pathHelper from '../src/internal-path-helper.js'
 
 const IS_WINDOWS = process.platform === 'win32'
 

--- a/packages/glob/__tests__/internal-path.test.ts
+++ b/packages/glob/__tests__/internal-path.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import {Path} from '../src/internal-path'
+import {Path} from '../src/internal-path.js'
 
 const IS_WINDOWS = process.platform === 'win32'
 

--- a/packages/glob/__tests__/internal-pattern-helper.test.ts
+++ b/packages/glob/__tests__/internal-pattern-helper.test.ts
@@ -1,8 +1,8 @@
 import * as path from 'path'
-import * as patternHelper from '../src/internal-pattern-helper'
-import {MatchKind} from '../src/internal-match-kind'
-import {IS_WINDOWS} from '../../io/src/io-util'
-import {Pattern} from '../src/internal-pattern'
+import * as patternHelper from '../src/internal-pattern-helper.js'
+import {MatchKind} from '../src/internal-match-kind.js'
+import {IS_WINDOWS} from '../../io/src/io-util.js'
+import {Pattern} from '../src/internal-pattern.js'
 
 describe('pattern-helper', () => {
   it('getSearchPaths omits negate search paths', () => {

--- a/packages/glob/__tests__/internal-pattern.test.ts
+++ b/packages/glob/__tests__/internal-pattern.test.ts
@@ -1,9 +1,9 @@
-import * as io from '../../io/src/io'
+import * as io from '../../io/src/io.js'
 import * as os from 'os'
 import * as path from 'path'
-import {MatchKind} from '../src/internal-match-kind'
+import {MatchKind} from '../src/internal-match-kind.js'
 import {promises as fs} from 'fs'
-import {Pattern} from '../src/internal-pattern'
+import {Pattern} from '../src/internal-pattern.js'
 
 const IS_WINDOWS = process.platform === 'win32'
 

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,41 +1,41 @@
 {
   "name": "@actions/glob",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/glob",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^2.0.3",
+        "@actions/core": "^3.0.0",
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/@actions/core": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
-      "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.2"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
-      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^2.0.0"
+        "@actions/io": "^3.0.2"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
-      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@actions/io": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
-      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [
@@ -10,8 +10,15 @@
   ],
   "homepage": "https://github.com/actions/toolkit/tree/main/packages/glob",
   "license": "MIT",
+  "type": "module",
   "main": "lib/glob.js",
   "types": "lib/glob.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/glob.d.ts",
+      "import": "./lib/glob.js"
+    }
+  },
   "directories": {
     "lib": "lib",
     "test": "__tests__"
@@ -37,7 +44,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/core": "^2.0.3",
+    "@actions/core": "^3.0.0",
     "minimatch": "^3.0.4"
   }
 }

--- a/packages/glob/src/glob.ts
+++ b/packages/glob/src/glob.ts
@@ -1,7 +1,7 @@
-import {Globber, DefaultGlobber} from './internal-globber'
-import {GlobOptions} from './internal-glob-options'
-import {HashFileOptions} from './internal-hash-file-options'
-import {hashFiles as _hashFiles} from './internal-hash-files'
+import {Globber, DefaultGlobber} from './internal-globber.js'
+import {GlobOptions} from './internal-glob-options.js'
+import {HashFileOptions} from './internal-hash-file-options.js'
+import {hashFiles as _hashFiles} from './internal-hash-files.js'
 
 export {Globber, GlobOptions}
 

--- a/packages/glob/src/internal-glob-options-helper.ts
+++ b/packages/glob/src/internal-glob-options-helper.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import {GlobOptions} from './internal-glob-options'
+import {GlobOptions} from './internal-glob-options.js'
 
 /**
  * Returns a copy with defaults filled in.

--- a/packages/glob/src/internal-globber.ts
+++ b/packages/glob/src/internal-globber.ts
@@ -1,12 +1,12 @@
 import * as core from '@actions/core'
 import * as fs from 'fs'
-import * as globOptionsHelper from './internal-glob-options-helper'
+import * as globOptionsHelper from './internal-glob-options-helper.js'
 import * as path from 'path'
-import * as patternHelper from './internal-pattern-helper'
-import {GlobOptions} from './internal-glob-options'
-import {MatchKind} from './internal-match-kind'
-import {Pattern} from './internal-pattern'
-import {SearchState} from './internal-search-state'
+import * as patternHelper from './internal-pattern-helper.js'
+import {GlobOptions} from './internal-glob-options.js'
+import {MatchKind} from './internal-match-kind.js'
+import {Pattern} from './internal-pattern.js'
+import {SearchState} from './internal-search-state.js'
 
 const IS_WINDOWS = process.platform === 'win32'
 

--- a/packages/glob/src/internal-hash-files.ts
+++ b/packages/glob/src/internal-hash-files.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs'
 import * as stream from 'stream'
 import * as util from 'util'
 import * as path from 'path'
-import {Globber} from './glob'
+import {Globber} from './glob.js'
 
 export async function hashFiles(
   globber: Globber,

--- a/packages/glob/src/internal-path.ts
+++ b/packages/glob/src/internal-path.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import * as pathHelper from './internal-path-helper'
+import * as pathHelper from './internal-path-helper.js'
 import assert from 'assert'
 
 const IS_WINDOWS = process.platform === 'win32'

--- a/packages/glob/src/internal-pattern-helper.ts
+++ b/packages/glob/src/internal-pattern-helper.ts
@@ -1,6 +1,6 @@
-import * as pathHelper from './internal-path-helper'
-import {MatchKind} from './internal-match-kind'
-import {Pattern} from './internal-pattern'
+import * as pathHelper from './internal-path-helper.js'
+import {MatchKind} from './internal-match-kind.js'
+import {Pattern} from './internal-pattern.js'
 
 const IS_WINDOWS = process.platform === 'win32'
 

--- a/packages/glob/src/internal-pattern.ts
+++ b/packages/glob/src/internal-pattern.ts
@@ -1,10 +1,10 @@
 import * as os from 'os'
 import * as path from 'path'
-import * as pathHelper from './internal-path-helper'
+import * as pathHelper from './internal-path-helper.js'
 import assert from 'assert'
 import {Minimatch, IMinimatch, IOptions as IMinimatchOptions} from 'minimatch'
-import {MatchKind} from './internal-match-kind'
-import {Path} from './internal-path'
+import {MatchKind} from './internal-match-kind.js'
+import {Path} from './internal-path.js'
 
 const IS_WINDOWS = process.platform === 'win32'
 

--- a/packages/glob/tsconfig.json
+++ b/packages/glob/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "module": "node16",
+    "moduleResolution": "node16"
   },
   "include": [
     "./src"


### PR DESCRIPTION
## Description

We're upgrading all the packages in this repo to ESM modules. `@actions/glob` can go next since all its dependencies are ESM modules.