### PR TITLE
feat(github): add orchestration ID to user-agent in getOctokitOptions

### DIFF
--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -1,5 +1,10 @@
 # @actions/github Releases
 
+### 9.1.0
+
+- Append `actions_orchestration_id` to user-agent when `ACTIONS_ORCHESTRATION_ID` environment variable is set
+- Export `getUserAgentWithOrchestrationId` from `@actions/github/lib/utils` for downstream consumers
+
 ### 9.0.0
 
 - **Breaking change**: Package is now ESM-only

--- a/packages/github/__tests__/orchestration.test.ts
+++ b/packages/github/__tests__/orchestration.test.ts
@@ -73,9 +73,7 @@ describe('orchestration ID support', () => {
     it('sets userAgent when ACTIONS_ORCHESTRATION_ID is set', () => {
       process.env['ACTIONS_ORCHESTRATION_ID'] = 'test-orch-id'
       const opts = getOctokitOptions('fake-token')
-      expect(opts.userAgent).toBe(
-        'actions_orchestration_id/test-orch-id'
-      )
+      expect(opts.userAgent).toBe('actions_orchestration_id/test-orch-id')
     })
 
     it('does not set userAgent when ACTIONS_ORCHESTRATION_ID is not set', () => {
@@ -110,9 +108,7 @@ describe('orchestration ID support', () => {
     it('sanitizes special characters through getOctokitOptions', () => {
       process.env['ACTIONS_ORCHESTRATION_ID'] = 'bad chars here!'
       const opts = getOctokitOptions('fake-token')
-      expect(opts.userAgent).toBe(
-        'actions_orchestration_id/bad_chars_here_'
-      )
+      expect(opts.userAgent).toBe('actions_orchestration_id/bad_chars_here_')
     })
   })
 })

--- a/packages/github/__tests__/orchestration.test.ts
+++ b/packages/github/__tests__/orchestration.test.ts
@@ -63,9 +63,7 @@ describe('orchestration ID support', () => {
     it('does not duplicate orchestration ID if already present in base', () => {
       process.env['ACTIONS_ORCHESTRATION_ID'] = 'abc-123'
       const alreadyTagged = 'my-app actions_orchestration_id/abc-123'
-      expect(getUserAgentWithOrchestrationId(alreadyTagged)).toBe(
-        alreadyTagged
-      )
+      expect(getUserAgentWithOrchestrationId(alreadyTagged)).toBe(alreadyTagged)
     })
   })
 

--- a/packages/github/__tests__/orchestration.test.ts
+++ b/packages/github/__tests__/orchestration.test.ts
@@ -1,0 +1,118 @@
+import {getOctokitOptions, getUserAgentWithOrchestrationId} from '../src/utils'
+import {getUserAgentWithOrchestrationId as internalGetUserAgentWithOrchestrationId} from '../src/internal/utils'
+
+describe('orchestration ID support', () => {
+  let originalOrchId: string | undefined
+
+  beforeEach(() => {
+    originalOrchId = process.env['ACTIONS_ORCHESTRATION_ID']
+    delete process.env['ACTIONS_ORCHESTRATION_ID']
+  })
+
+  afterEach(() => {
+    if (originalOrchId !== undefined) {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = originalOrchId
+    } else {
+      delete process.env['ACTIONS_ORCHESTRATION_ID']
+    }
+  })
+
+  describe('getUserAgentWithOrchestrationId', () => {
+    it('returns undefined when env var is not set and no base user agent', () => {
+      expect(getUserAgentWithOrchestrationId()).toBeUndefined()
+    })
+
+    it('returns base user agent unchanged when env var is not set', () => {
+      expect(getUserAgentWithOrchestrationId('my-app')).toBe('my-app')
+    })
+
+    it('returns orchestration ID without base when env var is set and no base', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'abc-123'
+      expect(getUserAgentWithOrchestrationId()).toBe(
+        'actions_orchestration_id/abc-123'
+      )
+    })
+
+    it('appends orchestration ID to base user agent', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'abc-123'
+      expect(getUserAgentWithOrchestrationId('my-app')).toBe(
+        'my-app actions_orchestration_id/abc-123'
+      )
+    })
+
+    it('sanitizes special characters in orchestration ID', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'id with spaces/and$pecial!'
+      expect(getUserAgentWithOrchestrationId('my-app')).toBe(
+        'my-app actions_orchestration_id/id_with_spaces_and_pecial_'
+      )
+    })
+
+    it('preserves allowed characters in orchestration ID', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] =
+        'valid_id-with.allowed_chars.123'
+      expect(getUserAgentWithOrchestrationId()).toBe(
+        'actions_orchestration_id/valid_id-with.allowed_chars.123'
+      )
+    })
+
+    it('ignores whitespace-only orchestration ID', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = '   '
+      expect(getUserAgentWithOrchestrationId('my-app')).toBe('my-app')
+    })
+  })
+
+  describe('public re-export', () => {
+    it('exports getUserAgentWithOrchestrationId from utils (public API)', () => {
+      expect(getUserAgentWithOrchestrationId).toBe(
+        internalGetUserAgentWithOrchestrationId
+      )
+    })
+  })
+
+  describe('getOctokitOptions', () => {
+    it('sets userAgent when ACTIONS_ORCHESTRATION_ID is set', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'test-orch-id'
+      const opts = getOctokitOptions('fake-token')
+      expect(opts.userAgent).toBe(
+        'actions_orchestration_id/test-orch-id'
+      )
+    })
+
+    it('does not set userAgent when ACTIONS_ORCHESTRATION_ID is not set', () => {
+      const opts = getOctokitOptions('fake-token')
+      expect(opts.userAgent).toBeUndefined()
+    })
+
+    it('preserves and appends to caller-provided userAgent', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'test-orch-id'
+      const opts = getOctokitOptions('fake-token', {
+        userAgent: 'custom-agent/1.0'
+      })
+      expect(opts.userAgent).toBe(
+        'custom-agent/1.0 actions_orchestration_id/test-orch-id'
+      )
+    })
+
+    it('leaves caller-provided userAgent intact when env var is not set', () => {
+      const opts = getOctokitOptions('fake-token', {
+        userAgent: 'custom-agent/1.0'
+      })
+      expect(opts.userAgent).toBe('custom-agent/1.0')
+    })
+
+    it('does not mutate the original options object', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'test-orch-id'
+      const original = {userAgent: 'original/1.0'}
+      getOctokitOptions('fake-token', original)
+      expect(original.userAgent).toBe('original/1.0')
+    })
+
+    it('sanitizes special characters through getOctokitOptions', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'bad chars here!'
+      const opts = getOctokitOptions('fake-token')
+      expect(opts.userAgent).toBe(
+        'actions_orchestration_id/bad_chars_here_'
+      )
+    })
+  })
+})

