### PR TITLE
feat:  add support for commonjs loaders

### DIFF
--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -16,7 +16,9 @@
   "exports": {
     ".": {
       "types": "./lib/artifact.d.ts",
-      "import": "./lib/artifact.js"
+      "import": "./lib/artifact.js",
+      "require": "./lib/artifact.js",
+      "default": "./lib/artifact.js"
     }
   },
   "directories": {

--- a/packages/attest/package.json
+++ b/packages/attest/package.json
@@ -15,7 +15,9 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   },
   "directories": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -15,7 +15,9 @@
   "exports": {
     ".": {
       "types": "./lib/cache.d.ts",
-      "import": "./lib/cache.js"
+      "import": "./lib/cache.js",
+      "require": "./lib/cache.js",
+      "default": "./lib/cache.js"
     }
   },
   "directories": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,9 @@
   "exports": {
     ".": {
       "types": "./lib/core.d.ts",
-      "import": "./lib/core.js"
+      "import": "./lib/core.js",
+      "require": "./lib/core.js",
+      "default": "./lib/core.js"
     }
   },
   "directories": {

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -15,7 +15,9 @@
   "exports": {
     ".": {
       "types": "./lib/exec.d.ts",
-      "import": "./lib/exec.js"
+      "import": "./lib/exec.js",
+      "require": "./lib/exec.js",
+      "default": "./lib/exec.js"
     }
   },
   "directories": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -14,11 +14,15 @@
   "exports": {
     ".": {
       "types": "./lib/github.d.ts",
-      "import": "./lib/github.js"
+      "import": "./lib/github.js",
+      "require": "./lib/github.js",
+      "default": "./lib/github.js"
     },
     "./lib/utils": {
       "types": "./lib/utils.d.ts",
-      "import": "./lib/utils.js"
+      "import": "./lib/utils.js",
+      "require": "./lib/utils.js",
+      "default": "./lib/utils.js"
     }
   },
   "directories": {

--- a/packages/glob/package.json
+++ b/packages/glob/package.json
@@ -16,7 +16,9 @@
   "exports": {
     ".": {
       "types": "./lib/glob.d.ts",
-      "import": "./lib/glob.js"
+      "import": "./lib/glob.js",
+      "require": "./lib/glob.js",
+      "default": "./lib/glob.js"
     }
   },
   "directories": {

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -15,19 +15,27 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./lib/auth": {
       "types": "./lib/auth.d.ts",
-      "import": "./lib/auth.js"
+      "import": "./lib/auth.js",
+      "requier": "./lib/auth.js",
+      "default": "./lib/auth.js"
     },
-    "./lib/proxy": {  
-      "types": "./lib/proxy.d.ts",  
-      "import": "./lib/proxy.js"
+    "./lib/proxy": {
+      "types": "./lib/proxy.d.ts",
+      "import": "./lib/proxy.js",
+      "require": "./lib/proxy.js",
+      "default": "./lib/proxy.js"
     },
-    "./lib/interfaces": {  
-      "types": "./lib/interfaces.d.ts",  
-      "import": "./lib/interfaces.js"
+    "./lib/interfaces": {
+      "types": "./lib/interfaces.d.ts",
+      "import": "./lib/interfaces.js",
+      "require": "./lib/interfaces.js",
+      "default": "./lib/interfaces.js"
     }
   },
   "directories": {

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -15,11 +15,15 @@
   "exports": {
     ".": {
       "types": "./lib/io.d.ts",
-      "import": "./lib/io.js"
+      "import": "./lib/io.js",
+      "require": "./lib/io.js",
+      "default": "./lib/io.js"
     },
     "./lib/io-util": {
       "types": "./lib/io-util.d.ts",
-      "import": "./lib/io-util.js"
+      "import": "./lib/io-util.js",
+      "require": "./lib/io-util.js",
+      "default": "./lib/io-util.js"
     }
   },
   "directories": {

--- a/packages/tool-cache/package.json
+++ b/packages/tool-cache/package.json
@@ -15,7 +15,9 @@
   "exports": {
     ".": {
       "types": "./lib/tool-cache.d.ts",
-      "import": "./lib/tool-cache.js"
+      "import": "./lib/tool-cache.js",
+      "require": "./lib/tool-cache.js",
+      "default": "./lib/tool-cache.js"
     }
   },
   "directories": {


### PR DESCRIPTION
When this package was converted to ecmascript modules, it only defined an `import`
declaration in the package manifest making it impossible to load via
commonjs / require. Nodejs 22.12.0 added support for loading ecmascript
modules via require and commonjs modules via import. As long as the file
extension is `.js` and there is no top-level await, the same code can be
loaded by either mechanism. This change adds the `require` and `default`
declarations to the `exports` section of package.json making it possible
for this package to be used in either project type.

Fixes: #2294