### PR TITLE
Releases: use `ubuntu-latest` instead of `macos-latest-large`

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest-large
+    runs-on: ubuntu-latest
 
     steps:
       - name: setup repo
@@ -61,7 +61,7 @@ jobs:
           path: packages/${{ github.event.inputs.package }}/*.tgz
 
   publish:
-    runs-on: macos-latest-large
+    runs-on: ubuntu-slim
     needs: test
     environment: npm-publish
     permissions:


### PR DESCRIPTION
## Description

We don't explicitly need MacOS runners for this and `macos-latest-large` is technically slightly slower than `ubuntu-latest` in our unit tests.