### PR TITLE
Retry intermediary 403s in artifact-twirp-client

### DIFF
--- a/packages/artifact/__tests__/artifact-http-client.test.ts
+++ b/packages/artifact/__tests__/artifact-http-client.test.ts
@@ -234,6 +234,91 @@ describe('artifact-http-client', () => {
     expect(mockPost).toHaveBeenCalledTimes(1)
   })
 
+  it('should retry a 403 from an intermediary', async () => {
+    const mockPost = jest
+      .fn(() => {
+        const msgSucceeded = new http.IncomingMessage(new net.Socket())
+        msgSucceeded.statusCode = 200
+        return {
+          message: msgSucceeded,
+          readBody: async () => {
+            return Promise.resolve(
+              `{"ok": true, "signedUploadUrl": "http://localhost:8080/upload"}`
+            )
+          }
+        }
+      })
+      .mockImplementationOnce(() => {
+        const msgFailed = new http.IncomingMessage(new net.Socket())
+        msgFailed.statusCode = 403
+        msgFailed.statusMessage = 'Forbidden'
+        return {
+          message: msgFailed,
+          readBody: async () => {
+            return Promise.resolve(
+              `{"msg": "Error from intermediary with HTTP status code 403 \\"Forbidden\\""}`
+            )
+          }
+        }
+      })
+    const mockHttpClient = (
+      HttpClient as unknown as jest.Mock
+    ).mockImplementation(() => {
+      return {
+        post: mockPost
+      }
+    })
+
+    const client = internalArtifactTwirpClient(clientOptions)
+    const artifact = await client.CreateArtifact({
+      workflowRunBackendId: '1234',
+      workflowJobRunBackendId: '5678',
+      name: 'artifact',
+      version: 4
+    })
+
+    expect(mockHttpClient).toHaveBeenCalledTimes(1)
+    expect(artifact).toBeDefined()
+    expect(artifact.ok).toBe(true)
+    expect(artifact.signedUploadUrl).toBe('http://localhost:8080/upload')
+    expect(mockPost).toHaveBeenCalledTimes(2)
+  })
+
+  it('should fail immediately on a 403 that is not from an intermediary', async () => {
+    const mockPost = jest.fn(() => {
+      const msgFailed = new http.IncomingMessage(new net.Socket())
+      msgFailed.statusCode = 403
+      msgFailed.statusMessage = 'Forbidden'
+      return {
+        message: msgFailed,
+        readBody: async () => {
+          return Promise.resolve(`{"ok": false}`)
+        }
+      }
+    })
+
+    const mockHttpClient = (
+      HttpClient as unknown as jest.Mock
+    ).mockImplementation(() => {
+      return {
+        post: mockPost
+      }
+    })
+    const client = internalArtifactTwirpClient(clientOptions)
+    await expect(async () => {
+      await client.CreateArtifact({
+        workflowRunBackendId: '1234',
+        workflowJobRunBackendId: '5678',
+        name: 'artifact',
+        version: 4
+      })
+    }).rejects.toThrowError(
+      'Received non-retryable error: Failed request: (403) Forbidden'
+    )
+    expect(mockHttpClient).toHaveBeenCalledTimes(1)
+    expect(mockPost).toHaveBeenCalledTimes(1)
+  })
+
   it('should fail with a descriptive error', async () => {
     // 409 duplicate error
     const mockPost = jest.fn(() => {

--- a/packages/artifact/src/internal/shared/artifact-twirp-client.ts
+++ b/packages/artifact/src/internal/shared/artifact-twirp-client.ts
@@ -92,7 +92,6 @@ class ArtifactHttpClient implements Rpc {
         if (this.isSuccessStatusCode(statusCode)) {
           return {response, body}
         }
-        isRetryable = this.isRetryableHttpStatusCode(statusCode)
         errorMessage = `Failed request: (${statusCode}) ${response.message.statusMessage}`
         if (body.msg) {
           if (UsageError.isUsageErrorMessage(body.msg)) {
@@ -101,6 +100,7 @@ class ArtifactHttpClient implements Rpc {
 
           errorMessage = `${errorMessage}: ${body.msg}`
         }
+        isRetryable = this.isRetryableHttpStatusCode(statusCode, errorMessage)
       } catch (error) {
         if (error instanceof SyntaxError) {
           debug(`Raw Body: ${rawBody}`)
@@ -147,7 +147,10 @@ class ArtifactHttpClient implements Rpc {
     return statusCode >= 200 && statusCode < 300
   }
 
-  isRetryableHttpStatusCode(statusCode?: number): boolean {
+  isRetryableHttpStatusCode(
+    statusCode?: number,
+    errorMessage?: string
+  ): boolean {
     if (!statusCode) return false
 
     const retryableStatusCodes = [
@@ -158,7 +161,24 @@ class ArtifactHttpClient implements Rpc {
       HttpCodes.TooManyRequests
     ]
 
-    return retryableStatusCodes.includes(statusCode)
+    if (retryableStatusCodes.includes(statusCode)) {
+      return true
+    }
+
+    // A 403 from the artifact Results Service usually means a genuine
+    // authorization failure (e.g. an expired runtime token, or an artifact
+    // outside the run's scope), which should fail fast rather than retry.
+    // However, the service's edge/proxy layer can also intermittently
+    // return a 403 of its own, distinguishable by a body identifying it as
+    // coming from an intermediary rather than the backend (e.g. "Error from
+    // intermediary with HTTP status code 403"). That flavor is a transient
+    // infrastructure hiccup, not an authorization decision, so it's safe -
+    // and worthwhile - to retry. See actions/download-artifact#464.
+    if (statusCode === HttpCodes.Forbidden && errorMessage) {
+      return /error from intermediary/i.test(errorMessage)
+    }
+
+    return false
   }
 
   async sleep(milliseconds: number): Promise<void> {


### PR DESCRIPTION
## Problem

CI intermittently fails an `actions/download-artifact@v8` step with:

```
Downloading single artifact
##[error]Unable to download artifact(s): Failed to ListArtifacts: Received non-retryable error: Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403 "Forbidden"
```

This happened downloading an artifact that had been uploaded moments earlier in the *same* workflow run by a sibling job (a Rails CI setup with several parallel matrix shards downloading the same precompiled-assets artifact). Two other parallel shards in the same run downloaded the identical artifact successfully, so the artifact existed and wasn't expired — this was a transient failure on the artifact service's edge/proxy layer, surfaced with no retry.

This matches the currently open, unaddressed report in `actions/download-artifact#464` ("intermittent 403s with no retry" — 6/96 parallel jobs failing this way in one run, one comment speculating it's "some sort of throttle perhaps getting incorrectly returned as a 403"). Per this repo's `CONTRIBUTING.md` and `download-artifact`'s own contributing guide, the retry logic actually lives here in `@actions/artifact`, not in `download-artifact`.

## Root cause

`ArtifactHttpClient.isRetryableHttpStatusCode()` in `packages/artifact/src/internal/shared/artifact-twirp-client.ts` only retries `502/504/500/503/429`. A `403` always falls into the non-retryable branch of `retryableRequest()` and throws immediately (`Received non-retryable error: ...`), matching the error above exactly.

## Why not just add 403 to the retryable list

A `403` from the Results Service can mean two very different things:
1. A transient edge/proxy hiccup — what "Error from intermediary with HTTP status code 403" explicitly says: the 403 came from an intermediary in front of the backend, not from the backend's own authorization logic.
2. A genuine, permanent authorization failure (expired/invalid runtime token, artifact out of scope, etc.).

Blindly adding `HttpCodes.Forbidden` to `retryableStatusCodes` would retry *all* 403s for up to `maxAttempts` (5) with exponential backoff, including genuine permanent failures — masking real auth bugs behind ~30-60s of pointless retrying before still failing.

## Fix

`isRetryableHttpStatusCode` now accepts the constructed error message and retries a `403` only when that message identifies it as coming from an intermediary (`/error from intermediary/i`). Every other `403` — including the existing `UsageError` case, which is checked earlier and unaffected — continues to fail fast exactly as before. `retryableRequest` was reordered slightly so the message (which already includes `statusMessage` and `body.msg`) is fully built before the retryability decision is made.

## Testing

Added two tests to `packages/artifact/__tests__/artifact-http-client.test.ts`, following the existing mock/assert pattern in that file:
- an intermediary-flavored 403 followed by a success retries and returns the artifact (2 `post` calls)
- a plain 403 with no intermediary signal still fails immediately on the first attempt (1 `post` call), matching today's behavior

Confirmed the new "retries" test fails with today's code (reproducing the exact `Received non-retryable error: ...: Error from intermediary...` message) and passes with the fix. Confirmed the existing 403 → `UsageError` test is unaffected.

Ran `npm run bootstrap`, `npm run build`, `npm test -- packages/artifact` (133/133 passing), `npm run format-check`, and `npm run lint` — all clean.

## Scope

Deliberately does **not** touch `packages/artifact/src/internal/find/retry-options.ts`, the separate octokit-based retry path used for the public/cross-repo API (`listArtifactsPublic`), which explicitly exempts `403` for good reason in that context (different threat model, different callers).

Also relevant: `actions/download-artifact#339`, an older, messier thread with several different root causes tangled together — some resolved by fixing `path` usage, some by pinning versions — but with multiple commenters reporting the same general category of intermittent, non-`path`-related download failures.

Happy to adjust the message-matching approach if maintainers have a more reliable signal for "this 403 came from the intermediary layer" (e.g., a header) than string-matching the body.