### PR TITLE
fix: Remove trailing whitespace in *.ts

### DIFF
--- a/packages/artifact/src/internal/upload/path-and-artifact-name-validation.ts
+++ b/packages/artifact/src/internal/upload/path-and-artifact-name-validation.ts
@@ -41,11 +41,9 @@ export function validateArtifactName(name: string): void {
     if (name.includes(invalidCharacterKey)) {
       throw new Error(
         `The artifact name is not valid: ${name}. Contains the following character: ${errorMessageForCharacter}
-          
 Invalid characters include: ${Array.from(
           invalidArtifactNameCharacters.values()
         ).toString()}
-          
 These characters are not allowed in the artifact name due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.`
       )
     }
@@ -69,11 +67,9 @@ export function validateFilePath(path: string): void {
     if (path.includes(invalidCharacterKey)) {
       throw new Error(
         `The path for one of the files in artifact is not valid: ${path}. Contains the following character: ${errorMessageForCharacter}
-          
 Invalid characters include: ${Array.from(
           invalidArtifactFilePathCharacters.values()
         ).toString()}
-          
 The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
           `
       )

--- a/packages/artifact/src/internal/upload/upload-zip-specification.ts
+++ b/packages/artifact/src/internal/upload/upload-zip-specification.ts
@@ -56,7 +56,7 @@ export function getUploadZipSpecification(
 
   /*
      Example
-     
+
      Input:
        rootDirectory: '/home/user/files/plz-upload'
        artifactFiles: [
@@ -64,7 +64,7 @@ export function getUploadZipSpecification(
          '/home/user/files/plz-upload/file2.txt',
          '/home/user/files/plz-upload/dir/file3.txt'
        ]
-     
+
      Output:
        specifications: [
          ['/home/user/files/plz-upload/file1.txt', '/file1.txt'],

--- a/packages/cache/src/generated/results/api/v1/cache.twirp-client.ts
+++ b/packages/cache/src/generated/results/api/v1/cache.twirp-client.ts
@@ -6,11 +6,11 @@ import {
     GetCacheEntryDownloadURLRequest,
     GetCacheEntryDownloadURLResponse,
   } from "./cache.js";
-  
+
   //==================================//
   //          Client Code             //
   //==================================//
-  
+
   interface Rpc {
     request(
       service: string,
@@ -19,7 +19,7 @@ import {
       data: object | Uint8Array
     ): Promise<object | Uint8Array>;
   }
-  
+
   export interface CacheServiceClient {
     CreateCacheEntry(
       request: CreateCacheEntryRequest
@@ -31,7 +31,7 @@ import {
       request: GetCacheEntryDownloadURLRequest
     ): Promise<GetCacheEntryDownloadURLResponse>;
   }
-  
+
   export class CacheServiceClientJSON implements CacheServiceClient {
     private readonly rpc: Rpc;
     constructor(rpc: Rpc) {
@@ -59,7 +59,7 @@ import {
         })
       );
     }
-  
+
     FinalizeCacheEntryUpload(
       request: FinalizeCacheEntryUploadRequest
     ): Promise<FinalizeCacheEntryUploadResponse> {
@@ -79,7 +79,7 @@ import {
         })
       );
     }
-  
+
     GetCacheEntryDownloadURL(
       request: GetCacheEntryDownloadURLRequest
     ): Promise<GetCacheEntryDownloadURLResponse> {
@@ -100,7 +100,7 @@ import {
       );
     }
   }
-  
+
   export class CacheServiceClientProtobuf implements CacheServiceClient {
     private readonly rpc: Rpc;
     constructor(rpc: Rpc) {
@@ -123,7 +123,7 @@ import {
         CreateCacheEntryResponse.fromBinary(data as Uint8Array)
       );
     }
-  
+
     FinalizeCacheEntryUpload(
       request: FinalizeCacheEntryUploadRequest
     ): Promise<FinalizeCacheEntryUploadResponse> {
@@ -138,7 +138,7 @@ import {
         FinalizeCacheEntryUploadResponse.fromBinary(data as Uint8Array)
       );
     }
-  
+
     GetCacheEntryDownloadURL(
       request: GetCacheEntryDownloadURLRequest
     ): Promise<GetCacheEntryDownloadURLResponse> {
@@ -154,4 +154,3 @@ import {
       );
     }
   }
-  

--- a/packages/core/src/oidc-utils.ts
+++ b/packages/core/src/oidc-utils.ts
@@ -50,9 +50,7 @@ export class OidcClient {
       .getJson<TokenResponse>(id_token_url)
       .catch(error => {
         throw new Error(
-          `Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
-        Error Message: ${error.message}`
+          `Failed to get ID Token.\n  Error Code: ${error.statusCode}\n  Error Message: ${error.message}`
         )
       })
 


### PR DESCRIPTION
Currently a couple typescript files include trailing whitespace. This makes committing generated js output (necessary for github actions) also have trailing whitespace. Yucky. ([example](https://github.com/oxidecomputer/oidcx-action/blob/518ad51cb414398492bc4902fd71600192f47a9e/dist/index.js#L25140-L25149))

Separately, `oidc-utils.ts` and `path-and-artifact-name-validation.ts` have trailing whitespace inside template strings used for error strings.  This means that both the source has unnecessary trailing whitespace **AND** the error strings include trailing whitespace and doubled newlines. Double (triple?) yucky.

I think someone misunderstood how newlines / leading whitespace / trailing whitespace in template literals worked.

Before: 
```
Failed to get ID Token. 
 
        Error Code : ${error.statusCode}
 
        Error Message: ${error.message}
```

After:
```
Failed to get ID Token.
  Error Code : ${error.statusCode}
  Error Message: ${error.message}
```