### PR TITLE
fix(tests): close sockets to remove a Jest warning about resources outliving their tests

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -677,5 +677,8 @@ describe('oidc-client-tests', () => {
     const http = new HttpClient('actions/oidc-client')
     const res = await http.get(getTokenEndPoint())
     expect(res.message.statusCode).toBe(200)
+    // Consume the response to close the socket
+    await res.readBody()
+    res.message.destroy()
   })
 })

--- a/packages/http-client/__tests__/basics.test.ts
+++ b/packages/http-client/__tests__/basics.test.ts
@@ -238,6 +238,8 @@ describe('basics', () => {
       'https://postman-echo.com/get'
     )
     expect(res.message.statusCode).toBe(200)
+    // Consume the response to close the socket
+    res.message.destroy()
   })
 
   it('does basic http delete request', async () => {


### PR DESCRIPTION
## Description

I noticed this while I was upgrading the packages. This should silence a warning from Jest.