### PR TITLE
feat(artifact): unblock v4+ on self-hosted GHES when ACTIONS_RESULTS_URL is set

### DIFF
--- a/packages/artifact/__tests__/config.test.ts
+++ b/packages/artifact/__tests__/config.test.ts
@@ -15,6 +15,11 @@ beforeEach(() => {
 })
 
 describe('isGhes', () => {
+  beforeEach(() => {
+    delete process.env.GITHUB_SERVER_URL
+    delete process.env.ACTIONS_RESULTS_URL
+  })
+
   it('should return false when the request domain is github.com', () => {
     process.env.GITHUB_SERVER_URL = 'https://github.com'
     expect(config.isGhes()).toBe(false)
@@ -35,9 +40,21 @@ describe('isGhes', () => {
     expect(config.isGhes()).toBe(false)
   })
 
-  it('should return false when the request domain is specific to an enterprise', () => {
+  it('should return true on a self-hosted enterprise hostname when ACTIONS_RESULTS_URL is unset', () => {
     process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
     expect(config.isGhes()).toBe(true)
+  })
+
+  it('should return false on a self-hosted enterprise hostname when ACTIONS_RESULTS_URL is set (v2 backend available)', () => {
+    process.env.GITHUB_SERVER_URL = 'https://my-enterprise.github.com'
+    process.env.ACTIONS_RESULTS_URL = 'https://results.example.com/'
+    expect(config.isGhes()).toBe(false)
+  })
+
+  it('should ignore ACTIONS_RESULTS_URL on github.com (already returns false there)', () => {
+    process.env.GITHUB_SERVER_URL = 'https://github.com'
+    process.env.ACTIONS_RESULTS_URL = 'https://results.example.com/'
+    expect(config.isGhes()).toBe(false)
   })
 })
 

--- a/packages/artifact/src/internal/shared/config.ts
+++ b/packages/artifact/src/internal/shared/config.ts
@@ -34,7 +34,21 @@ export function isGhes(): boolean {
   const isGheHost = hostname.endsWith('.GHE.COM')
   const isLocalHost = hostname.endsWith('.LOCALHOST')
 
-  return !isGitHubHost && !isGheHost && !isLocalHost
+  const hostnameLooksLikeGhes =
+    !isGitHubHost && !isGheHost && !isLocalHost
+
+  // GHES 3.13+ ships the artifact-storage-v2 backend that the v4+
+  // artifact client requires. The runner exposes the backend's
+  // presence via ACTIONS_RESULTS_URL (which getResultsServiceUrl()
+  // already requires for upload/download/list to function). When
+  // that env var is set we know the backend is reachable, so an
+  // unrecognised hostname does not need to short-circuit into a
+  // GHESNotSupportedError.
+  if (hostnameLooksLikeGhes && process.env['ACTIONS_RESULTS_URL']) {
+    return false
+  }
+
+  return hostnameLooksLikeGhes
 }
 
 export function getGitHubWorkspaceDir(): string {


### PR DESCRIPTION
Closes #2439
Related to #2123 (more general vendor-aware approach for non-GitHub servers; this PR addresses the narrower GHES-3.13+ case via existing runtime signals)

`isGhes()` in `packages/artifact/src/internal/shared/config.ts` currently throws `GHESNotSupportedError` on any GHES, regardless of release. GHES 3.13 added the artifact-storage-v2 backend that v4+ requires, but the gate is hostname-only and ignores the release. `ACTIONS_RESULTS_URL` is the runtime signal for v2 availability; the same package's `getResultsServiceUrl()` already requires it. This change makes `isGhes()` return `false` when the hostname looks like GHES and `ACTIONS_RESULTS_URL` is set.

Behaviour matrix:

- `github.com`, `*.ghe.com`, `*.localhost`: hostname check still returns `false`. No change.
- GHES <3.13 (no v2 backend, `ACTIONS_RESULTS_URL` unset): `isGhes()` returns `true`, throws as before. No change.
- GHES 3.13+ (v2 backend present, `ACTIONS_RESULTS_URL` set): `isGhes()` returns `false`, upload/download/list proceed.

Tests in `packages/artifact/__tests__/config.test.ts` cover both new branches. Also added a `beforeEach` cleanup of `GITHUB_SERVER_URL` and `ACTIONS_RESULTS_URL` inside the `isGhes` describe block; the previous setup relied on `jest.resetModules()` alone and could leak `ACTIONS_RESULTS_URL` from sibling tests. The previously-misleadingly-titled "should return false ... is specific to an enterprise" test (which expected `true`) is renamed to match its actual assertion.

Verified on a GHES 3.19.5 instance where the v2 backend is operational but v4+ artifact actions were blocked solely by the hostname gate.

Relationship to #2123: that PR takes a more general approach with an `ACTIONS_VENDOR` env var as an explicit opt-in, supporting non-GitHub vendor servers (Gitea, Forgejo, etc.) in addition to GHES. This PR is narrower: it consults an existing runtime signal (`ACTIONS_RESULTS_URL`) that GHES 3.13+ runners already emit, so no operator action is required and no new env-var contract is introduced. The two approaches are complementary; if both land, the check here would short-circuit before vendor detection on v2-supporting GHES.
