### PR TITLE
`@actions/github`: use `@actions/http-client` 4.x

### DIFF
--- a/packages/github/package-lock.json
+++ b/packages/github/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^3.0.2",
+        "@actions/http-client": "^4.0.0",
         "@octokit/core": "^7.0.6",
         "@octokit/plugin-paginate-rest": "^14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
-      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -49,7 +49,7 @@
     "url": "https://github.com/actions/toolkit/issues"
   },
   "dependencies": {
-    "@actions/http-client": "^3.0.2",
+    "@actions/http-client": "^4.0.0",
     "@octokit/core": "^7.0.6",
     "@octokit/plugin-paginate-rest": "^14.0.0",
     "@octokit/plugin-rest-endpoint-methods": "^17.0.0",


### PR DESCRIPTION
`@actions/github` was updated to use ESM but is still using CJS `@actions/http-client` 3.x. Given `@actions/core` is typically installed alongside which does support `@actions/http-client` 4.x, this meant most actions were unnecessarily bundling two versions of `@actions/http-client`.