### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -163,7 +163,7 @@ echo "FOO=BAR" >> $GITHUB_ENV
 
 Running `$FOO` in a future step will now return `BAR`
 
-For multiline strings, you may use a heredoc style syntax with your choice of delimeter. In the below example, we use `EOF`.
+For multiline strings, you may use a heredoc style syntax with your choice of delimiter. In the below example, we use `EOF`.
 
 ```
 steps:
@@ -180,9 +180,9 @@ This would set the value of the `JSON_RESPONSE` env variable to the value of the
 The expected syntax for the heredoc style is:
 
 ```
-{VARIABLE_NAME}<<{DELIMETER}
+{VARIABLE_NAME}<<{DELIMITER}
 {VARIABLE_VALUE}
-{DELIMETER}
+{DELIMITER}
 ```
 
 This is wrapped by the core `exportVariable` method which sets for future steps but also updates the variable for this step.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -26,7 +26,7 @@ This package is used by the v2+ versions of our first party cache action. You ca
 
 #### Save Cache
 
-Saves a cache containing the files in `paths` using the `key` provided. The files would be compressed using zstandard compression algorithm if zstd is installed, otherwise gzip is used. Function returns the cache id if the cache was saved succesfully and throws an error if cache upload fails.
+Saves a cache containing the files in `paths` using the `key` provided. The files would be compressed using zstandard compression algorithm if zstd is installed, otherwise gzip is used. Function returns the cache id if the cache was saved successfully and throws an error if cache upload fails.
 
 ```js
 const cache = require('@actions/cache');

