### PR TITLE
custom user-agent string for attestation API reqs

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+## 3.1.0
+
+- Add support for `ACTIONS_ORCHESTRATION_ID` in user-agent [#2320](https://github.com/actions/toolkit/pull/2320)
+
 ## 3.0.0
 
 - **Breaking change**: Package is now ESM-only

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "tsc": "tsc"
+    "tsc": "tsc && cp src/package-version.cjs lib/"
   },
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"

--- a/packages/attest/src/package-version.cjs
+++ b/packages/attest/src/package-version.cjs
@@ -1,0 +1,7 @@
+// This file exists as a CommonJS module to read the version from package.json.
+// In an ESM package, using `require()` directly in .ts files requires disabling
+// ESLint rules and doesn't work reliably across all Node.js versions.
+// By keeping this as a .cjs file, we can use require() naturally and export
+// the version for the ESM modules to import.
+const packageJson = require('../package.json')
+module.exports = {version: packageJson.version}

--- a/packages/attest/src/store.ts
+++ b/packages/attest/src/store.ts
@@ -1,6 +1,7 @@
 import * as github from '@actions/github'
 import {retry} from '@octokit/plugin-retry'
 import {RequestHeaders} from '@octokit/types'
+import {version} from './package-version.cjs'
 
 const CREATE_ATTESTATION_REQUEST = 'POST /repos/{owner}/{repo}/attestations'
 const DEFAULT_RETRY_COUNT = 5
@@ -24,11 +25,16 @@ export const writeAttestation = async (
   const retries = options.retry ?? DEFAULT_RETRY_COUNT
   const octokit = github.getOctokit(token, {retry: {retries}}, retry)
 
+  const headers = {
+    'User-Agent': getUserAgent(),
+    ...options.headers
+  }
+
   try {
     const response = await octokit.request(CREATE_ATTESTATION_REQUEST, {
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      headers: options.headers,
+      headers,
       bundle: attestation as {
         mediaType?: string
         verificationMaterial?: {[key: string]: unknown}
@@ -45,4 +51,18 @@ export const writeAttestation = async (
     const message = err instanceof Error ? err.message : err
     throw new Error(`Failed to persist attestation: ${message}`)
   }
+}
+
+const getUserAgent = (): string => {
+  const baseUserAgent = `@actions/attest-${version}`
+
+  const orchId = process.env['ACTIONS_ORCHESTRATION_ID']
+  if (orchId) {
+    // Sanitize the orchestration ID to ensure it contains only valid characters
+    // Valid characters: 0-9, a-z, _, -, .
+    const sanitizedId = orchId.replace(/[^a-z0-9_.-]/gi, '_')
+    return `${baseUserAgent} actions_orchestration_id/${sanitizedId}`
+  }
+
+  return baseUserAgent
 }


### PR DESCRIPTION
This pull request updates the `@actions/attest` package to improve how the package version is accessed and to enhance the user agent string sent with requests to the attestation API.

Follows the pattern for including the `ACTIONS_ORCHESTRATION_ID` value in the user agent string introduced in https://github.com/actions/toolkit/pull/2229