### PR TITLE
feat(`@actions/github`): added `refName` and `refType` to context

### DIFF
--- a/packages/github/__tests__/lib.test.ts
+++ b/packages/github/__tests__/lib.test.ts
@@ -81,6 +81,16 @@ describe('@actions/context', () => {
   })
 
   describe('refs', () => {
+    const ORIGINAL_ENV = {...process.env}
+
+    beforeEach(() => {
+      process.env = {...ORIGINAL_ENV}
+    })
+
+    afterAll(() => {
+      process.env = ORIGINAL_ENV
+    })
+
     it.each([
       'refs/heads/main',
       'refs/heads/feature-branch',

--- a/packages/github/__tests__/lib.test.ts
+++ b/packages/github/__tests__/lib.test.ts
@@ -79,4 +79,32 @@ describe('@actions/context', () => {
       repo: 'test'
     })
   })
+
+  describe('refs', () => {
+    it.each([
+      'refs/heads/main',
+      'refs/heads/feature-branch',
+      'refs/pull/42/merge',
+      'refs/tags/v2.0.4'
+    ])(`should set context.ref: %s`, ref => {
+      process.env.GITHUB_REF = ref
+
+      expect(new Context()).toHaveProperty(`ref`, ref)
+    })
+
+    it.each([`meh-${Date.now()}`, 'catpants', 'v1.2.3'])(
+      'should set context.refName: %s',
+      refName => {
+        process.env.GITHUB_REF_NAME = refName
+
+        expect(new Context()).toHaveProperty('refName', refName)
+      }
+    )
+
+    it.each(['branch', 'tag'])('should set context.refType: %s', refType => {
+      process.env.GITHUB_REF_TYPE = refType
+
+      expect(new Context()).toHaveProperty('refType', refType)
+    })
+  })
 })

--- a/packages/github/src/context.ts
+++ b/packages/github/src/context.ts
@@ -12,6 +12,8 @@ export class Context {
   eventName: string
   sha: string
   ref: string
+  refName: string
+  refType: string
   workflow: string
   action: string
   actor: string
@@ -41,6 +43,8 @@ export class Context {
     this.eventName = process.env.GITHUB_EVENT_NAME as string
     this.sha = process.env.GITHUB_SHA as string
     this.ref = process.env.GITHUB_REF as string
+    this.refName = process.env.GITHUB_REF_NAME as string
+    this.refType = process.env.GITHUB_REF_TYPE as string
     this.workflow = process.env.GITHUB_WORKFLOW as string
     this.action = process.env.GITHUB_ACTION as string
     this.actor = process.env.GITHUB_ACTOR as string


### PR DESCRIPTION
## Summary

* Added `refName` exposing `GITHUB_REF_NAME` environment variable
* Added `refType` exposing `GITHUB_REF_TYPE` environment variable

## Background

Both of the environment variables are documented in the default environment variables section:

Variable | Description
--- | ---
`GITHUB_REF_NAME` | The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, `feature-branch-1`. <br/><br/>For pull requests that were not merged, the format is `<pr_number>/merge.`
`GITHUB_REF_TYPE` | The type of ref that triggered the workflow run. Valid values are `branch` or `tag`.

Source: https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables

> [!NOTE]
>
> I didn't see any unit tests related to these data values. Let me know if I missed anything.