### PR TITLE
fix(cache): make error classification resilient to minification

### DIFF
--- a/packages/cache/__tests__/saveCache.test.ts
+++ b/packages/cache/__tests__/saveCache.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import * as path from 'path'
-import {saveCache} from '../src/cache'
+import {saveCache, ReserveCacheError} from '../src/cache'
 import * as cacheHttpClient from '../src/internal/cacheHttpClient'
 import * as cacheUtils from '../src/internal/cacheUtils'
 import * as config from '../src/internal/config'
@@ -219,6 +219,59 @@ test('save with reserve cache failure should fail', async () => {
   expect(createTarMock).toHaveBeenCalledTimes(1)
   expect(saveCacheMock).toHaveBeenCalledTimes(0)
   expect(getCompressionMock).toHaveBeenCalledTimes(1)
+})
+
+// Regression test for a minification-fragility bug: the catch block classified
+// errors with `typedError.name === ReserveCacheError.name`. A name-mangling
+// minifier (esbuild/terser/rolldown without keep-names) rewrites the class
+// binding, so `ReserveCacheError.name` becomes a short mangled string while
+// instances still carry the literal `this.name = 'ReserveCacheError'` from the
+// constructor. The comparison then never matches, routing a benign reserve race
+// (common in a build matrix sharing one cache key) to core.warning instead of
+// core.info. We simulate the minifier by mangling the class's runtime name and
+// assert the classification still holds.
+test('save with reserve cache failure is logged as info even when the class name is mangled (minification-safe)', async () => {
+  const paths = ['node_modules']
+  const primaryKey = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  const logInfoMock = jest.spyOn(core, 'info')
+  const logWarningMock = jest.spyOn(core, 'warning')
+
+  // Simulate what a name-mangling minifier does to the class identifier.
+  const originalNameDescriptor = Object.getOwnPropertyDescriptor(
+    ReserveCacheError,
+    'name'
+  )
+  Object.defineProperty(ReserveCacheError, 'name', {
+    value: 'r',
+    configurable: true
+  })
+
+  try {
+    jest.spyOn(cacheHttpClient, 'reserveCache').mockImplementation(async () => {
+      const response: TypedResponse<ReserveCacheResponse> = {
+        statusCode: 500,
+        result: null,
+        headers: {}
+      }
+      return response
+    })
+    jest
+      .spyOn(cacheUtils, 'getCompressionMethod')
+      .mockReturnValueOnce(Promise.resolve(CompressionMethod.Zstd))
+
+    const cacheId = await saveCache(paths, primaryKey)
+
+    expect(cacheId).toBe(-1)
+    // A benign reserve race must be info, never a warning annotation.
+    expect(logInfoMock).toHaveBeenCalledWith(
+      `Failed to save: Unable to reserve cache with key ${primaryKey}, another job may be creating this cache. More details: undefined`
+    )
+    expect(logWarningMock).not.toHaveBeenCalled()
+  } finally {
+    if (originalNameDescriptor) {
+      Object.defineProperty(ReserveCacheError, 'name', originalNameDescriptor)
+    }
+  }
 })
 
 test('save with server error should fail', async () => {

--- a/packages/cache/__tests__/saveCacheV2.test.ts
+++ b/packages/cache/__tests__/saveCacheV2.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import * as path from 'path'
-import {saveCache} from '../src/cache'
+import {saveCache, FinalizeCacheError} from '../src/cache'
 import * as cacheUtils from '../src/internal/cacheUtils'
 import {CacheFilename, CompressionMethod} from '../src/internal/constants'
 import * as config from '../src/internal/config'
@@ -507,6 +507,80 @@ test('save with finalize cache entry failure and specific error message', async 
 
   expect(cacheId).toBe(-1)
   expect(logWarningMock).toHaveBeenCalledWith(errorMessage)
+})
+
+// Regression test for the minification-fragility bug on the v2 path. saveCacheV2
+// classifies a FinalizeCacheError with
+// `isErrorOfType(typedError, FinalizeCacheError, 'FinalizeCacheError')`. A
+// name-mangling minifier (esbuild/terser/rolldown without keep-names) rewrites
+// the FinalizeCacheError class binding, so the pre-fix
+// `typedError.name === FinalizeCacheError.name` check would miss it and fall
+// through to the generic else branch — logging
+// `core.warning('Failed to save: <msg>')` instead of the FinalizeCacheError
+// branch's bare `core.warning('<msg>')`. We simulate the minifier by mangling
+// the class's runtime name and assert the FinalizeCacheError branch still fires.
+test('finalize cache failure is classified correctly even when the class name is mangled (minification-safe, v2)', async () => {
+  const paths = 'node_modules'
+  const key = 'Linux-node-bb828da54c148048dd17899ba9fda624811cfb43'
+  const logWarningMock = jest.spyOn(core, 'warning')
+  const signedUploadURL = 'https://blob-storage.local?signed=true'
+  const archiveFileSize = 1024
+  const errorMessage =
+    'Cache entry finalization failed due to concurrent access'
+  const options: UploadOptions = {
+    archiveSizeBytes: archiveFileSize,
+    useAzureSdk: true,
+    uploadChunkSize: 64 * 1024 * 1024,
+    uploadConcurrency: 8
+  }
+
+  // Simulate what a name-mangling minifier does to the class identifier.
+  const originalNameDescriptor = Object.getOwnPropertyDescriptor(
+    FinalizeCacheError,
+    'name'
+  )
+  Object.defineProperty(FinalizeCacheError, 'name', {
+    value: 'f',
+    configurable: true
+  })
+
+  try {
+    jest
+      .spyOn(CacheServiceClientJSON.prototype, 'CreateCacheEntry')
+      .mockReturnValue(
+        Promise.resolve({
+          ok: true,
+          signedUploadUrl: signedUploadURL,
+          message: ''
+        })
+      )
+    jest.spyOn(cacheHttpClient, 'saveCache').mockResolvedValue()
+    jest
+      .spyOn(cacheUtils, 'getCompressionMethod')
+      .mockReturnValueOnce(Promise.resolve(CompressionMethod.Zstd))
+    jest
+      .spyOn(cacheUtils, 'getArchiveFileSizeInBytes')
+      .mockReturnValueOnce(archiveFileSize)
+    jest
+      .spyOn(CacheServiceClientJSON.prototype, 'FinalizeCacheEntryUpload')
+      .mockReturnValue(
+        Promise.resolve({ok: false, entryId: '', message: errorMessage})
+      )
+
+    const cacheId = await saveCache([paths], key, options)
+
+    expect(cacheId).toBe(-1)
+    // The FinalizeCacheError branch logs the bare message; the generic else
+    // branch prefixes it with "Failed to save:". Assert the former fired.
+    expect(logWarningMock).toHaveBeenCalledWith(errorMessage)
+    expect(logWarningMock).not.toHaveBeenCalledWith(
+      `Failed to save: ${errorMessage}`
+    )
+  } finally {
+    if (originalNameDescriptor) {
+      Object.defineProperty(FinalizeCacheError, 'name', originalNameDescriptor)
+    }
+  }
 })
 
 test('save with multiple large caches should succeed in v2 (testing 50GB)', async () => {

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -39,6 +39,26 @@ export class FinalizeCacheError extends Error {
   }
 }
 
+/**
+ * Resilient check for one of the error types above that survives both JS
+ * minification and duplicate copies of this module in a dependency tree.
+ *
+ * `instanceof` covers the common single-bundle case (and keeps working under
+ * minification because each error sets its prototype explicitly), while the
+ * `name` comparison covers errors thrown from a different copy/realm of
+ * @actions/cache where `instanceof` would fail. The `name` argument must be a
+ * string literal: comparing against `ctor.name` breaks under name-mangling
+ * minifiers (the class binding gets renamed while the constructor's
+ * `this.name = '...'` literal does not), which is the bug this guards against.
+ */
+function isErrorOfType<T extends Error>(
+  error: Error,
+  ctor: new (...args: never[]) => T,
+  name: string
+): boolean {
+  return error instanceof ctor || error.name === name
+}
+
 function checkPaths(paths: string[]): void {
   if (!paths || paths.length === 0) {
     throw new ValidationError(
@@ -204,7 +224,7 @@ async function restoreCacheV1(
     return cacheEntry.cacheKey
   } catch (error) {
     const typedError = error as Error
-    if (typedError.name === ValidationError.name) {
+    if (isErrorOfType(typedError, ValidationError, 'ValidationError')) {
       throw error
     } else {
       // warn on cache restore failure and continue build
@@ -336,7 +356,7 @@ async function restoreCacheV2(
     return response.matchedKey
   } catch (error) {
     const typedError = error as Error
-    if (typedError.name === ValidationError.name) {
+    if (isErrorOfType(typedError, ValidationError, 'ValidationError')) {
       throw error
     } else {
       // Supress all non-validation cache related errors because caching should be optional
@@ -476,9 +496,11 @@ async function saveCacheV1(
     await cacheHttpClient.saveCache(cacheId, archivePath, '', options)
   } catch (error) {
     const typedError = error as Error
-    if (typedError.name === ValidationError.name) {
+    if (isErrorOfType(typedError, ValidationError, 'ValidationError')) {
       throw error
-    } else if (typedError.name === ReserveCacheError.name) {
+    } else if (
+      isErrorOfType(typedError, ReserveCacheError, 'ReserveCacheError')
+    ) {
       core.info(`Failed to save: ${typedError.message}`)
     } else {
       // Log server errors (5xx) as errors, all other errors as warnings
@@ -621,11 +643,15 @@ async function saveCacheV2(
     cacheId = parseInt(finalizeResponse.entryId)
   } catch (error) {
     const typedError = error as Error
-    if (typedError.name === ValidationError.name) {
+    if (isErrorOfType(typedError, ValidationError, 'ValidationError')) {
       throw error
-    } else if (typedError.name === ReserveCacheError.name) {
+    } else if (
+      isErrorOfType(typedError, ReserveCacheError, 'ReserveCacheError')
+    ) {
       core.info(`Failed to save: ${typedError.message}`)
-    } else if (typedError.name === FinalizeCacheError.name) {
+    } else if (
+      isErrorOfType(typedError, FinalizeCacheError, 'FinalizeCacheError')
+    ) {
       core.warning(typedError.message)
     } else {
       // Log server errors (5xx) as errors, all other errors as warnings

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -50,6 +50,15 @@ export class FinalizeCacheError extends Error {
  * string literal: comparing against `ctor.name` breaks under name-mangling
  * minifiers (the class binding gets renamed while the constructor's
  * `this.name = '...'` literal does not), which is the bug this guards against.
+ *
+ * Two signature choices are load-bearing — do not "simplify" them:
+ * - It returns `boolean`, not a type predicate (`error is T`). These error
+ *   classes are structurally identical to `Error`, so a predicate narrows
+ *   `typedError` to `never` in the `else` branches and breaks the downstream
+ *   `instanceof HttpClientError` / `.statusCode` checks.
+ * - The generic `<T extends Error>` is required. With a concrete
+ *   `ctor: ... => Error`, `error instanceof ctor` narrows `error` to `never` on
+ *   the right side of the `||`, breaking the `error.name` access.
  */
 function isErrorOfType<T extends Error>(
   error: Error,


### PR DESCRIPTION
## Problem

`packages/cache/src/cache.ts` classifies caught errors with
`typedError.name === SomeError.name`. The error classes set `this.name` to a
string literal, but the comparison reads the **class binding's** `.name`. When
an action bundles `@actions/cache` with a name-mangling minifier (esbuild /
terser / rolldown without keep-names), the binding is renamed, so
`SomeError.name` no longer equals the literal and the check silently fails.

Most visibly, a benign `ReserveCacheError` (a reserve race when matrix jobs
share a cache key) is then logged via `core.warning` instead of `core.info`,
producing noisy warning annotations even though caching succeeded.

## Fix

Replace the `=== SomeError.name` comparisons (7 sites across `restoreCacheV1/V2`
and `saveCacheV1/V2`) with a helper:

```ts
function isErrorOfType<T extends Error>(
  error: Error,
  ctor: new (...args: never[]) => T,
  name: string
): boolean {
  return error instanceof ctor || error.name === name
}
```

`instanceof` handles the normal case and survives minification (the classes
already set their prototype via `Object.setPrototypeOf`); the `name`
string-literal fallback handles a duplicate / cross-realm copy of
`@actions/cache` where `instanceof` fails.

## Tests

Regression tests simulate a minifier by mangling an error class's runtime name,
then assert the reserve race (v1) and a finalize failure (v2) are still
classified correctly. Both fail on `main` and pass with this change.
`npm test`, `npm run lint`, and `npm run build` all pass.
