### PR TITLE
fix(artifact): downgrade zero-byte upload warning to debug

### DIFF
--- a/packages/artifact/src/internal/upload/blob-upload.ts
+++ b/packages/artifact/src/internal/upload/blob-upload.ts
@@ -102,7 +102,7 @@ export async function uploadToBlobStorage(
   core.info(`SHA256 digest of uploaded artifact is ${sha256Hash}`)
 
   if (uploadByteCount === 0) {
-    core.warning(
+    core.debug(
       `No data was uploaded to blob storage. Reported upload byte count is 0.`
     )
   }


### PR DESCRIPTION
## Problem

When uploading a zero-byte file with `skipArchive: true`, a warning is emitted even though the upload completes successfully:

```
Warning: No data was uploaded to blob storage. Reported upload byte count is 0.
```

Zero-byte files are a valid use case (marker files, lock files, empty placeholders) and the upload finalizes correctly with `size: 0`.

## Fix

Downgrade `core.warning()` to `core.debug()` so the message remains available for troubleshooting but doesn't pollute workflow output for legitimate zero-byte uploads.

## Related

Fixes #2333
Related: https://github.com/actions/upload-artifact/issues/777