### PR TITLE
`@actions/glob`: fix `minimatch` imports

### DIFF
--- a/packages/glob/RELEASES.md
+++ b/packages/glob/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/glob Releases
 
+## 0.6.1
+
+- Fix a bad import for `minimatch`
+
 ## 0.6.0
 
 - **Breaking change**: Package is now ESM-only

--- a/packages/glob/package-lock.json
+++ b/packages/glob/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/glob",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/glob",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/glob",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "preview": true,
   "description": "Actions glob lib",
   "keywords": [

--- a/packages/glob/src/internal-pattern.ts
+++ b/packages/glob/src/internal-pattern.ts
@@ -2,9 +2,13 @@ import * as os from 'os'
 import * as path from 'path'
 import * as pathHelper from './internal-path-helper.js'
 import assert from 'assert'
-import {Minimatch, IMinimatch, IOptions as IMinimatchOptions} from 'minimatch'
+import minimatch from 'minimatch'
 import {MatchKind} from './internal-match-kind.js'
 import {Path} from './internal-path.js'
+
+type IMinimatch = minimatch.IMinimatch
+type IMinimatchOptions = minimatch.IOptions
+const {Minimatch} = minimatch
 
 const IS_WINDOWS = process.platform === 'win32'
 


### PR DESCRIPTION
## Description

Looks like the imports broke for `minimatch`. We can't go to a higher version because of other breaking changes so instead we're going to just fix the import pattern.