### PR TITLE
Custom user-agent string for storage record API reqs

### DIFF
--- a/packages/attest/RELEASES.md
+++ b/packages/attest/RELEASES.md
@@ -1,5 +1,9 @@
 # @actions/attest Releases
 
+## 3.2.0
+
+- Add custom user-agent for more API calls [#2321](https://github.com/actions/toolkit/pull/2321)
+
 ## 3.1.0
 
 - Add support for `ACTIONS_ORCHESTRATION_ID` in user-agent [#2320](https://github.com/actions/toolkit/pull/2320)

--- a/packages/attest/package-lock.json
+++ b/packages/attest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@actions/attest",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@actions/attest",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/attest",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Actions attestation lib",
   "keywords": [
     "github",
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "tsc": "tsc && cp src/package-version.cjs lib/"
+    "tsc": "tsc && cp src/internal/package-version.cjs lib/internal/"
   },
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"

--- a/packages/attest/src/artifactMetadata.ts
+++ b/packages/attest/src/artifactMetadata.ts
@@ -55,7 +55,7 @@ export async function createStorageRecord(
   const octokit = github.getOctokit(token, {retry: {retries}}, retry)
 
   const headersWithUserAgent = {
-    'user-agent': getUserAgent(),
+    'User-Agent': getUserAgent(),
     ...headers
   }
 

--- a/packages/attest/src/artifactMetadata.ts
+++ b/packages/attest/src/artifactMetadata.ts
@@ -1,6 +1,7 @@
 import * as github from '@actions/github'
 import {retry} from '@octokit/plugin-retry'
 import {RequestHeaders} from '@octokit/types'
+import {getUserAgent} from './internal/utils.js'
 
 const CREATE_STORAGE_RECORD_REQUEST =
   'POST /orgs/{owner}/artifacts/metadata/storage-record'
@@ -52,10 +53,16 @@ export async function createStorageRecord(
 ): Promise<number[]> {
   const retries = retryAttempts ?? DEFAULT_RETRY_COUNT
   const octokit = github.getOctokit(token, {retry: {retries}}, retry)
+
+  const headersWithUserAgent = {
+    'user-agent': getUserAgent(),
+    ...headers
+  }
+
   try {
     const response = await octokit.request(CREATE_STORAGE_RECORD_REQUEST, {
       owner: github.context.repo.owner,
-      headers,
+      headers: headersWithUserAgent,
       ...buildRequestParams(artifactOptions, packageRegistryOptions)
     })
 

--- a/packages/attest/src/internal/package-version.cjs
+++ b/packages/attest/src/internal/package-version.cjs
@@ -3,5 +3,5 @@
 // ESLint rules and doesn't work reliably across all Node.js versions.
 // By keeping this as a .cjs file, we can use require() naturally and export
 // the version for the ESM modules to import.
-const packageJson = require('../package.json')
+const packageJson = require('../../package.json')
 module.exports = {version: packageJson.version}

--- a/packages/attest/src/internal/utils.ts
+++ b/packages/attest/src/internal/utils.ts
@@ -1,0 +1,15 @@
+import {version} from './package-version.cjs'
+
+export const getUserAgent = (): string => {
+  const baseUserAgent = `@actions/attest-${version}`
+
+  const orchId = process.env['ACTIONS_ORCHESTRATION_ID']
+  if (orchId) {
+    // Sanitize the orchestration ID to ensure it contains only valid characters
+    // Valid characters: 0-9, a-z, _, -, .
+    const sanitizedId = orchId.replace(/[^a-z0-9_.-]/gi, '_')
+    return `${baseUserAgent} actions_orchestration_id/${sanitizedId}`
+  }
+
+  return baseUserAgent
+}

--- a/packages/attest/src/store.ts
+++ b/packages/attest/src/store.ts
@@ -1,7 +1,7 @@
 import * as github from '@actions/github'
 import {retry} from '@octokit/plugin-retry'
 import {RequestHeaders} from '@octokit/types'
-import {version} from './package-version.cjs'
+import {getUserAgent} from './internal/utils.js'
 
 const CREATE_ATTESTATION_REQUEST = 'POST /repos/{owner}/{repo}/attestations'
 const DEFAULT_RETRY_COUNT = 5
@@ -51,18 +51,4 @@ export const writeAttestation = async (
     const message = err instanceof Error ? err.message : err
     throw new Error(`Failed to persist attestation: ${message}`)
   }
-}
-
-const getUserAgent = (): string => {
-  const baseUserAgent = `@actions/attest-${version}`
-
-  const orchId = process.env['ACTIONS_ORCHESTRATION_ID']
-  if (orchId) {
-    // Sanitize the orchestration ID to ensure it contains only valid characters
-    // Valid characters: 0-9, a-z, _, -, .
-    const sanitizedId = orchId.replace(/[^a-z0-9_.-]/gi, '_')
-    return `${baseUserAgent} actions_orchestration_id/${sanitizedId}`
-  }
-
-  return baseUserAgent
 }


### PR DESCRIPTION
This pull request updates the `@actions/attest` package to enhance the user agent string sent with requests to the storage record API.

Follow-up to #2320. Follows the pattern for including the `ACTIONS_ORCHESTRATION_ID` value in the user agent string introduced in https://github.com/actions/toolkit/pull/2229