### PR TITLE
fix(http-client): correctly handle ipv6 literals

### DIFF
--- a/packages/http-client/__tests__/basics.test.ts
+++ b/packages/http-client/__tests__/basics.test.ts
@@ -66,6 +66,31 @@ describe('basics', () => {
     expect(obj.headers['user-agent']).toBe('actions/http-client')
   })
 
+  it('can make a request to an IPv6 literal host', async () => {
+    const res: httpm.HttpClientResponse = await _http.get(
+      // This is Cloudflare's DNS, the IPv6 equivalent of 1.1.1.1
+      'https://[2606:4700:4700::1111]'
+    )
+
+    expect(res.message.statusCode).toBeDefined()
+  })
+
+  it('can make a request to an IPv6 literal host with an explicit port', async () => {
+    const res: httpm.HttpClientResponse = await _http.get(
+      'https://[2606:4700:4700::1111]:443'
+    )
+
+    expect(res.message.statusCode).toBeDefined()
+  })
+
+  it('can make a request to an IPv6 literal host with a path', async () => {
+    const res: httpm.HttpClientResponse = await _http.get(
+      'https://[2606:4700:4700::1111]/hello'
+    )
+
+    expect(res.message.statusCode).toBeDefined()
+  })
+
   /* TODO write a mock rather then relying on a third party
   it('does basic https get request', async () => {
     const res: httpm.HttpClientResponse = await _http.get(


### PR DESCRIPTION
Right now, attempting to access a literal IPv6 endpoint results in a `getaddrinfo ENOTFOUND`, because `URL.hostname` returns bracketed IPv6 literals, like `[2001:db8::1]`, while node expects them unbracketed; the mismatch results in it trying to resolve the IPv6 address as a domain, and failing. 

Fixes https://github.com/actions/cache/issues/1718 .