--- a/packages/cache/RELEASES.md
+++ b/packages/cache/RELEASES.md
@@ -132,7 +132,7 @@ Read more about the change & access the migration guide: [reference to the annou
 
 ## 3.1.3
 
-- Fix to prevent from setting MYSYS environement variable globally [#1329](https://github.com/actions/toolkit/pull/1329).
+- Fix to prevent from setting MYSYS environment variable globally [#1329](https://github.com/actions/toolkit/pull/1329).
 
 ## 3.1.2
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -370,7 +370,7 @@ async function restoreCacheV2(
     if (typedError.name === ValidationError.name) {
       throw error
     } else {
-      // Supress all non-validation cache related errors because caching should be optional
+      // Suppress all non-validation cache related errors because caching should be optional
       // Log server errors (5xx) as errors, all other errors as warnings
       if (
         typedError instanceof HttpClientError &&

--- a/packages/cache/src/internal/cacheUtils.ts
+++ b/packages/cache/src/internal/cacheUtils.ts
@@ -127,7 +127,7 @@ export async function getGnuTarPathOnWindows(): Promise<string> {
 
 export function assertDefined<T>(name: string, value?: T): T {
   if (value === undefined) {
-    throw Error(`Expected ${name} but value was undefiend`)
+    throw Error(`Expected ${name} but value was undefined`)
   }
 
   return value

--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -61,7 +61,7 @@ async function getTarArgs(
   const cacheFileName = utils.getCacheFileName(compressionMethod)
   const tarFile = 'cache.tar'
   const workingDirectory = getWorkingDirectory()
-  // Speficic args for BSD tar on windows for workaround
+  // Specific args for BSD tar on windows for workaround
   const BSD_TAR_ZSTD =
     tarPath.type === ArchiveToolType.BSD &&
     compressionMethod !== CompressionMethod.Gzip &&

--- a/packages/cache/src/options.ts
+++ b/packages/cache/src/options.ts
@@ -88,7 +88,7 @@ export interface DownloadOptions {
  * @param copy the original upload options
  */
 export function getUploadOptions(copy?: UploadOptions): UploadOptions {
-  // Defaults if not overriden
+  // Defaults if not overridden
   const result: UploadOptions = {
     useAzureSdk: false,
     uploadConcurrency: 4,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -132,7 +132,7 @@ These will surface to the UI in the Actions page and on Pull Requests. They look
 
 ![Annotations Image](../../docs/assets/annotations.png)
 
-These annotations can also be attached to particular lines and columns of your source files to show exactly where a problem is occuring. 
+These annotations can also be attached to particular lines and columns of your source files to show exactly where a problem is occurring. 
 
 These options are: 
 ```typescript

--- a/packages/core/src/summary.ts
+++ b/packages/core/src/summary.ts
@@ -150,7 +150,7 @@ class Summary {
   /**
    * If the summary buffer is empty
    *
-   * @returns {boolen} true if the buffer is empty
+   * @returns {boolean} true if the buffer is empty
    */
   isEmptyBuffer(): boolean {
     return this._buffer.length === 0
@@ -255,10 +255,10 @@ class Summary {
   }
 
   /**
-   * Adds a collapsable HTML details element to the summary buffer
+   * Adds a collapsible HTML details element to the summary buffer
    *
    * @param {string} label text for the closed state
-   * @param {string} content collapsable content
+   * @param {string} content collapsible content
    *
    * @returns {Summary} summary instance
    */

--- a/packages/github/RELEASES.md
+++ b/packages/github/RELEASES.md
@@ -70,7 +70,7 @@
   - `GitHub.plugin()` no longer supports an array as first argument. Multiple args must be passed in instead.
 
 ### 3.0.0
-- [Swap to @octokit/core and use plugins to leverage lastest octokit apis](https://github.com/actions/toolkit/pull/453)
+- [Swap to @octokit/core and use plugins to leverage latest octokit apis](https://github.com/actions/toolkit/pull/453)
 - [Add comment field to payload context](https://github.com/actions/toolkit/pull/375) 
 
 ### 2.2.0

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -26,7 +26,7 @@ export const GitHub = Octokit.plugin(
 export {getUserAgentWithOrchestrationId} from './internal/utils.js'
 
 /**
- * Convience function to correctly format Octokit Options to pass into the constructor.
+ * Convenience function to correctly format Octokit Options to pass into the constructor.
  *
  * @param     token    the repo PAT or GITHUB_TOKEN
  * @param     options  other options to set

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -36,7 +36,7 @@ See the [tests](./__tests__) for detailed examples.
 
 ## Debugging
 
-To enable detailed console logging of all HTTP requests and responses, set the NODE_DEBUG environment varible:
+To enable detailed console logging of all HTTP requests and responses, set the NODE_DEBUG environment variable:
 
 ```shell
 export NODE_DEBUG=http

--- a/packages/http-client/RELEASES.md
+++ b/packages/http-client/RELEASES.md
@@ -44,7 +44,7 @@
 ## 2.1.0
 
 - Add support for `*` and subdomains in `no_proxy` [#1355](https://github.com/actions/toolkit/pull/1355) [#1223](https://github.com/actions/toolkit/pull/1223)
-- Bypass proxy for loopback IP adresses [#1360](https://github.com/actions/toolkit/pull/1360))
+- Bypass proxy for loopback IP addresses [#1360](https://github.com/actions/toolkit/pull/1360)
 
 ## 2.0.1
 

--- a/packages/tool-cache/RELEASES.md
+++ b/packages/tool-cache/RELEASES.md
@@ -38,11 +38,11 @@
 ### 1.7.1
 
 - [Fallback to os-releases file to get linux version](https://github.com/actions/toolkit/pull/594)
-- [Update to latest @actions/io verison](https://github.com/actions/toolkit/pull/838)
+- [Update to latest @actions/io version](https://github.com/actions/toolkit/pull/838)
 
 ### 1.7.0
 
-- [Allow arbirtary headers when downloading tools to the tc](https://github.com/actions/toolkit/pull/530)
+- [Allow arbitrary headers when downloading tools to the tc](https://github.com/actions/toolkit/pull/530)
 - [Export `isExplicitVersion` and `evaluateVersions` functions](https://github.com/actions/toolkit/pull/796)
 - [Force overwrite on default when extracted compressed files](https://github.com/actions/toolkit/pull/807)
 

--- a/packages/tool-cache/src/tool-cache.ts
+++ b/packages/tool-cache/src/tool-cache.ts
@@ -703,7 +703,7 @@ export function isExplicitVersion(versionSpec: string): boolean {
 }
 
 /**
- * Get the highest satisfiying semantic version in `versions` which satisfies `versionSpec`
+ * Get the highest satisfying semantic version in `versions` which satisfies `versionSpec`
  *
  * @param versions        array of versions to evaluate
  * @param versionSpec     semantic version spec to satisfy

--- a/scripts/audit-allow-list
+++ b/scripts/audit-allow-list
@@ -44,7 +44,7 @@ const fs = require('fs')
 
 const USAGE = "Usage: npm audit --json | scripts/audit-allow-list"
 
-// To add entires to the allow list:
+// To add entries to the allow list:
 //   - Run `npm audit --json`
 //   - Copy `path` from each `actions[k].resolves` you want to allow
 //   - Fill in the `advisoryUrl` and `justification` (these are just for documentation)


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=afterall,intoto,vulnerabilit --skip="*.json"`

% `codespell --ignore-words-list=afterall,intoto,vulnerabilit --skip="*.json" --write-changes`