### PR TITLE
fix(cache): ensure trailing slash when joining base URL with API path

### DIFF
--- a/packages/cache/src/internal/cacheHttpClient.ts
+++ b/packages/cache/src/internal/cacheHttpClient.ts
@@ -43,7 +43,7 @@ function getCacheApiUrl(resource: string): string {
     throw new Error('Cache Service Url not found, unable to restore cache.')
   }
 
-  const url = `${baseUrl}_apis/artifactcache/${resource}`
+  const url = `${baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`}_apis/artifactcache/${resource}`
   core.debug(`Resource Url: ${url}`)
   return url
 }


### PR DESCRIPTION
## Problem

When `ACTIONS_CACHE_URL` (or `ACTIONS_RESULTS_URL`) does not end with a trailing slash, `getCacheApiUrl()` constructs an invalid URL:

```
https://forgejo.ellis.link_apis/artifactcache/...
```

instead of:

```
https://forgejo.ellis.link/_apis/artifactcache/...
```

This affects self-hosted runners and Forgejo instances where the base URL is configured without a trailing slash.

## Fix

Normalize the base URL to always include a trailing slash before appending the API path segment.

## Related

Fixes #2375