--- a/packages/github/__tests__/orchestration.test.ts
+++ b/packages/github/__tests__/orchestration.test.ts
@@ -59,6 +59,14 @@ describe('orchestration ID support', () => {
       process.env['ACTIONS_ORCHESTRATION_ID'] = '   '
       expect(getUserAgentWithOrchestrationId('my-app')).toBe('my-app')
     })
+
+    it('does not duplicate orchestration ID if already present in base', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'abc-123'
+      const alreadyTagged = 'my-app actions_orchestration_id/abc-123'
+      expect(getUserAgentWithOrchestrationId(alreadyTagged)).toBe(
+        alreadyTagged
+      )
+    })
   })
 
   describe('public re-export', () => {
@@ -109,6 +117,16 @@ describe('orchestration ID support', () => {
       process.env['ACTIONS_ORCHESTRATION_ID'] = 'bad chars here!'
       const opts = getOctokitOptions('fake-token')
       expect(opts.userAgent).toBe('actions_orchestration_id/bad_chars_here_')
+    })
+
+    it('does not duplicate orchestration ID when caller already applied it', () => {
+      process.env['ACTIONS_ORCHESTRATION_ID'] = 'test-orch-id'
+      const opts = getOctokitOptions('fake-token', {
+        userAgent: 'my-app actions_orchestration_id/test-orch-id'
+      })
+      expect(opts.userAgent).toBe(
+        'my-app actions_orchestration_id/test-orch-id'
+      )
     })
   })
 })

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -49,8 +49,10 @@ export function getUserAgentWithOrchestrationId(
   const orchId = process.env['ACTIONS_ORCHESTRATION_ID']?.trim()
   if (orchId) {
     const sanitizedId = orchId.replace(/[^a-z0-9_.-]/gi, '_')
+    const tag = `actions_orchestration_id/${sanitizedId}`
+    if (baseUserAgent?.includes(tag)) return baseUserAgent
     const ua = baseUserAgent ? `${baseUserAgent} ` : ''
-    return `${ua}actions_orchestration_id/${sanitizedId}`
+    return `${ua}${tag}`
   }
   return baseUserAgent
 }

