### PR TITLE
Fix artifact name used if `skipArchive` is set to false

### DIFF
--- a/packages/artifact/__tests__/upload-artifact.test.ts
+++ b/packages/artifact/__tests__/upload-artifact.test.ts
@@ -589,7 +589,7 @@ describe('upload-artifact', () => {
       )
     })
 
-    it('should use the file basename as artifact name when skipArchive is true', async () => {
+    it('should use the artifact name as well when skipArchive is true', async () => {
       jest
         .spyOn(uploadZipSpecification, 'getUploadZipSpecification')
         .mockRestore()
@@ -643,10 +643,10 @@ describe('upload-artifact', () => {
         {skipArchive: true}
       )
 
-      // Verify CreateArtifact was called with the file basename, not the original name
+      // Verify CreateArtifact was called with the original name
       expect(createArtifactSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'file1.txt'
+          name: 'original-name'
         })
       )
     })

--- a/packages/artifact/src/internal/upload/upload-artifact.ts
+++ b/packages/artifact/src/internal/upload/upload-artifact.ts
@@ -48,7 +48,6 @@ export async function uploadArtifact(
     }
 
     artifactFileName = path.basename(files[0])
-    name = artifactFileName
   }
 
   validateArtifactName(name)


### PR DESCRIPTION
The relatively newly added support to upload artifacts without archiving to a ZIP file seems to be somewhat flawed as discussed e.g. here [1] and [2].

Instead of using the (already) required `name` in `uploadArtifact()` it is blindly overridden by `artifactFileName`. This breaks various GitHub actions logic e.g. to upload files already packed to a `tar.gz` (and therefore without any benefit of repacking to a ZIP archive) but expecting to download it under the given name of the uploaded artifact. It seems that in `actions/upload-artifact` [3] it breaks the `overwrite` action designed as follows:
`If true, an artifact with a matching name will be deleted before a new one is uploaded.`

Yes, it is documented downstream (`actions/upload-artifact`) that basename is used instead if `archive` is set to `false` but this behavior seems to be a design flaw as there is no need to enforce different artifact name generation and usage based on if a ZIP archive is uploaded or not. Further restrictions like only supporting single files are logic consequences.

[1] https://github.com/actions/upload-artifact/issues/785
[2] https://github.com/actions/upload-artifact/issues/769
[3] https://github.com/actions/upload-artifact

Fixes: #2441