--- a/packages/github/src/internal/utils.ts
+++ b/packages/github/src/internal/utils.ts
@@ -42,3 +42,15 @@ export function getProxyFetch(destinationUrl): typeof fetch {
 export function getApiBaseUrl(): string {
   return process.env['GITHUB_API_URL'] || 'https://api.github.com'
 }
+
+export function getUserAgentWithOrchestrationId(
+  baseUserAgent?: string
+): string | undefined {
+  const orchId = process.env['ACTIONS_ORCHESTRATION_ID']?.trim()
+  if (orchId) {
+    const sanitizedId = orchId.replace(/[^a-z0-9_.-]/gi, '_')
+    const ua = baseUserAgent ? `${baseUserAgent} ` : ''
+    return `${ua}actions_orchestration_id/${sanitizedId}`
+  }
+  return baseUserAgent
+}

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -23,6 +23,8 @@ export const GitHub = Octokit.plugin(
   paginateRest
 ).defaults(defaults)
 
+export {getUserAgentWithOrchestrationId} from './internal/utils.js'
+
 /**
  * Convience function to correctly format Octokit Options to pass into the constructor.
  *
@@ -39,6 +41,14 @@ export function getOctokitOptions(
   const auth = Utils.getAuthString(token, opts)
   if (auth) {
     opts.auth = auth
+  }
+
+  // Orchestration ID
+  const userAgent = Utils.getUserAgentWithOrchestrationId(
+    opts.userAgent as string | undefined
+  )
+  if (userAgent) {
+    opts.userAgent = userAgent
   }
 
   return opts


### PR DESCRIPTION
## Summary

Appends `actions_orchestration_id/{sanitizedId}` to the user-agent string when the `ACTIONS_ORCHESTRATION_ID` environment variable is set. This follows the same pattern already used in `@actions/http-client` and `@actions/attest`.

## Changes

### `packages/github/src/internal/utils.ts`
- Added `getUserAgentWithOrchestrationId(baseUserAgent?)` — reads env var, sanitizes with `/[^a-z0-9_.-]/gi`, appends to user-agent. Trims whitespace-only values.

### `packages/github/src/utils.ts`
- `getOctokitOptions()` now calls the helper to include orchestration ID automatically
- Re-exports `getUserAgentWithOrchestrationId` for downstream consumers (e.g. `actions/github-script`) via `@actions/github/lib/utils`

### `packages/github/__tests__/orchestration.test.ts`
- 14 deterministic unit tests covering:
  - Helper function (env var present/absent, sanitization, whitespace, allowed chars)
  - `getOctokitOptions` integration (auto-append, preserve caller UA, no mutation)
  - Public re-export wiring verification

### `packages/github/RELEASES.md`
- Added 9.1.0 release notes

## Why

Actions orchestration needs to track which orchestration triggered API calls. The http-client and attest packages already do this — `@actions/github` was the missing piece. This unblocks [actions/github-script#708](https://github.com/actions/github-script/pull/708) from needing a local workaround.

## Testing

All 14 tests pass. No existing tests affected.

Part of https://github.com/github/c2c-actions/issues/10001